### PR TITLE
feat(installer): auto-open .env on the Gemini-key path (CASE B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,23 +124,25 @@ node installer.mjs --non-interactive --name "<name>" --dest "<parent-location>" 
      is offline.)* **Move on to point 2.**
 
    - **CASE B — "Gemini API key" option.** Here, and only here, the key is missing (it **never**
-     travels through the chat or the CLI) → the brain is not verified yet. **Actively guide the
-     user**: (a) **open the `.env` YOURSELF in their editor** — i.e. **LAUNCH it via a shell command
-     (Bash)**. Do **NOT** use the Read tool and do **not** merely print its contents in the chat:
-     "open" means making an **editor window appear on the user's side** (`.env` is a *hidden* file that
-     an average person won't be able to locate on their own). Use an **absolute path** (or `$HOME/…`),
-     **never a quoted `~`** (it doesn't expand in the shell):
+     travels through the chat or the CLI) → the brain is not verified yet. **The installer has
+     ALREADY opened the user's `.env` in their editor itself** (deterministic, CASE B only — it prints
+     `✓ I opened your .env in your editor`). So your job is **only to guide the paste**: tell them
+     "Your `.env` is open in your editor — paste your key right after `GOOGLE_GEMINI_API_KEY=`, save
+     (⌘S on macOS), and let me know when it's done." *(free key: https://aistudio.google.com/apikey ;
+     **repeat the calm framing** — notes' text leaves the machine, and for a confidential vault you'd
+     enable billing / data-controls so it isn't used for training, see SETUP §9; or switch to option 1
+     fully-local.)*
+     (a) **Only if the installer did NOT open it** (headless / no GUI editor — it prints the
+     `⚠️ Gemini key not provided yet … paste it into <path>` copy instead), open it YOURSELF via a
+     shell command (Bash) — making an **editor window appear on the user's side** (`.env` is a *hidden*
+     file an average person won't locate). Use an **absolute path** (or `$HOME/…`), **never a quoted
+     `~`** (it doesn't expand in the shell):
      ```bash
      open -t "$HOME/<sub-path>/.env"   # macOS — opens TextEdit (field-verified)
      notepad "<path>\.env"              # Windows
      xdg-open "<path>/.env"             # Linux (or: ${EDITOR:-nano} "<path>/.env")
      ```
-     Then tell them exactly what to do: "I've opened your `.env` in TextEdit — paste your key right
-     after `GOOGLE_GEMINI_API_KEY=`, save (⌘S), and let me know when it's done." *(free key:
-     https://aistudio.google.com/apikey ; **repeat the calm framing** — notes' text leaves the machine,
-     and for a confidential vault you'd enable billing / data-controls so it isn't used for training,
-     see SETUP §9; or switch to option 1 fully-local.)* **If nothing opens**
-     (no GUI editor, headless), chain the fallbacks without waiting: reveal in Finder
+     If even that opens nothing, chain the fallbacks without waiting: reveal in Finder
      (`open -R "$HOME/<sub-path>/.env"`), or VS Code (`code "<path>/.env"`); only as a last resort,
      give the path + the line to fill in. **The key stays edited in `.env` by the user — never pasted
      into the chat nor passed as an argument.** Then (b) **run, from the brain folder, the deterministic

--- a/installer.mjs
+++ b/installer.mjs
@@ -10,7 +10,7 @@
 //
 //   Usage:  node installer.mjs
 // ═══════════════════════════════════════════════════════════════════════════
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import {
   existsSync,
   readFileSync,
@@ -49,6 +49,7 @@ import {
   envConfigForEmbedder,
   embedderReady,
 } from "./scripts/lib/embedder-choice.mjs";
+import { openEnvInEditor } from "./scripts/lib/open-env.mjs";
 
 // ROOT = the LAUNCHER (this cloned repo). READ-ONLY, reusable source: the
 // installer NEVER writes to it. It CREATES a brain folder elsewhere (TARGET),
@@ -696,10 +697,25 @@ console.log(`Your second brain was created in: ${c.C}${TARGET}${c.X}`);
 // missing (fully-local / endpoint option → no Gemini key to request).
 const geminiKeyMissing = embedderCfg.needsGeminiKey && !geminiKey;
 if (geminiKeyMissing) {
-  console.log(
-    `\n${c.B}⚠️ Gemini key not provided yet.${c.X} Before opening Claude Code, paste it into`
-  );
-  console.log(`   ${c.C}${toPosix(envPath)}${c.X} (line ${c.C}GOOGLE_GEMINI_API_KEY=${c.X}).`);
+  // CASE B only (Gemini chosen, key still missing): pop the user's editor on the
+  // .env so they don't have to hunt for a hidden file. Best-effort & non-fatal —
+  // if nothing opens we keep printing the path as the fallback.
+  const { opened } = openEnvInEditor(envPath, {
+    platform: process.platform,
+    env: process.env,
+    spawn,
+  });
+  if (opened) {
+    console.log(
+      `\n${c.B}✓ I opened your .env in your editor.${c.X} Paste your Gemini key right after`
+    );
+    console.log(`   ${c.C}GOOGLE_GEMINI_API_KEY=${c.X}, save${process.platform === "darwin" ? " (⌘S)" : ""}, then open Claude Code in the brain.`);
+  } else {
+    console.log(
+      `\n${c.B}⚠️ Gemini key not provided yet.${c.X} Before opening Claude Code, paste it into`
+    );
+    console.log(`   ${c.C}${toPosix(envPath)}${c.X} (line ${c.C}GOOGLE_GEMINI_API_KEY=${c.X}).`);
+  }
   console.log(
     `   If you open Claude Code first: paste the key then ask your question again (the server re-reads`
   );

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -68,11 +68,11 @@
       **refreshed** watch (EmbeddingGemma, bge-m3, Qwen3, E2GraphRAG…), **privacy scale by
       provider**, plain-language "embedder ≠ chat LLM", eval-first. **STATUS: 🔬 STUDY — nothing
       enacted.** *(feeds the SPI plan + ADR 0007)*
-    - [`auto-open-env-gemini.md`](plans/auto-open-env-gemini.md) — make the **installer open `.env`
-      itself** on the Gemini-key path (CASE B), deterministically, instead of relying on the
-      Claude-driven amorce. Diagnosed (**not** a code regression — the old behaviour was the amorce,
-      non-deterministic). **STATUS: ⏳ PENDING** — fix to run after a `/clear`.
   - **`plans/archived/`** — shipped/closed plans (kept for the detail of the steps):
+    - [`auto-open-env-gemini.md`](plans/archived/auto-open-env-gemini.md) — make the **installer open
+      `.env` itself** on the Gemini-key path (CASE B), deterministically (tested seam
+      `scripts/lib/open-env.mjs`, guard `SBG_NO_OPEN_ENV`), instead of relying on the Claude-driven
+      amorce. **STATUS: ✅ SHIPPED** (2026-06-13; proven end-to-end + real-Mac TextEdit confirm).
     - [`embedder-spi.md`](plans/archived/embedder-spi.md) — abstract the RAG's embedder behind an
       `Embedder` SPI port + stamp the index with an identity (provider/model/dimension) to make a
       swap **safe** (natural-language confirm-gate, never a silent reindex). Concretizes

--- a/maintainers/plans/archived/auto-open-env-gemini.md
+++ b/maintainers/plans/archived/auto-open-env-gemini.md
@@ -7,6 +7,37 @@
 
 ---
 
+> ## STATUS — ✅ LIVRÉ (2026-06-13, branche `feat/auto-open-env`)
+> 3 commits : seam `9860c9a` · wiring `37b7c0c` · amorce `f322460`. Suite 147/147 verte
+> (dont `open-env.test.mjs` 13/13). Prouvé end-to-end : Gemini GUARD ON → exit 0, copy `!opened`,
+> aucune fenêtre ; in-process → exit 0, `.env` JAMAIS ouvert ; **GUI réel (Thomas) → TextEdit s'ouvre
+> sur le `.env`, copy `✓ I opened your .env`**.
+
+## Tracking
+
+- [x] **Part 1 — tested cross-platform opener seam (`scripts/lib/open-env.mjs`, TDD)** _(9860c9a)_
+  - [x] `buildOpenEnvCommand(platform, absPath)` — darwin / win32 / linux / unknown→null
+  - [x] `shouldOpenEnv(env, platform)` — guard matrix (SBG_NO_OPEN_ENV, CI, linux headless)
+  - [x] `openEnvInEditor(absPath, {platform, env, spawn})` — best-effort, swallow errors, `{opened}`
+  - [x] `open-env.test.mjs` green (command matrix + guard matrix + swallow-errors) — 13/13
+- [x] **Part 2 — wire into `installer.mjs` (CASE B only)** _(37b7c0c)_
+  - [x] import `spawn` from `node:child_process`
+  - [x] call `openEnvInEditor` in the `geminiKeyMissing` branch
+  - [x] adapt banner copy to `opened` / `!opened`
+  - [x] never invoked for in-process / Ollama / endpoint-completed (structurally — guarded by `geminiKeyMissing`)
+- [x] **Part 3 — reconcile the amorce (`CLAUDE.md`, Step 4 → point 1 → CASE B)** _(f322460)_
+  - [x] "installer already opened `.env`" wording; Claude only guides the paste; fallback if not opened
+  - [x] key-never-in-chat guardrail preserved
+- [x] **Validation**
+  - [x] full test suite green incl. `open-env.test.mjs` — 147/147
+  - [x] disposable Gemini install, GUARD ON → exit 0, `!opened` copy, no editor window
+  - [x] manual Mac GUI (Thomas) → TextEdit opens on `.env`, `opened` copy _(2026-06-13)_
+  - [x] disposable in-process install → exit 0, `.env` NOT opened
+  - [x] cleanup `rm -rf /tmp/sbg-gem.*`
+- [x] **Commits (3, on a branch)** + plan archived per `plan-done-equals-archived`
+
+---
+
 ## Diagnosis (verified 2026-06-10 — NOT a code regression)
 
 - **There is no auto-open logic anywhere in `installer.mjs` / `scripts/`** — `grep` for

--- a/scripts/lib/open-env.mjs
+++ b/scripts/lib/open-env.mjs
@@ -1,0 +1,41 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// open-env.mjs — best-effort, cross-platform opener for the brain's `.env`.
+// Used on the Gemini-key install path (CASE B) to pop the user's editor on the
+// `.env` so they can paste GOOGLE_GEMINI_API_KEY without hunting for a hidden
+// file. Pure/seam-injectable: no implicit I/O, spawn is injected.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Maps a platform + ABSOLUTE path to the editor-open command, or null if the
+// platform is unknown. Always an absolute path (never a quoted `~`, which the
+// shell would not expand).
+export function buildOpenEnvCommand(platform, absPath) {
+  if (platform === "darwin") return { command: "open", args: ["-t", absPath] };
+  if (platform === "win32") return { command: "notepad", args: [absPath] };
+  if (platform === "linux") return { command: "xdg-open", args: [absPath] };
+  return null;
+}
+
+// Guard: should we even attempt to pop an editor? false in automated/headless
+// contexts where a window would spam (tests/CI) or hang (headless Linux).
+export function shouldOpenEnv(env, platform) {
+  if (env.SBG_NO_OPEN_ENV) return false;
+  if (env.CI) return false;
+  if (platform === "linux" && !env.DISPLAY && !env.WAYLAND_DISPLAY) return false;
+  return true;
+}
+
+// Thin, best-effort wrapper: if the guard allows and we have a command, spawn a
+// detached editor on `absPath` and detach. NEVER throws — a failed/absent editor
+// must not break the install. Returns { opened: boolean }. `spawn` is injected.
+export function openEnvInEditor(absPath, { platform, env, spawn }) {
+  if (!shouldOpenEnv(env, platform)) return { opened: false };
+  const cmd = buildOpenEnvCommand(platform, absPath);
+  if (!cmd) return { opened: false };
+  try {
+    const child = spawn(cmd.command, cmd.args, { detached: true, stdio: "ignore" });
+    child.unref();
+    return { opened: true };
+  } catch {
+    return { opened: false };
+  }
+}

--- a/scripts/lib/open-env.test.mjs
+++ b/scripts/lib/open-env.test.mjs
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildOpenEnvCommand, shouldOpenEnv, openEnvInEditor } from "./open-env.mjs";
+
+test("buildOpenEnvCommand — darwin → open -t <absPath> (TextEdit)", () => {
+  assert.deepEqual(buildOpenEnvCommand("darwin", "/home/u/brain/.env"), {
+    command: "open",
+    args: ["-t", "/home/u/brain/.env"],
+  });
+});
+
+test("buildOpenEnvCommand — win32 → notepad <absPath>", () => {
+  assert.deepEqual(buildOpenEnvCommand("win32", "C:\\u\\brain\\.env"), {
+    command: "notepad",
+    args: ["C:\\u\\brain\\.env"],
+  });
+});
+
+test("buildOpenEnvCommand — linux → xdg-open <absPath> (GUI default)", () => {
+  assert.deepEqual(buildOpenEnvCommand("linux", "/home/u/brain/.env"), {
+    command: "xdg-open",
+    args: ["/home/u/brain/.env"],
+  });
+});
+
+test("buildOpenEnvCommand — unknown platform → null", () => {
+  assert.equal(buildOpenEnvCommand("aix", "/home/u/brain/.env"), null);
+});
+
+test("shouldOpenEnv — plain desktop session → true", () => {
+  assert.equal(shouldOpenEnv({}, "darwin"), true);
+});
+
+test("shouldOpenEnv — SBG_NO_OPEN_ENV set → false (escape hatch)", () => {
+  assert.equal(shouldOpenEnv({ SBG_NO_OPEN_ENV: "1" }, "darwin"), false);
+});
+
+test("shouldOpenEnv — CI set → false", () => {
+  assert.equal(shouldOpenEnv({ CI: "true" }, "darwin"), false);
+});
+
+test("shouldOpenEnv — linux headless (no DISPLAY/WAYLAND) → false", () => {
+  assert.equal(shouldOpenEnv({}, "linux"), false);
+});
+
+test("shouldOpenEnv — linux with DISPLAY → true", () => {
+  assert.equal(shouldOpenEnv({ DISPLAY: ":0" }, "linux"), true);
+});
+
+test("openEnvInEditor — desktop session → spawns detached and returns {opened:true}", () => {
+  const calls = [];
+  let unrefed = false;
+  const spawn = (command, args, opts) => {
+    calls.push({ command, args, opts });
+    return { unref: () => { unrefed = true; } };
+  };
+  const res = openEnvInEditor("/home/u/brain/.env", { platform: "darwin", env: {}, spawn });
+  assert.deepEqual(res, { opened: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, "open");
+  assert.deepEqual(calls[0].args, ["-t", "/home/u/brain/.env"]);
+  assert.equal(calls[0].opts.detached, true);
+  assert.equal(calls[0].opts.stdio, "ignore");
+  assert.equal(unrefed, true);
+});
+
+test("openEnvInEditor — guard off (SBG_NO_OPEN_ENV) → no spawn, {opened:false}", () => {
+  let called = false;
+  const spawn = () => { called = true; return { unref() {} }; };
+  const res = openEnvInEditor("/x/.env", { platform: "darwin", env: { SBG_NO_OPEN_ENV: "1" }, spawn });
+  assert.deepEqual(res, { opened: false });
+  assert.equal(called, false);
+});
+
+test("openEnvInEditor — unknown platform (no command) → no spawn, {opened:false}", () => {
+  let called = false;
+  const spawn = () => { called = true; return { unref() {} }; };
+  const res = openEnvInEditor("/x/.env", { platform: "aix", env: {}, spawn });
+  assert.deepEqual(res, { opened: false });
+  assert.equal(called, false);
+});
+
+test("openEnvInEditor — throwing spawn is swallowed → {opened:false}", () => {
+  const spawn = () => { throw new Error("ENOENT"); };
+  const res = openEnvInEditor("/x/.env", { platform: "darwin", env: {}, spawn });
+  assert.deepEqual(res, { opened: false });
+});


### PR DESCRIPTION
## What

On the Gemini-key install path (**CASE B**: embedder = Gemini, key still missing), the installer now **opens the user's `.env` in their editor itself** — deterministically — instead of relying on the Claude-driven amorce (which was non-deterministic and the source of the perceived "regression": some sessions opened it, others only printed the path).

## How

- **Part 1** — tested cross-platform seam `scripts/lib/open-env.mjs` (TDD, 13/13):
  - `buildOpenEnvCommand(platform, absPath)` — darwin (`open -t`) / win32 (`notepad`) / linux (`xdg-open`) / unknown→null
  - `shouldOpenEnv(env, platform)` — guard: false on `SBG_NO_OPEN_ENV`, `CI`, linux headless (no `DISPLAY`/`WAYLAND_DISPLAY`)
  - `openEnvInEditor(absPath, {platform, env, spawn})` — best-effort, **swallows every error (never fatal)**, returns `{opened}`
- **Part 2** — wired into `installer.mjs` in the `geminiKeyMissing` branch; banner copy adapts to `opened` / `!opened`. Never invoked for in-process / Ollama / endpoint-completed (structurally — outside the `geminiKeyMissing` branch).
- **Part 3** — amorce `CLAUDE.md` CASE B repointed: "installer already opened `.env`", Claude only guides the paste, fallback if it didn't open. Key-never-in-chat guardrail preserved.

## Validation

- Full suite **147/147** (incl. `open-env.test.mjs`)
- Disposable Gemini install, GUARD ON → exit 0, `!opened` copy, **no editor window**
- Disposable in-process install → exit 0, `.env` **not** opened
- **Real Mac GUI** → TextEdit opens on the `.env` + `✓ I opened your .env` copy

Plan archived: `maintainers/plans/archived/auto-open-env-gemini.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)