### PR TITLE
ADR 0002: note the bootstrap.mjs → installer.mjs rename

### DIFF
--- a/maintainers/decisions/0002-in-house-installer-vs-plugin.md
+++ b/maintainers/decisions/0002-in-house-installer-vs-plugin.md
@@ -27,8 +27,10 @@ Two forces settle the answer:
 
 The generator stays an **in-house installer**: a launcher you clone, driven by a **conversational
 bootstrap stub** (the launcher's `CLAUDE.md`) that has Claude gather the answers **in chat**, then
-runs **ONE** command `node bootstrap.mjs --non-interactive`. The deterministic script does
-everything (copy, generation, `git init` of the brain, RAG install, MCP smoke-test).
+runs **ONE** command `node bootstrap.mjs --non-interactive` *(the script has since been renamed
+**`installer.mjs`** — the name above is kept as the historical record of this decision)*. The
+deterministic script does everything (copy, generation, `git init` of the brain, RAG install, MCP
+smoke-test).
 
 We **do not package** the generator as a plugin/marketplace for now.
 


### PR DESCRIPTION
Tiny doc clarification: ADR 0002 still referenced `node bootstrap.mjs`. The script was renamed `installer.mjs` after the decision. Keeps the historical name (an ADR is a snapshot) and adds an inline note pointing to the current name, so a re-reader isn't confused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)