### PR TITLE
Genericize references to a private second brain (don't name it in the launcher)

### DIFF
--- a/maintainers/decisions/0010-debounce-auto-push-to-stop-hook.md
+++ b/maintainers/decisions/0010-debounce-auto-push-to-stop-hook.md
@@ -13,7 +13,7 @@ The brain persists notes with a `PostToolUse Write|Edit → auto-commit.mjs` hoo
 **every** edit. That part is wanted and kept. The problem was that the **same** hook also **pushed**:
 once `git config secondbrain.autopush true` is set, every edit fired a **network `git push`** — plus
 a blocking `sleepSync(3000)` retry on failure. On a normal turn (dozens of edits) that meant **dozens
-of pushes**, which Thomas felt directly on his own brain (Inqom Rain) as "wasted time" and which
+of pushes**, which Thomas felt directly on his own brain in daily use as "wasted time" and which
 risks **rate-limiting** on GitHub/GitLab. Only the *push* cadence is the issue — the per-edit local
 commits are fine.
 
@@ -76,7 +76,7 @@ Visually, over a single exchange — many edits, many local commits, **one** pus
 - **Multi-window / multi-machine** → non-fast-forward races are possible; best-effort by design, the
   loser repushes next `Stop`. **Documented limit, not handled here** (use `/sync`).
 - **Hook timeout** raised to 30 s (the one retry/pause no longer slows every save).
-- **Already-generated brains** (Inqom Rain) have **frozen** settings → **manual backport** (procedure
+- **Already-generated brains** have **frozen** settings → **manual backport** (procedure
   in the plan): copy `auto-push.mjs` + `lib/git-push.mjs`, make `auto-commit.mjs` commit-only, add the
   `Stop` block to `<brain>/.claude/settings.json`, reopen a fresh conversation.
 - This is the concrete **reference instance of ADR 0009**: a pure tested `shouldPush(...)` (rung 1) +
@@ -92,5 +92,5 @@ Visually, over a single exchange — many edits, many local commits, **one** pus
   turn** and that returning `exit 0` does **not** block the turn — these rest on **documented hook
   semantics**, not an observed run (the simulation invoked `auto-push.mjs` directly). **Accepted at
   merge** because the failure mode is benign: if `Stop` misbehaves, the push simply doesn't happen and
-  the **local commits stay safe — nothing is lost**. To be confirmed in real use on Inqom Rain; if it
+  the **local commits stay safe — nothing is lost**. To be confirmed in real use on a generated brain; if it
   ever proves wrong, revisit here.

--- a/maintainers/plans/archived/debounce-auto-push.md
+++ b/maintainers/plans/archived/debounce-auto-push.md
@@ -44,9 +44,9 @@
 - [x] **Part 5 — Doc** _(2026-06-13)_
   - [x] MAJ `SETUP.md` (section auto-commit/push) : commits locaux par édition, push 1×/tour, rattrapage au Stop suivant, multi-machine = skill `sync` _(§2 + §7)_
   - [x] MAJ `CLAUDE.md.template` si la mécanique y est décrite (auto-commit/push) _(ligne « enable auto-push » précisée : 1×/tour, non-bloquant)_
-  - [x] note de suivi : backport manuel possible sur les cerveaux déjà générés (Inqom Rain) _(voir « Backport » ci-dessous)_
+  - [x] note de suivi : backport manuel possible sur les cerveaux déjà générés _(voir « Backport » ci-dessous)_
 
-### Backport (cerveaux déjà générés — ex. Inqom Rain)
+### Backport (cerveaux déjà générés)
 Les settings/scripts d'un cerveau déjà installé sont **figés** (copiés à l'install). Pour bénéficier
 du debounce sur un cerveau existant, backport **manuel** dans le dossier du cerveau :
 1. copier `scripts/auto-push.mjs` + `scripts/lib/git-push.mjs` depuis le launcher ;
@@ -102,7 +102,7 @@ Stop                       →  scripts/auto-push.mjs     (git push si condition
 5. Pas d'upstream → skip propre + message (jamais throw ; `-u` reste câblé à l'install).
 6. Tours sans édition → `@{u}..HEAD` vide → sortie rapide, **pas d'appel réseau**.
 7. `timeout` du hook `Stop` confortable (30 s) ; le retry/sleep ne ralentit plus chaque save.
-8. Cerveaux déjà générés (Inqom Rain) = settings figés → backport manuel (note de suivi).
+8. Cerveaux déjà générés = settings figés → backport manuel (note de suivi).
 9. Tests : `auto-commit` devient « ne pousse jamais » ; le push part dans `auto-push.test.mjs`.
 
 ## Commits suggérés (séparés, sur la branche)


### PR DESCRIPTION
The launcher is reusable/read-only and must **not** name a user's private second brain. This redacts the named references introduced in #4:

- `maintainers/decisions/0010-debounce-auto-push-to-stop-hook.md` — 3 mentions → generic "his own brain in daily use" / "already-generated brains" / "a generated brain".
- `maintainers/plans/archived/debounce-auto-push.md` — 3 mentions → generic "cerveaux déjà générés".

Working tree is otherwise clean of the name. (PR #4's body was also edited on GitHub.)

> Note: commit `01054d2` (merged in #4) still contains the name in its **message body**; rewriting merged history on `main` is destructive and was left alone — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)