### PR TITLE
docs: engine packaging — four-part model + ADR 0012 (supersedes 0003), study + Phase 0 plan

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -27,7 +27,7 @@
     plugin / marketplace.
   - [`0003-no-brain-capability-upgrade.md`](decisions/0003-no-brain-capability-upgrade.md) —
     no (yet) upgradability of capabilities: disproportionate complexity + simple local iteration
-    (home-grown skills); to be reopened on feedback.
+    (home-grown skills); to be reopened on feedback. **SUPERSEDED by 0012.**
   - [`0004-claude-only-for-now.md`](decisions/0004-claude-only-for-now.md) —
     Claude-only for now (vault + RAG already agnostic); cross-platform not ruled out, on
     feedback, with the orchestration layer to adapt.
@@ -73,6 +73,15 @@
     (non-Claude/Obsidian edits) + the on-brand remedy held in reserve (an event-bound `git add -A`
     sweep on `SessionStart`/`Stop`, gated on a *proven* need). Names the split ADR 0009 already
     implied. **Scope: Second brain (runtime).**
+  - [`0012-engine-packaging-four-part-model.md`](decisions/0012-engine-packaging-four-part-model.md) —
+    **engine packaging, supersedes 0003**: reopens upgradability on the trigger 0003 named (production +
+    parallel evolution). Fixes the **four-part vocabulary** — **Installer** (out of scope) / **Engine**
+    (the upstream-provided runtime machinery = the upgrade subject) / **Personal Extensions** (user-made
+    tooling grafted on, sacred) / **Content** (the vault, never touched). Sets the **founding principle**:
+    additive-only upgrade (write-allowlist + managed file set, never `rsync --delete`) — a user addition
+    is *never* deleted/overwritten, structurally. Three **regimes** (replace / merge-3way / never-touch),
+    Engine versioned as a **vector**. **Phased + channel-deferred** (decouple now, defer npm/plugin to
+    proven need; engine must start **offline**). **Scope: Second brain (runtime) + Installer.**
 - **[`eval-set.md`](eval-set.md)** — 🧪 **dev tool**: the RAG eval-set (Step 2 of the embedder plan).
   Measures the retrieval quality of the current embedder as a **reproducible score** (judge =
   Claude via `claude -p`), on the Flemmr vault → **Gemini baseline** to replay on the local

--- a/maintainers/decisions/0003-no-brain-capability-upgrade.md
+++ b/maintainers/decisions/0003-no-brain-capability-upgrade.md
@@ -1,6 +1,8 @@
 # ADR 0003 — No (yet) upgradability of generated brains' capabilities
 
-- **STATUS:** ACCEPTED (2026-06-05).
+- **STATUS:** ACCEPTED (2026-06-05) — **SUPERSEDED by [`0012`](0012-engine-packaging-four-part-model.md)
+  (2026-06-14)**, which enacts the reopening this ADR scheduled for itself. The "no upgrade for now" is
+  lifted; the sovereignty invariant below is **kept and strengthened** (now a structural write-allowlist).
 - **Scope:** Second brain (runtime) + Installer — the launcher↔brain relationship (the installer deliberately does NOT push upgrades to already-generated brains).
 - **Related:** [`0001-launcher-vs-brain.md`](0001-launcher-vs-brain.md) (the launcher→brain link
   is severed "by construction" — that's the cause of this consequence), [`0002-in-house-installer-vs-plugin.md`](0002-in-house-installer-vs-plugin.md).

--- a/maintainers/decisions/0012-engine-packaging-four-part-model.md
+++ b/maintainers/decisions/0012-engine-packaging-four-part-model.md
@@ -1,0 +1,94 @@
+# ADR 0012 — Engine packaging: an upgradable engine under a four-part model
+
+- **STATUS:** ACCEPTED (2026-06-14). **Supersedes [`0003`](0003-no-brain-capability-upgrade.md)** —
+  enacts the reopening 0003 scheduled for itself ("publication widens the user base"). The *framing*
+  (vocabulary, founding principle, regimes, phasing) is decided here; the **distribution channel**
+  stays deferred to the study + real feedback.
+- **Scope:** Second brain (runtime) + Installer — the launcher↔brain split of ADR 0001.
+- **Related:** [`0001`](0001-launcher-vs-brain.md) (launcher↔brain), [`0002`](0002-in-house-installer-vs-plugin.md)
+  (in-house installer + its hybrid addendum), [`0003`](0003-no-brain-capability-upgrade.md) (the deferral
+  this lifts), [`0006`](0006-rag-mcp-is-stable-contract.md) (stable MCP port — what makes an engine swap
+  invisible), [`0007`](0007-three-embedder-adapters-privacy-scale.md) (embedder SPI + index identity —
+  what makes a format change safe). Working detail: [`../plans/engine-packaging-study.md`](../plans/engine-packaging-study.md)
+  and its Phase 0 action plan.
+
+## Context
+
+ADR 0003 deferred engine upgradability and **named its own trigger**: reopen when publication widens the
+user base, aiming for "the hybrid — updatable engine + brain/vault always owned and never overwritten".
+That moment is here. The project is **in production** (client demos), and the brain and its engine now
+**evolve in parallel**: Thomas wants existing users to **upgrade their engine** while keeping **their
+content** and **their own tooling**, and plans to **refactor the engine** (RAG + constitution + hooks;
+e.g. a `CLAUDE.md` that has grown too big). 0003's pain point — "a fix in the engine does not flow back
+into already-created brains" — is now concrete.
+
+What was missing to act was not a channel but a **shared model**: which parts of a brain even *are* "the
+engine", and what an upgrade may touch. This ADR records that model.
+
+## Decision
+
+**1 — A four-part model (vocabulary, fixed).** A brain has exactly four parts; "the engine" is one of
+them, not a catch-all:
+
+| Part | What | Upgrade |
+|---|---|---|
+| **Installer** | the launcher + what it needs to generate a brain (`installer.mjs`, install-side `scripts/lib/`, `templates/`); read-only, reusable (ADR 0001) | **out of scope** — it *performs* upgrades, it isn't upgraded inside a brain |
+| **Engine** *(the motor)* | the **upstream-provided** runtime machinery: RAG, runtime hooks/scripts, shipped skills, the constitution `CLAUDE.md`, `.mcp.json` | **upgradable** (the subject) |
+| **Personal Extensions** | the **user-made** tooling grafted onto the brain: home-made skills, custom scripts/sub-agents/hooks. Machinery, but authored locally | **never touched** |
+| **Content** | the user's notes — their **data** (`vault/**`) | **never touched** |
+
+When Thomas says "engine", he means the Engine row. Personal Extensions are a **first-class category**,
+sacred like Content but for a different reason: theirs **by authorship**, where Content is theirs **by
+data**. A brain is *plastic* — people graft their own tooling onto it, and that must always survive.
+
+**2 — Founding principle: additive-only upgrade (non-negotiable).** An engine upgrade **MUST NEVER
+delete or overwrite a Personal Extension or any Content.** Mechanically: the upgrade writes only the
+files declared in the engine **manifest** (a **write-allowlist**), as a **managed file set** — **never**
+"replace the folder" / `rsync --delete`. A file absent from the manifest *cannot even be enumerated* for
+deletion. This is a **structural** guarantee, stronger than 0003's "non-destructive behaviour".
+
+**3 — Three upgrade regimes.** Every engine file falls in exactly one:
+- **Replace (re-substituted):** pure upstream machinery the user never edits (`rag/src/**`, provided
+  hooks/scripts) — overwritten, placeholders re-substituted, but only files named in the manifest.
+- **Merge 3-way (opt-in):** upstream-provided **but** user-editable (constitution `CLAUDE.md`, shipped
+  skills) — never overwritten; the new version is offered as a diff the user accepts hunk by hunk
+  (protects a fork). This regime is what makes "engine vs content" safe despite the constitution and
+  shipped skills living inside the engine.
+- **Never-touch:** Content **and** every Personal Extension — absent from the manifest ⇒ untouchable.
+
+The Engine is therefore versioned as a **vector** (`rag` / `constitution-template` / `scripts`), not a
+single number, surfaced at runtime (e.g. via `vault_stats`).
+
+**4 — Phased, channel-deferred.** Decouple **now** (observable version + relocatable paths + ownership
+manifest — Phase 0), and **defer the distribution channel** (opt-in re-pull / npm package / plugin) to
+proven need. Any channel must preserve ADR 0001's **self-sufficiency**: the engine **starts offline, with
+no network dependency** (today it is vendored as `tsx rag/src` — that property is kept).
+
+## Consequences
+
+- **Existing brains become upgradable without losing a single user addition** — the founding principle
+  guarantees it by construction, answering 0003's "no fix propagation" pain.
+- **The planned engine refactor is safe**: behind the stable MCP port (0006) it is invisible to a brain's
+  constitution and skills; an index-format change triggers a reindex via the 0007 machinery — minutes,
+  **zero content loss** (the vault is the source of truth).
+- **"Engine = everything but content" is made safe** by the Personal Extensions category + the merge
+  regime — the two ideas Thomas needed to reconcile.
+- **New surface to maintain** (manifest, version vector, upgrade command). Deliberately **staged** so
+  none of it lands before demos or before the user base proves the need.
+- **Inherited and hardened invariant** (from 0003): opt-in, non-destructive, no silent auto-update, no
+  mandatory upstream link, no sovereignty reclaim — plus, now, no network dependency at engine startup.
+
+## Rejected / deferred alternatives
+
+- **A single "engine bucket"** (no Personal Extensions category) — rejected: it cannot honour the
+  founding principle cleanly; user-grafted tooling would be at risk on every upgrade.
+- **Jump straight to an npm package / plugin** (study Tracks B/C) — **deferred**: reintroduces a
+  registry/network dependency before the user base justifies it, weakening 0001's offline guarantee. If
+  adopted later, **vendored-first** (an offline fallback shipped in the brain).
+- **Auto-upgrade / mandatory upstream link** — rejected, as in 0003: violates sovereignty.
+
+## Supersedes 0003
+
+0003's "no upgrade, for now" is **lifted**. Everything else in 0003 is **kept and strengthened**: its
+sovereignty invariant survives verbatim, now backed by the structural write-allowlist of the founding
+principle rather than by careful behaviour alone.

--- a/maintainers/plans/engine-packaging-phase0-action.md
+++ b/maintainers/plans/engine-packaging-phase0-action.md
@@ -1,40 +1,63 @@
 # Engine packaging — Phase 0 action plan (Track D: decouple now, defer the channel)
 
 **STATUS: 🗺️ ACTION PLAN — not started.** Enacts **Phase 0** of
-[`engine-packaging-study.md`](engine-packaging-study.md) (Track D). Makes the motor **observable and
-relocatable** without choosing a distribution channel yet. **Scope:** Second brain (runtime) + Installer.
-**Governing invariant (ADR 0003):** opt-in, non-destructive of local divergences, never reclaims the
-brain's sovereignty.
+[`engine-packaging-study.md`](engine-packaging-study.md) (Track D), under the four-part model and the
+founding principle of [`ADR 0012`](../decisions/0012-engine-packaging-four-part-model.md). Makes the
+**Engine observable and relocatable** without choosing a distribution channel yet. **Scope:** Second
+brain (runtime) + Installer.
+
+**Governing principle (ADR 0012, non-negotiable):** *additive-only upgrade.* An upgrade **never deletes
+or overwrites** a **Personal Extension** or any **Content**. Mechanically: a **write-allowlist** + a
+**managed file set**, never "replace the folder" / `rsync --delete`. Phase 0 lays the data that makes
+this guarantee *structural* (the manifest); it implements no upgrade command.
+
+**Vocabulary (ADR 0012):** *Installer* (the launcher — out of scope) · **Engine** (the upstream-provided
+runtime machinery — the subject) · **Personal Extensions** (user-made tooling grafted on — sacred) ·
+**Content** (the vault — sacred). "Engine" below always means the second one.
 
 ---
 
 ## Goal
 
-Build the **seam**, commit to **no policy**. After this plan, a brain can (a) report which motor it
-runs, (b) run an engine that lives *anywhere* (not only `<brain>/rag/`), and (c) be upgraded later by a
-follow-up (Track A/B/C) that knows exactly which files are "engine". Zero behaviour change for existing
-brains: every new input **defaults to today's value**.
+Build the **seam**, commit to **no policy**. After this plan, a brain can (a) **report** which Engine it
+runs (a version *vector*), (b) run an Engine **told where the vault is** (not welded to `<brain>/rag/`),
+and (c) be upgraded later by a follow-up (Track A/B/C) that knows, deterministically, **which files are
+Engine** — so that Personal Extensions and Content are untouchable *by construction*. **Zero behaviour
+change for existing brains:** every new input **defaults to today's value**.
 
-Three deliverables, independent, shippable one at a time (a `/clear` between each):
+Three deliverables, independent, shippable one at a time (a `/clear` between each), each in TDD
+(skill `tdd-discipline`: a failing test first, baby-steps, refactor not optional):
 
-1. **Relocatable paths** — `config.ts` reads vault/cache/env from the environment, defaulting to the
-   current relative paths.
-2. **Observable version** — real semver + `engine_version` and `index_schema_version` surfaced via
-   `vault_stats`; the index stamp carries the schema version.
-3. **Ownership map** — an explicit `engine-manifest.json` + a marker separating the engine-owned
-   `vault-rag` entry from user connector entries in `.mcp.json`.
+1. **Relocatable paths** — `config.ts` reads vault/cache/env from the environment, defaulting to today's
+   relative paths.
+2. **Observable version vector** — real semver + `engine_version` (a vector) and `index_schema_version`
+   surfaced via `vault_stats`; the index stamp carries the schema version.
+3. **Ownership manifest** — an explicit `engine-manifest.json` keyed **by upgrade regime**
+   (replace / merge / never-touch) + an Engine marker for `.mcp.json` — with the **survival test** as the
+   plan's first acceptance gate.
 
-Each is TDD (cf. skill `tdd-discipline`): a failing test first, baby-steps, refactor not optional.
+## Acceptance gate #0 — the founding principle, made testable (do this first)
 
----
+Before any of the three steps, write the **survival test** that every later step must keep green. It is
+the executable form of ADR 0012's principle:
+
+> Given a brain with a **home-made skill** (`.claude/skills/zzz-mine/SKILL.md`), a **custom script**
+> (`scripts/my-tool.mjs`), a **custom sub-agent**, and a **vault note** — none of them mentioned by
+> `engine-manifest.json` — the set of paths an upgrade is *allowed to write* (derived **only** from the
+> manifest's `replace ∪ merge ∪ regenerate ∪ engineMcpServers`) **contains none of them.**
+
+This test has no production code to pass yet (the manifest doesn't exist until Step 3); it is written
+**red** alongside Step 3 and is the gate that makes "Personal Extensions are sacred" a fact, not a hope.
+It encodes the **write-allowlist** semantics: the upgrade enumerates *what it may touch*, never *what to
+delete* — so an unmentioned file cannot even be a candidate.
 
 ## Step 1 — Relocatable paths (config.ts reads the environment)
 
 **Why:** today [`rag/src/lib/config.ts`](../../rag/src/lib/config.ts) pins everything by position
-(`resolve(__dirname, "../../..")`) → the engine is welded to `<brain>/rag/`. An upgrade channel needs the
-engine to be able to live elsewhere and be *told* where the vault is.
+(`resolve(__dirname, "../../..")`) → the Engine is welded to `<brain>/rag/`. An upgrade channel needs the
+Engine to be able to live elsewhere and be *told* where the vault is.
 
-**Change:** introduce a pure, tested resolver that prefers an env var, else falls back to today's path.
+**Change:** a pure, tested resolver that prefers an env var, else falls back to today's path.
 
 ```ts
 // pure + unit-testable: env wins, else the historical relative default
@@ -46,118 +69,144 @@ export const CACHE_DIR = resolvePath(process.env.CACHE_DIR, resolve(__dirname, "
 const envPath        = resolvePath(process.env.SBG_ENV_PATH, resolve(projectRoot, ".env"));
 ```
 
-**Tests** (`config.test.mts` or a new `paths.test.mts`):
-- env set (absolute) → returned, resolved.
-- env set (relative) → resolved against cwd.
-- env empty / whitespace / unset → historical fallback (the regression guard).
+**Tests** (`paths.test.mts`): env absolute → resolved; env relative → resolved against cwd; empty /
+whitespace / unset → historical fallback (the regression guard).
 
 **Acceptance:** existing brains — no env set — behave **identically** (same `VAULT_DIR`/`CACHE_DIR`/
-`envPath` as before). New env vars override. `rag` test suite stays green.
+`envPath`). New env vars override. `rag` suite stays green.
 
-**Out of scope here:** changing `.mcp.json.template` to *pass* those vars — do it only if Step 1's
-defaults don't already cover the current layout (they do), so leave the template alone until a channel
-(A/B) actually needs relocation. Document the vars in `.env.example` as **advanced/optional**.
+**Out of scope:** changing `.mcp.json.template` to *pass* those vars — the defaults already cover the
+current layout, so leave the template untouched until a channel (A/B) needs relocation. Document the vars
+in `.env.example` as **advanced/optional**.
 
-## Step 2 — Observable version (semver + vault_stats + index schema stamp)
+## Step 2 — Observable version vector (semver + vault_stats + index schema stamp)
 
-**Why:** `rag/package.json` is a static `1.0.0`, never bumped, and nothing surfaces it. You cannot tell a
-stale brain from a fresh one — the prerequisite of any upgrade UX and of stale-index detection.
+**Why:** `rag/package.json` is a static `1.0.0`, never bumped, surfaced nowhere. You cannot tell a stale
+brain from a fresh one — the prerequisite of any upgrade UX and of stale-index detection. And per ADR
+0012 the Engine is **several layers**, so the version is a **vector**, not one number.
 
-**2a. Real semver.** Adopt semver for `rag/package.json`. Define the bump rule in a one-paragraph note at
-the top of the engine (or in the manifest of Step 3): **MINOR** = behaviour/format change behind the
-stable MCP port; **MAJOR** = the index schema changes (forces a reindex); **PATCH** = fix, no format
-change. Start at the honest current number (keep `1.0.0` or bump to `1.1.0` with this change — decide in
-the PR).
+**2a. Real semver + version vector.** The Engine version is
+`{ rag, constitutionTemplate, scripts }`. **This step implements `rag` end-to-end** (semver in
+`rag/package.json`); `constitutionTemplate` and `scripts` start as static fields in the manifest
+(Step 3) and get their own bump discipline when those layers actually change. Bump rule for `rag`:
+**MAJOR** = index schema changes (forces a reindex) · **MINOR** = behaviour/format change behind the
+stable MCP port · **PATCH** = fix, no format change. Start at the honest current number (decide
+`1.0.0` vs `1.1.0` in the PR).
 
-**2b. Index schema version in the stamp.** Extend the existing index identity (ADR 0007 already stamps
-provider/model/dimension — find it via the embedder-identity / index-freshness code) with an
-`indexSchemaVersion` constant. On engine start, compare the running constant to the stamped value
-(reuse `index-freshness`): mismatch → the **existing** confirm-gate → reindex path. No new framework.
+**2b. Index schema version in the stamp.** Extend the existing index identity (ADR 0007 stamps
+provider/model/dimension — see the embedder-identity / index-freshness code) with an `indexSchemaVersion`
+constant. On Engine start, compare the running constant to the stamped value (reuse `index-freshness`):
+mismatch → the **existing** confirm-gate → reindex path. **No new framework** — this is the same
+machinery that already guards an embedder swap.
 
-**2c. Surface via `vault_stats`.** Add `engine_version` (from `package.json`) and `index_schema_version`
-(the stamped value + the running constant, so a drift is visible) to the `vault_stats` tool output.
-This is the only public-contract change, and it is **additive** (ADR 0006 allows generalising
-`vault_stats`; precedent set in its addendum) → no breakage.
+**2c. Surface via `vault_stats`.** Add `engine_version` (the vector, read from `package.json` + manifest)
+and `index_schema_version` (stamped value + running constant, so a drift is visible) to `vault_stats`.
+Only public-contract change, and it is **additive** (ADR 0006 allows generalising `vault_stats`) → no
+breakage.
 
-**Tests:**
-- `vault_stats` output includes `engine_version` matching `package.json` (read it, don't hardcode the
-  string — non-brittle assert per `tdd-discipline`).
-- stamp round-trip: write schema vN, read back vN.
-- drift: running constant ≠ stamped value → the stale path fires (mock the gate, assert it's called).
+**Tests:** `vault_stats` includes `engine_version.rag` matching `package.json` (read it, don't hardcode —
+non-brittle assert); stamp round-trip (write vN, read vN); drift (running ≠ stamped → stale path fires,
+gate mocked).
 
-**Acceptance:** `vault_stats` reports the motor; bumping `indexSchemaVersion` makes a brain detect its
-index as stale and offer a reindex; same-version brains see no prompt.
+**Acceptance:** `vault_stats` reports the Engine vector; bumping `indexSchemaVersion` makes a brain detect
+its index stale and offer a reindex; same-version brains see no prompt.
 
-## Step 3 — Ownership map (engine-manifest.json + .mcp.json marker)
+## Step 3 — Ownership manifest (engine-manifest.json, keyed by regime + .mcp.json marker)
 
-**Why:** today the engine/content/tools line is implicit. [`tracked-files.mjs`](../../scripts/lib/tracked-files.mjs)
+**Why:** today the four-part line is implicit. [`tracked-files.mjs`](../../scripts/lib/tracked-files.mjs)
 is an *install-time* allowlist, not an *upgrade-time* ownership map. A future `update-engine` must know,
-deterministically, what it may overwrite — and must **never** touch a user's connectors or forked skills.
+deterministically, **what it may write** — and, by the founding principle, *what it must never touch*.
 
-**3a. `engine-manifest.json`** at the launcher root (and copied into the brain): the explicit ownership
-table from the study, machine-readable. Sketch:
+**3a. `engine-manifest.json`** at the launcher root (and copied into the brain), keyed **by the three
+regimes** of ADR 0012. The file lists **only Engine paths**; everything not listed is, by construction,
+a Personal Extension or Content → untouchable.
 
 ```json
 {
-  "engineVersion": "1.1.0",
+  "manifestVersion": 1,
+  "engineVersion": { "rag": "1.1.0", "constitutionTemplate": "1.0.0", "scripts": "1.0.0" },
   "indexSchemaVersion": 1,
-  "owned": {
-    "replace": ["rag/src/**", "rag/package.json", "rag/tsconfig.json"],
-    "regenerate": ["rag/launch.sh", "rag/launch.cmd"]
+  "regimes": {
+    "replace":   ["rag/src/**", "rag/package.json", "rag/tsconfig.json"],
+    "regenerate":["rag/launch.sh", "rag/launch.cmd"],
+    "merge":     ["CLAUDE.md", ".claude/settings.json",
+                  ".claude/skills/coach/**", ".claude/skills/sync/**",
+                  ".claude/skills/sync-sources/**", ".claude/skills/improve/**",
+                  ".claude/skills/prepare-1-1/**", ".claude/skills/tdd-discipline/**",
+                  "scripts/auto-commit.mjs", "scripts/auto-push.mjs",
+                  "scripts/status-line.mjs", "scripts/verify-rag.mjs"]
   },
-  "userOwned": {
-    "neverTouch": ["vault/**", "CLAUDE.md", ".env", ".claude/skills/**"],
-    "merge": [".mcp.json", ".claude/settings.json"]
-  },
-  "undecided": ["scripts/auto-commit.mjs", "scripts/auto-push.mjs",
-                "scripts/status-line.mjs", "scripts/verify-rag.mjs"]
+  "engineMcpServers": ["vault-rag"]
 }
 ```
 
-Resolve the `undecided` list **in this PR** (it's open question #4 of the study): rule each engine-owned
-(upgradable) or frozen-at-install. Recommendation to validate: the auto-commit/push/status/verify scripts
-are **engine-owned** (they're mechanism, not the user's content) → `replace`, but only via the future
-opt-in `update-engine`, never silently.
+**Two open questions of the study, resolved here (ADR 0012 makes the call):**
 
-**3b. `.mcp.json` engine marker.** Mark the engine-owned server entry so a future merge can rewrite *only*
-it and leave connectors alone. Cheapest non-invasive option: a comment-free convention — the engine entry
-is always keyed `vault-rag`, and the manifest declares `"engineMcpServers": ["vault-rag"]`. A future
-`update-engine` rewrites only those keys, deep-merging the rest. (Avoid a custom `.mcp.json` schema
-extension — keep it a plain MCP file.)
+- **Q#4 — the hook/runtime scripts** (`auto-commit`, `auto-push`, `status-line`, `verify-rag`): Engine,
+  but **`merge`, not `replace`.** The founding principle tie-breaks: a user *might* have tweaked them, so
+  we never blind-overwrite — we offer a diff. (They also carry install-substituted placeholders
+  `{{NODE}}`/`{{PROJECT_ROOT}}`; a clean merge compares against the **template**, not the substituted
+  file — an implementation note for Phase 1.)
+- **Q#5 — the shipped skills** (`coach`, `sync`…): Engine, **`merge`.** They live in the user's
+  `.claude/skills/` and may be **forked** → never overwrite. **Critically, they are listed by name**, one
+  glob per shipped skill — **never** a blanket `.claude/skills/**`, which would swallow a home-made skill
+  and break the founding principle. A separate opt-in `update-skills` (Phase 1) drives their 3-way merge.
+
+**Replace ⇒ "replace-if-unmodified, else confirm" (the principle, even for `replace`).** Even a `replace`
+file must not blind-overwrite a locally-patched copy. So the manifest is designed to carry (or let Phase 1
+derive from git) a **provenance fingerprint** per Engine file; the upgrade overwrites only when the local
+file still matches the shipped one, otherwise it falls back to merge/confirm (dpkg-conffiles semantics).
+Phase 0 reserves the field; Phase 1 implements the comparison.
+
+**3b. `.mcp.json` Engine marker.** The Engine MCP entry is always keyed `vault-rag`; the manifest declares
+`engineMcpServers: ["vault-rag"]`. A future `update-engine` rewrites **only** those keys and **deep-merges
+the rest** (the user's Slack/Drive/Notion connectors are never enumerated for rewrite). Keep `.mcp.json` a
+plain MCP file — no custom schema extension.
 
 **Tests** (`engine-manifest.test.mjs`):
-- the manifest's `owned.replace` globs all resolve under `rag/` (no accidental vault/ entry).
-- `userOwned.neverTouch` and `owned.replace` are **disjoint** (a path can't be both) — the guard that
-  protects sovereignty.
-- `engineMcpServers` lists exactly the entries the installer writes into `.mcp.json.template`
-  (cross-check against the template) → the marker can't drift from reality.
+- **the survival test (gate #0)** — a home-made skill, a custom script, a sub-agent and a vault note are
+  **not** in `replace ∪ merge ∪ regenerate` nor under `engineMcpServers`.
+- **no over-broad glob** — no manifest glob matches a synthetic `.claude/skills/<random>/SKILL.md` or
+  `scripts/<random>.mjs` (guards against a blanket `.claude/skills/**`).
+- **regime disjointness** — `replace`, `merge`, `regenerate` are pairwise disjoint.
+- **engine paths only** — every listed path resolves to an Engine artefact the installer actually writes
+  (cross-check against `.mcp.json.template` for `engineMcpServers`; against the shipped skill folders for
+  the `merge` skill globs) → the manifest can't drift from reality.
 
-**Acceptance:** a single source of truth declares who owns what; a test fails loudly if engine and
-user buckets ever overlap. No runtime behaviour changes yet — this is data for Phase 1.
+**Acceptance:** one machine-readable source of truth, keyed by regime; the survival test is green and
+fails loudly if Engine ever overlaps a Personal Extension. **No runtime behaviour changes** — this is data
+for Phase 1.
 
 ---
 
 ## Sequencing & validation
 
-- **Order:** 1 → 2 → 3 (each independent; 2 and 3 both lean on 1 being merged but don't block on each
-  other). One `/clear` between steps.
-- **Definition of done (per house rule):** when Phase 0 ships, set this file's STATUS to ✅ with the
-  commit SHAs + what was verified, and `git mv` it into [`plans/archived/`](archived/).
-- **Whole-plan acceptance:** existing brains unchanged (no env set, no new prompts); a fresh install
-  reports `engine_version` via `vault_stats`; bumping `indexSchemaVersion` triggers the existing
-  reindex gate; the ownership manifest exists and its disjointness test is green.
-- **Explicitly NOT in Phase 0:** any re-pull/update command, any npm publish, any plugin, any
-  `.mcp.json` *merge* logic. Those are Phase 1+ (Tracks A/B/C). Phase 0 only lays the seam.
+- **Order:** gate #0 (survival test, red) → 1 → 2 → 3 (3 turns gate #0 green). Steps 1/2/3 are
+  independent; one `/clear` between them.
+- **Whole-plan acceptance:**
+  1. **Founding principle** — the survival test is green (Personal Extensions & Content are outside every
+     writable regime).
+  2. **No regression** — existing brains, no env set: identical paths, no new prompts; `rag` suite green.
+  3. **Observable** — a fresh brain reports its `engine_version` vector via `vault_stats`.
+  4. **Safe schema bump** — bumping `indexSchemaVersion` triggers the *existing* reindex gate; same
+     version → no prompt.
+- **Definition of done (house rule):** set this file's STATUS to ✅ with commit SHAs + what was verified,
+  and `git mv` it into [`plans/archived/`](archived/).
+- **Explicitly NOT in Phase 0:** any re-pull/update command, npm publish, plugin, `.mcp.json` *merge*
+  logic, fingerprint comparison, or `update-skills`. Those are Phase 1+ (Tracks A/B/C). Phase 0 lays the
+  seam only.
+- **Production note (demos in flight):** Phase 0 is non-regressive by design, but the standing rule holds
+  — **nothing merges to `main` before the client demos**; this work lands on a branch, verified by a
+  green `rag` suite + `verify-rag` on a test brain, and merges only after.
 
 ## Then what
 
-Phase 0 unblocks, in order of likely need:
-- **Phase 1 (Track A)** — opt-in `update-engine` reading `engine-manifest.json`, re-pulling the `owned`
-  set from a pinned source, reindexing iff `indexSchemaVersion` moved. Non-destructive by construction
-  (the manifest's disjointness guarantees it can't touch user buckets).
-- **Phase 2 (Tracks B → C)** — at publication: semver npm package with a vendored offline fallback, then
-  a plugin wrapping install + update. The ADR 0002-addendum hybrid, enacted on proven user-base need.
+- **Phase 1 (Track A)** — opt-in `update-engine` reading `engine-manifest.json`: re-pull the `replace`
+  set from a pinned source (replace-if-unmodified, else confirm), 3-way-merge the `merge` set, never touch
+  the rest; reindex iff `indexSchemaVersion` moved. Non-destructive **by construction** — the survival
+  test already proves the boundary. A sibling opt-in `update-skills` drives the shipped-skill merges.
+- **Phase 2 (Tracks B → C)** — at publication: semver npm package with a **vendored offline fallback**
+  (Engine must still start offline, ADR 0001/0012), then a plugin wrapping install + update. The ADR
+  0002-addendum hybrid, enacted on proven user-base need.
 
-When Phase 0 is designed enough to commit to, write the **ADR superseding 0003** (it explicitly invites
-this) recording: the engine/content/tools split, the observable-version decision, and the staged channel
-plan — with the sovereignty invariant as the non-negotiable.
+The framing is now fixed by **ADR 0012**; this plan is its first, smallest, fully-reversible increment.

--- a/maintainers/plans/engine-packaging-phase0-action.md
+++ b/maintainers/plans/engine-packaging-phase0-action.md
@@ -36,6 +36,23 @@ Three deliverables, independent, shippable one at a time (a `/clear` between eac
    (replace / merge / never-touch) + an Engine marker for `.mcp.json` — with the **survival test** as the
    plan's first acceptance gate.
 
+## Execution kickoff (run in a fresh window — avoid context rot)
+
+Execute this plan from a **new session**, not by dragging a long conversation along. The committed docs
+(ADR 0012 + this plan) **are** the external memory — the new window needs nothing else. Open it and give
+it only:
+
+> Read and follow `maintainers/decisions/0012-engine-packaging-four-part-model.md` and
+> `maintainers/plans/engine-packaging-phase0-action.md` **to the letter** (four-part model, additive-only
+> founding principle, three regimes). Work on branch **`claude/engine-packaging-phase0-impl`**. **Do NOT
+> merge to `main`** (demo week — runtime code merges only after). **TDD strict** (skill `tdd-discipline`):
+> write **gate #0** (the survival test) first, then **Step 1 only**, then stop and show me the diff. Keep
+> the `rag` suite green; commit + push to the impl branch.
+
+**Steps 2 and 3 each get their own fresh window**, same pattern (one clean context per step — the
+tablet-friendly equivalent of `/clear` between steps). Branch off `main` once the framing PR is merged;
+otherwise branch off `claude/engine-packaging-study-2nzmkg`.
+
 ## Acceptance gate #0 — the founding principle, made testable (do this first)
 
 Before any of the three steps, write the **survival test** that every later step must keep green. It is

--- a/maintainers/plans/engine-packaging-phase0-action.md
+++ b/maintainers/plans/engine-packaging-phase0-action.md
@@ -1,0 +1,163 @@
+# Engine packaging — Phase 0 action plan (Track D: decouple now, defer the channel)
+
+**STATUS: 🗺️ ACTION PLAN — not started.** Enacts **Phase 0** of
+[`engine-packaging-study.md`](engine-packaging-study.md) (Track D). Makes the motor **observable and
+relocatable** without choosing a distribution channel yet. **Scope:** Second brain (runtime) + Installer.
+**Governing invariant (ADR 0003):** opt-in, non-destructive of local divergences, never reclaims the
+brain's sovereignty.
+
+---
+
+## Goal
+
+Build the **seam**, commit to **no policy**. After this plan, a brain can (a) report which motor it
+runs, (b) run an engine that lives *anywhere* (not only `<brain>/rag/`), and (c) be upgraded later by a
+follow-up (Track A/B/C) that knows exactly which files are "engine". Zero behaviour change for existing
+brains: every new input **defaults to today's value**.
+
+Three deliverables, independent, shippable one at a time (a `/clear` between each):
+
+1. **Relocatable paths** — `config.ts` reads vault/cache/env from the environment, defaulting to the
+   current relative paths.
+2. **Observable version** — real semver + `engine_version` and `index_schema_version` surfaced via
+   `vault_stats`; the index stamp carries the schema version.
+3. **Ownership map** — an explicit `engine-manifest.json` + a marker separating the engine-owned
+   `vault-rag` entry from user connector entries in `.mcp.json`.
+
+Each is TDD (cf. skill `tdd-discipline`): a failing test first, baby-steps, refactor not optional.
+
+---
+
+## Step 1 — Relocatable paths (config.ts reads the environment)
+
+**Why:** today [`rag/src/lib/config.ts`](../../rag/src/lib/config.ts) pins everything by position
+(`resolve(__dirname, "../../..")`) → the engine is welded to `<brain>/rag/`. An upgrade channel needs the
+engine to be able to live elsewhere and be *told* where the vault is.
+
+**Change:** introduce a pure, tested resolver that prefers an env var, else falls back to today's path.
+
+```ts
+// pure + unit-testable: env wins, else the historical relative default
+export function resolvePath(envValue: string | undefined, fallback: string): string {
+  return envValue && envValue.trim() ? resolve(envValue) : fallback;
+}
+export const VAULT_DIR = resolvePath(process.env.VAULT_DIR, resolve(projectRoot, "vault"));
+export const CACHE_DIR = resolvePath(process.env.CACHE_DIR, resolve(__dirname, "../../.cache"));
+const envPath        = resolvePath(process.env.SBG_ENV_PATH, resolve(projectRoot, ".env"));
+```
+
+**Tests** (`config.test.mts` or a new `paths.test.mts`):
+- env set (absolute) → returned, resolved.
+- env set (relative) → resolved against cwd.
+- env empty / whitespace / unset → historical fallback (the regression guard).
+
+**Acceptance:** existing brains — no env set — behave **identically** (same `VAULT_DIR`/`CACHE_DIR`/
+`envPath` as before). New env vars override. `rag` test suite stays green.
+
+**Out of scope here:** changing `.mcp.json.template` to *pass* those vars — do it only if Step 1's
+defaults don't already cover the current layout (they do), so leave the template alone until a channel
+(A/B) actually needs relocation. Document the vars in `.env.example` as **advanced/optional**.
+
+## Step 2 — Observable version (semver + vault_stats + index schema stamp)
+
+**Why:** `rag/package.json` is a static `1.0.0`, never bumped, and nothing surfaces it. You cannot tell a
+stale brain from a fresh one — the prerequisite of any upgrade UX and of stale-index detection.
+
+**2a. Real semver.** Adopt semver for `rag/package.json`. Define the bump rule in a one-paragraph note at
+the top of the engine (or in the manifest of Step 3): **MINOR** = behaviour/format change behind the
+stable MCP port; **MAJOR** = the index schema changes (forces a reindex); **PATCH** = fix, no format
+change. Start at the honest current number (keep `1.0.0` or bump to `1.1.0` with this change — decide in
+the PR).
+
+**2b. Index schema version in the stamp.** Extend the existing index identity (ADR 0007 already stamps
+provider/model/dimension — find it via the embedder-identity / index-freshness code) with an
+`indexSchemaVersion` constant. On engine start, compare the running constant to the stamped value
+(reuse `index-freshness`): mismatch → the **existing** confirm-gate → reindex path. No new framework.
+
+**2c. Surface via `vault_stats`.** Add `engine_version` (from `package.json`) and `index_schema_version`
+(the stamped value + the running constant, so a drift is visible) to the `vault_stats` tool output.
+This is the only public-contract change, and it is **additive** (ADR 0006 allows generalising
+`vault_stats`; precedent set in its addendum) → no breakage.
+
+**Tests:**
+- `vault_stats` output includes `engine_version` matching `package.json` (read it, don't hardcode the
+  string — non-brittle assert per `tdd-discipline`).
+- stamp round-trip: write schema vN, read back vN.
+- drift: running constant ≠ stamped value → the stale path fires (mock the gate, assert it's called).
+
+**Acceptance:** `vault_stats` reports the motor; bumping `indexSchemaVersion` makes a brain detect its
+index as stale and offer a reindex; same-version brains see no prompt.
+
+## Step 3 — Ownership map (engine-manifest.json + .mcp.json marker)
+
+**Why:** today the engine/content/tools line is implicit. [`tracked-files.mjs`](../../scripts/lib/tracked-files.mjs)
+is an *install-time* allowlist, not an *upgrade-time* ownership map. A future `update-engine` must know,
+deterministically, what it may overwrite — and must **never** touch a user's connectors or forked skills.
+
+**3a. `engine-manifest.json`** at the launcher root (and copied into the brain): the explicit ownership
+table from the study, machine-readable. Sketch:
+
+```json
+{
+  "engineVersion": "1.1.0",
+  "indexSchemaVersion": 1,
+  "owned": {
+    "replace": ["rag/src/**", "rag/package.json", "rag/tsconfig.json"],
+    "regenerate": ["rag/launch.sh", "rag/launch.cmd"]
+  },
+  "userOwned": {
+    "neverTouch": ["vault/**", "CLAUDE.md", ".env", ".claude/skills/**"],
+    "merge": [".mcp.json", ".claude/settings.json"]
+  },
+  "undecided": ["scripts/auto-commit.mjs", "scripts/auto-push.mjs",
+                "scripts/status-line.mjs", "scripts/verify-rag.mjs"]
+}
+```
+
+Resolve the `undecided` list **in this PR** (it's open question #4 of the study): rule each engine-owned
+(upgradable) or frozen-at-install. Recommendation to validate: the auto-commit/push/status/verify scripts
+are **engine-owned** (they're mechanism, not the user's content) → `replace`, but only via the future
+opt-in `update-engine`, never silently.
+
+**3b. `.mcp.json` engine marker.** Mark the engine-owned server entry so a future merge can rewrite *only*
+it and leave connectors alone. Cheapest non-invasive option: a comment-free convention — the engine entry
+is always keyed `vault-rag`, and the manifest declares `"engineMcpServers": ["vault-rag"]`. A future
+`update-engine` rewrites only those keys, deep-merging the rest. (Avoid a custom `.mcp.json` schema
+extension — keep it a plain MCP file.)
+
+**Tests** (`engine-manifest.test.mjs`):
+- the manifest's `owned.replace` globs all resolve under `rag/` (no accidental vault/ entry).
+- `userOwned.neverTouch` and `owned.replace` are **disjoint** (a path can't be both) — the guard that
+  protects sovereignty.
+- `engineMcpServers` lists exactly the entries the installer writes into `.mcp.json.template`
+  (cross-check against the template) → the marker can't drift from reality.
+
+**Acceptance:** a single source of truth declares who owns what; a test fails loudly if engine and
+user buckets ever overlap. No runtime behaviour changes yet — this is data for Phase 1.
+
+---
+
+## Sequencing & validation
+
+- **Order:** 1 → 2 → 3 (each independent; 2 and 3 both lean on 1 being merged but don't block on each
+  other). One `/clear` between steps.
+- **Definition of done (per house rule):** when Phase 0 ships, set this file's STATUS to ✅ with the
+  commit SHAs + what was verified, and `git mv` it into [`plans/archived/`](archived/).
+- **Whole-plan acceptance:** existing brains unchanged (no env set, no new prompts); a fresh install
+  reports `engine_version` via `vault_stats`; bumping `indexSchemaVersion` triggers the existing
+  reindex gate; the ownership manifest exists and its disjointness test is green.
+- **Explicitly NOT in Phase 0:** any re-pull/update command, any npm publish, any plugin, any
+  `.mcp.json` *merge* logic. Those are Phase 1+ (Tracks A/B/C). Phase 0 only lays the seam.
+
+## Then what
+
+Phase 0 unblocks, in order of likely need:
+- **Phase 1 (Track A)** — opt-in `update-engine` reading `engine-manifest.json`, re-pulling the `owned`
+  set from a pinned source, reindexing iff `indexSchemaVersion` moved. Non-destructive by construction
+  (the manifest's disjointness guarantees it can't touch user buckets).
+- **Phase 2 (Tracks B → C)** — at publication: semver npm package with a vendored offline fallback, then
+  a plugin wrapping install + update. The ADR 0002-addendum hybrid, enacted on proven user-base need.
+
+When Phase 0 is designed enough to commit to, write the **ADR superseding 0003** (it explicitly invites
+this) recording: the engine/content/tools split, the observable-version decision, and the staged channel
+plan — with the sovereignty invariant as the non-negotiable.

--- a/maintainers/plans/engine-packaging-study.md
+++ b/maintainers/plans/engine-packaging-study.md
@@ -1,0 +1,180 @@
+# Engine packaging — making the motor upgradable without touching the brain
+
+**STATUS: 🔬 STUDY — nothing enacted.** Reopens [`ADR 0003`](../decisions/0003-no-brain-capability-upgrade.md)
+on the trigger it named itself ("publication widens the user base"). Feeds a future ADR + action plan.
+**Scope:** Installer + Second brain (runtime) — the launcher↔brain split of ADR 0001.
+
+---
+
+## 1. The problem, in the user's words
+
+> "Package the **engine** on one side. The content and the rest is fine — I already have a second
+> brain in use for this project — but now the two evolve in parallel. I'd like an **upgrade path**,
+> even for people who already installed my second brain: they keep **their content** and **their
+> tools**, and they can swap in a newer **motor**."
+
+Restated against our architecture: today a brain is **frozen at install day** (ADR 0001 severs the
+launcher→brain link "by construction"; ADR 0003 accepts the consequence). We want to make the **engine**
+(the RAG/MCP motor) an **independently replaceable unit**, while the **vault**, the **constitution**,
+the **skills** and the **connectors** stay owned and **never overwritten**.
+
+Three buckets, and which side of the line they sit on:
+
+| Bucket | Examples | Owner | On upgrade |
+|---|---|---|---|
+| **Engine (the motor)** | `rag/src/**`, `rag/package.json`, engine-side `scripts/*` | Maintainer | **Replaced** |
+| **Content** | `vault/**`, `CLAUDE.md`, retros/daily/people notes | User | **Untouched** |
+| **Tools** | `.mcp.json` connector entries, `.claude/skills/**` (incl. home-made), `.env` | User | **Preserved / merged** |
+
+The whole study is about drawing that line **explicitly** (today it is implicit) and choosing a
+**distribution channel** for the engine bucket.
+
+## 2. What already makes this feasible (don't re-pay)
+
+We are in a good position — several earlier decisions were quietly laying the groundwork:
+
+- **[ADR 0006](../decisions/0006-rag-mcp-is-stable-contract.md) — the MCP surface is a stable public
+  contract.** `search_vault / get_document / list_documents / vault_stats / reindex` is the port the
+  harness depends on; everything behind it is swappable. **An engine upgrade that preserves this port
+  is invisible to the brain's constitution and skills.** This is the single most important enabler.
+- **[ADR 0007](../decisions/0007-three-embedder-adapters-privacy-scale.md) — embedder SPI + index
+  identity stamping.** The index already records *who* encoded it (provider/model/dimension) and a
+  swap triggers a **confirm-gate → reindex**, never a silent mismatch. The machinery to detect
+  "this index is incompatible with the current engine" **already exists** — we extend it, we don't
+  invent it (see §5, the hard part).
+- **[ADR 0002 addendum (2026-06-14)](../decisions/0002-in-house-installer-vs-plugin.md)** already
+  sketches the target: the **"Hybrid (npm engine + plugin + thin scaffolder)"** — *not rejected, only
+  deferred to publication.*
+- **[ADR 0009](../decisions/0009-prefer-deterministic-mechanisms.md)** — the posture to apply: prefer
+  a deterministic, verifiable mechanism (a pinned version, a git condition, a stamped schema) over a
+  probabilistic one.
+
+## 3. What blocks it today (the coupling to break)
+
+The engine is **vendored inside the brain** at `rag/` and **assumes the brain's folder layout** via
+hardcoded relative paths — [`rag/src/lib/config.ts`](../../rag/src/lib/config.ts):
+
+```ts
+const projectRoot = resolve(__dirname, "../../..");   // = brain root, by position
+export const VAULT_DIR = resolve(projectRoot, "vault");
+export const CACHE_DIR = resolve(__dirname, "../../.cache");
+const envPath = resolve(projectRoot, ".env");
+```
+
+and the launch line — [`.mcp.json.template`](../../.mcp.json.template):
+`npx tsx rag/src/index.ts`, `cwd: {{PROJECT_ROOT}}`.
+
+Consequences for an upgrade:
+1. **The engine can't live anywhere but `<brain>/rag/`** → no way to point a brain at an engine sitting
+   elsewhere (a shared install, an npm cache, a newer checkout).
+2. **No version is observable at runtime.** `rag/package.json` is a static `1.0.0`, never bumped, and
+   `vault_stats` does **not** surface it. You cannot tell which motor a brain is running.
+3. **`.mcp.json` mixes engine-owned and user-owned entries** (the `vault-rag` server vs the user's
+   Slack/Drive/Notion connectors) with no marker separating them → naïve overwrite would clobber tools.
+4. **No manifest** says which files are "engine". The copy logic in
+   [`tracked-files.mjs`](../../scripts/lib/tracked-files.mjs) is an install-time allowlist, not an
+   upgrade-time ownership map.
+
+None of these is hard individually. (1) and (2) are the cheap, reversible groundwork (Track D below).
+
+## 4. The tracks
+
+Ordered from least to most invasive. They are **not exclusive** — D is groundwork for A/B/C, and the
+recommendation (§6) phases them.
+
+### Track A — `update-engine`: opt-in re-pull from a pinned source
+A brain-side command (Claude-driven, like install) that fetches the engine from a **pinned reference**
+(a git tag or a tarball URL recorded in the brain) and **overwrites only the engine bucket** (`rag/src`,
+`rag/package.json`, engine scripts), then `npm install` + reindex-if-needed. Vault/.env/skills/connectors
+untouched.
+- **Pros:** smallest change; stays self-hosted (no registry, honours ADR 0001 offline guarantee if the
+  source is a local checkout); fully under the "opt-in + non-destructive" invariant of ADR 0003.
+- **Cons:** re-introduces a launcher→brain coupling (the very link 0001 severed) — *mitigated* by making
+  it explicit, pinned, and user-triggered, not a standing remote. Needs the ownership manifest (§3.4)
+  to know what to overwrite.
+
+### Track B — Engine as a versioned npm package (`@second-brain/vault-rag`)
+The engine ships to npm with real semver; the brain's `.mcp.json` runs `npx @second-brain/vault-rag@^1`
+instead of `tsx rag/src/index.ts`. The vault/cache/.env paths move from hardcoded relatives to
+**env-injected** (`VAULT_DIR`, `CACHE_DIR`, `ENV_PATH` passed by `.mcp.json`). Upgrade = bump the range
+(or `npx` resolves the latest cached).
+- **Pros:** clean, idiomatic, genuine version negotiation; the brain shrinks (no vendored `rag/`); the
+  `.mcp.json` engine line becomes a trivially-rewritable one-liner, cleanly separable from connectors.
+  This is the "npm engine" half of the ADR 0002-addendum hybrid.
+- **Cons:** reintroduces a **registry dependency** → the offline/rug-pull/"forever as generated"
+  guarantee of ADR 0001 weakens. *Mitigations:* pin an exact version + keep a **vendored fallback**
+  (`npm pack` cached in the brain), so offline still works and a yanked version doesn't brick a brain.
+- **Prereq:** the path decoupling of Track D is **mandatory** here.
+
+### Track C — Claude Code plugin (the full hybrid: engine + skills + `/update-engine`)
+A marketplace plugin distributes the engine (depending on B's package), the shared skills, and an
+`/install-second-brain` + `/update-engine` command. The brain stays a separate owned repo; the plugin's
+MCP server is pointed at it via config.
+- **Pros:** best discoverability *and* updatability in one; the ADR 0002-addendum already establishes a
+  plugin *can* ship and run the scaffolder.
+- **Cons:** most moving parts (marketplace + package + scaffolder), and the **non-technical-audience
+  invariant of ADR 0002** must hold — the plugin/marketplace concepts must stay hidden behind the
+  chat-guided flow. Hooks still land in the **brain-local** `settings.json` (written by the scaffolder),
+  not as global plugin hooks. Premature before publication.
+
+### Track D — Decouple the layout now, defer the channel (groundwork)
+The cheap, reversible first move, independent of which channel wins:
+1. `config.ts` reads `VAULT_DIR` / `CACHE_DIR` / `ENV_PATH` from env, **defaulting to today's relative
+   paths** (zero behaviour change for existing brains).
+2. Bump `rag/package.json` to real semver and **surface `engine_version` (+ index schema version) in
+   `vault_stats`** → a brain can finally report its motor.
+3. Write an explicit **`engine-manifest.json`** (the ownership map of §1's table) + add a marker in
+   `.mcp.json` separating the engine-owned `vault-rag` entry from user connector entries.
+- This makes the **seam**; it commits to **no policy**. Pure ADR 0009 spirit (deterministic, no
+  over-engineering). After D, Tracks A/B/C are each a small, well-scoped follow-up.
+
+## 5. The hard part, common to all tracks: index forward-compatibility
+
+The real cost ADR 0003 flagged ("forward compatibility of the index, migrations") is **not** moving
+files — it's that a new engine may change the **index format / chunking / embedding**. Good news: ADR
+0007 already stamps the index with an **embedder identity** and gates a swap behind a **confirm →
+reindex**. The extension is small and reuses that machinery:
+
+- Add an **index schema version** alongside the embedder identity in the stamp.
+- On engine start, compare the running engine's schema version to the index's stamp.
+- On mismatch → the **same confirm-gate / reindex** path already built for an embedder swap. A reindex
+  is minutes and **loses no content** (the vault is the source of truth; the index is derived/regenerable).
+
+So "migrations" reduce, for the vector store, to "**detect stale → reindex**", which we already do. No
+bespoke migration framework needed unless we later persist something non-regenerable.
+
+## 6. Recommendation — phased, reversible, invariant-driven
+
+A single rule governs every phase — the **invariant from ADR 0003**: *opt-in, non-destructive of local
+divergences, never reclaims the brain's sovereignty (no silent auto-update, no mandatory upstream link,
+no overwriting the user's vault/constitution/home-made skills/connectors).*
+
+- **Phase 0 — now (Track D):** version the engine for real (semver + `engine_version`/schema in
+  `vault_stats`), env-inject the paths (defaults unchanged), write the `engine-manifest.json` ownership
+  map, mark engine-vs-user entries in `.mcp.json`. Low risk, reversible, unblocks everything. *This is
+  the only part worth doing before publication.*
+- **Phase 1 — on first real "my brain is stale" feedback (Track A):** ship an opt-in, manifest-driven
+  `update-engine` that re-pulls from a pinned source and reindexes if the schema moved. Stays self-hosted
+  (no registry), honours the invariant.
+- **Phase 2 — at publication, if feedback demands it (Track B, then C):** graduate the engine to a
+  semver npm package with a vendored offline fallback; later wrap install + update in a plugin for
+  discoverability. This is the ADR 0002-addendum hybrid, enacted only once the user base proves the need.
+
+**Do not** jump straight to B/C: it re-pays the offline/self-sufficiency cost of ADR 0001 before the
+user base justifies it. **Do** invest in Phase 0 now — it is cheap, it makes the motor *observable and
+relocatable*, and it is the prerequisite every other track shares.
+
+## 7. Open questions (to settle before writing the ADR)
+
+1. **Source of truth for Track A's "pinned reference"** — a git tag of the launcher, or a published
+   tarball? (git tag keeps it self-hosted; tarball is closer to B.)
+2. **Vendored fallback for Track B** — do we always `npm pack` into the brain at install (offline
+   guarantee) or only on request? Cost: disk vs the "forever as generated" promise.
+3. **`.mcp.json` merge strategy** — regenerate only the `vault-rag` line and 3-way-merge connectors, or
+   keep connectors in a separate included file the engine never touches?
+4. **What is "engine scripts" exactly** — `auto-commit` / `auto-push` / `status-line` / `verify-rag`:
+   engine bucket (upgradable) or frozen-at-install? They straddle the line; the manifest must rule.
+5. **Skills** — the shared skills (`coach`, `sync`, …) are maintainer-authored but live in the user's
+   `.claude/skills/`. Are they "engine" (upgradable) or "content" (frozen, user may have edited them)?
+   Likely: a **separate opt-in `update-skills`** with a 3-way merge, never an overwrite (a user may have
+   forked `coach`). Keep distinct from `update-engine`.

--- a/maintainers/plans/engine-packaging-study.md
+++ b/maintainers/plans/engine-packaging-study.md
@@ -4,6 +4,16 @@
 on the trigger it named itself ("publication widens the user base"). Feeds a future ADR + action plan.
 **Scope:** Installer + Second brain (runtime) — the launcher↔brain split of ADR 0001.
 
+> 🧱 **FOUNDING PRINCIPLE — extensibility, set by Thomas (2026-06-14), non-negotiable from day one.**
+> Upgrading the engine **MUST NEVER delete or overwrite anything a user added** — home-made skills,
+> custom scripts, sub-agents, hooks, notes. The brain is **extensible by design**: user additions are
+> sacred. Mechanically this means the upgrade is **additive-only** — it touches *only* the engine files
+> explicitly listed in the manifest (a **write-allowlist**), as a **managed file set**, **never** by
+> "replace the folder" / `rsync --delete`. Anything not in the manifest is, by construction,
+> untouchable. This is **stronger** than ADR 0003's "non-destructive": a structural guarantee, not a
+> careful behaviour — an unknown file *cannot even be enumerated* for deletion. Every track below
+> inherits this as a hard constraint; a track that can't honour it is rejected.
+
 ---
 
 ## 1. The problem, in the user's words
@@ -18,16 +28,68 @@ launcher→brain link "by construction"; ADR 0003 accepts the consequence). We w
 (the RAG/MCP motor) an **independently replaceable unit**, while the **vault**, the **constitution**,
 the **skills** and the **connectors** stay owned and **never overwritten**.
 
-Three buckets, and which side of the line they sit on:
+**Thomas's vocabulary (2026-06-14) — three things, fixed for all our exchanges.** The brain world has
+**exactly three** parts, and when Thomas says **"the engine"** he means the **middle** one:
 
-| Bucket | Examples | Owner | On upgrade |
+| Term | What it is | Lives | On an engine upgrade |
 |---|---|---|---|
-| **Engine (the motor)** | `rag/src/**`, `rag/package.json`, engine-side `scripts/*` | Maintainer | **Replaced** |
-| **Content** | `vault/**`, `CLAUDE.md`, retros/daily/people notes | User | **Untouched** |
-| **Tools** | `.mcp.json` connector entries, `.claude/skills/**` (incl. home-made), `.env` | User | **Preserved / merged** |
+| **Installer** | the launcher + all it needs to generate a brain (`installer.mjs`, install-side `scripts/lib/`, `templates/`) | the **launcher** repo (read-only, reusable — ADR 0001) | **out of scope** — it's the tool that *performs* an upgrade, not a thing upgraded inside a brain |
+| **Engine** *(= "the motor")* | everything that makes a brain *run*: RAG, runtime hooks/scripts, shared skills, the constitution `CLAUDE.md`, `.mcp.json` | inside the **brain** | **the subject of this study** — upgradable, under the founding principle |
+| **Content** | the user's notes — their data | the brain's `vault/**` | **never touched** |
 
-The whole study is about drawing that line **explicitly** (today it is implicit) and choosing a
-**distribution channel** for the engine bucket.
+So: **"engine", in our conversations, = the runtime machinery of a brain, excluding both the installer
+and the content.** It has several sub-parts that may each need a different packaging strategy
+(§1.bis) — but the word always points at this middle category.
+
+**The catch — and the founding principle above.** "Engine = everything but content" does **not** mean
+"the upgrade may rewrite all of it". Inside the engine, a **second axis** decides what an upgrade may
+touch: **who authored it.** The user *extends and edits* the engine (home-made skills, custom
+scripts/sub-agents, a personalised `CLAUDE.md`, configured connectors) — and those additions are
+**sacred** (founding principle). So the real upgrade boundary is not content-vs-engine, it's
+**upstream-provided vs locally-added/edited**, *inside* the engine. The whole study is about drawing
+**that** line explicitly (today it's implicit) and choosing a distribution channel for the
+upstream-provided part.
+
+## 1.bis "The engine" is really 3+1 versioned layers (refined 2026-06-14)
+
+Field input (Thomas): the planned refactor — and the very word "engine" — spans **more than `rag/src`**.
+What he wants to repackage and improve covers **three sub-systems at once**, each with a **different
+upgrade rule**. Treating them as one undivided "engine bucket" is wrong — they must be **versioned and
+upgraded independently**:
+
+| Layer | Files | Protected by | Upgrade rule |
+|---|---|---|---|
+| **A — Retrieval (RAG)** | `rag/src/**` | ADR 0006 (stable MCP port) | Replaceable cleanly; format change → reindex (ADR 0007) |
+| **B — Constitution** | `CLAUDE.md` (+ `templates/<locale>/CLAUDE.md.template`) | ADR 0003 | **Never overwritten** (user-edited); a slimmer template helps *future* brains only; existing brains via an **opt-in non-destructive diff** |
+| **C — Hooks/scripts** | `auto-commit`, `auto-push`, `status-line`, `verify-rag` | — (the "undecided" of §3.4) | Engine-owned but **re-substituted** on upgrade (`{{NODE}}`/`{{PROJECT_ROOT}}`), opt-in only |
+| **(D — Skills)** | `.claude/skills/**` (incl. home-made) | ADR 0003 | Separate `update-skills`, 3-way merge, never overwrite a fork |
+
+**Three upgrade regimes** fall out of the two axes (content/engine × upstream-provided/locally-added).
+Every engine file lands in exactly one:
+1. **Replace (re-substituted)** — pure upstream machinery the user never edits: `rag/src/**`, the
+   provided runtime hooks/scripts. Overwritten on upgrade (placeholders re-substituted) — but **only the
+   files named in the manifest**; a user-added script sitting next to them is invisible to the upgrade
+   and survives untouched.
+2. **Merge 3-way (opt-in)** — upstream-provided **but** user-editable: the constitution `CLAUDE.md`, the
+   shipped skills (`coach`, `sync`…). **Never** overwritten; the new version is offered as a diff the
+   user accepts hunk by hunk → a fork is protected.
+3. **Never touch** — the vault **and** every local addition (home-made skills, custom scripts/sub-agents,
+   `.env`, configured connectors). Absent from the manifest ⇒ **structurally** untouchable.
+
+Regime 3 is the founding principle made mechanical; regime 2 is what makes "engine = everything but
+content" *safe* even though the constitution and the shipped skills live inside the engine.
+
+**Consequence for Phase 0:** the "observable version" (study §4 Track D, plan step 2) is **not one
+number** — it's a small **version vector** (`rag` / `constitution-template` / `scripts`). And the
+manifest's ownership map gets **one bucket per regime** (replace / merge / never-touch), not a single
+`owned.replace`.
+
+**On "`CLAUDE.md` too big"** (Thomas's example, layer B): that's a **context/prompt** optimisation, *not*
+RAG. The constitution is **auto-loaded every session** → its size costs tokens each turn and dilutes
+Claude's attention. The idiomatic move: **slim the constitution to invariants + pointers** and push the
+bulk into **skills** (loaded on demand, not permanently). It improves *new* installs immediately; for
+existing brains it can only land via the opt-in diff above (their `CLAUDE.md` is personalised — never
+force-replaced, per ADR 0003).
 
 ## 2. What already makes this feasible (don't re-pay)
 

--- a/maintainers/plans/engine-packaging-study.md
+++ b/maintainers/plans/engine-packaging-study.md
@@ -28,27 +28,28 @@ launcher→brain link "by construction"; ADR 0003 accepts the consequence). We w
 (the RAG/MCP motor) an **independently replaceable unit**, while the **vault**, the **constitution**,
 the **skills** and the **connectors** stay owned and **never overwritten**.
 
-**Thomas's vocabulary (2026-06-14) — three things, fixed for all our exchanges.** The brain world has
-**exactly three** parts, and when Thomas says **"the engine"** he means the **middle** one:
+**Thomas's vocabulary (2026-06-14) — four things, fixed for all our exchanges.** The brain world has
+**exactly four** parts, and when Thomas says **"the engine"** he means the one labelled so:
 
 | Term | What it is | Lives | On an engine upgrade |
 |---|---|---|---|
-| **Installer** | the launcher + all it needs to generate a brain (`installer.mjs`, install-side `scripts/lib/`, `templates/`) | the **launcher** repo (read-only, reusable — ADR 0001) | **out of scope** — it's the tool that *performs* an upgrade, not a thing upgraded inside a brain |
-| **Engine** *(= "the motor")* | everything that makes a brain *run*: RAG, runtime hooks/scripts, shared skills, the constitution `CLAUDE.md`, `.mcp.json` | inside the **brain** | **the subject of this study** — upgradable, under the founding principle |
-| **Content** | the user's notes — their data | the brain's `vault/**` | **never touched** |
+| **Installer** | the launcher + all it needs to generate a brain (`installer.mjs`, install-side `scripts/lib/`, `templates/`) | the **launcher** repo (read-only, reusable — ADR 0001) | **out of scope** — it *performs* an upgrade, it isn't a thing upgraded inside a brain |
+| **Engine** *(= "the motor")* | the **upstream-provided** runtime machinery: RAG, runtime hooks/scripts, the shipped skills, the constitution `CLAUDE.md`, `.mcp.json` | inside the **brain** | **the subject of this study** — upgradable, under the founding principle |
+| **Personal Extensions** *(short: "Extensions")* | the **user-made** tooling grafted onto the brain: home-made skills, custom scripts/sub-agents/hooks. Machinery, but authored locally — **not** content | inside the **brain** | **never touched** (sacred — founding principle) |
+| **Content** | the user's notes — their **data** | the brain's `vault/**` | **never touched** |
 
-So: **"engine", in our conversations, = the runtime machinery of a brain, excluding both the installer
-and the content.** It has several sub-parts that may each need a different packaging strategy
-(§1.bis) — but the word always points at this middle category.
+So: **"engine", in our conversations, = the upstream-provided runtime machinery of a brain** — excluding
+the installer, the user's own **Personal Extensions**, and the content. A brain is **plastic**: people
+graft their own tooling onto it, and that tooling is a **first-class category**, sacred like the content
+but for a different reason — Personal Extensions are theirs **by authorship**, content is theirs **by
+data**.
 
-**The catch — and the founding principle above.** "Engine = everything but content" does **not** mean
-"the upgrade may rewrite all of it". Inside the engine, a **second axis** decides what an upgrade may
-touch: **who authored it.** The user *extends and edits* the engine (home-made skills, custom
-scripts/sub-agents, a personalised `CLAUDE.md`, configured connectors) — and those additions are
-**sacred** (founding principle). So the real upgrade boundary is not content-vs-engine, it's
-**upstream-provided vs locally-added/edited**, *inside* the engine. The whole study is about drawing
-**that** line explicitly (today it's implicit) and choosing a distribution channel for the
-upstream-provided part.
+**The catch — and the founding principle above.** The split isn't only "machinery vs data": the user
+also *edits* engine files (a personalised `CLAUDE.md`, a forked `coach` skill). The decisive axis is
+**who authored it** — **Engine (upstream-provided)** vs **Personal Extensions (locally-added or -edited)**.
+Personal Extensions are **sacred**. The **merge regime** (below) handles the overlap — when a user edits an
+upstream file. The whole study is about drawing **that** line explicitly (today it's implicit) and
+choosing a distribution channel for the **Engine** part only.
 
 ## 1.bis "The engine" is really 3+1 versioned layers (refined 2026-06-14)
 


### PR DESCRIPTION
## What

Framing-only change for making the **engine upgradable** without ever touching a user's content or
their own tooling. **Docs only** — everything lands under `maintainers/` (dev-only, `DEV_ONLY_PREFIXES`):
it is **never copied into a generated brain** and **changes no runtime behaviour**. Safe to merge any
time, including during the demo week — zero impact on installs or on existing brains.

## Contents

- **ADR 0012 — `0012-engine-packaging-four-part-model.md`** (supersedes 0003). Fixes the vocabulary and
  the non-negotiables:
  - **Four-part model**: *Installer* (the launcher — out of scope) · **Engine** (the upstream-provided
    runtime machinery = the upgrade subject) · **Personal Extensions** (user-made tooling grafted on —
    sacred *by authorship*) · **Content** (the vault — sacred *by data*). "Engine" = the second one.
  - **Founding principle**: *additive-only upgrade* — a Personal Extension or Content is **never**
    deleted/overwritten. Structural guarantee (write-allowlist + managed file set, never `rsync --delete`).
  - **Three upgrade regimes** (replace / merge-3way / never-touch); Engine versioned as a **vector**.
  - **Phased + channel-deferred**: decouple now, defer npm/plugin to proven need; the engine must start
    **offline** (ADR 0001/0012).
- **0003** marked **SUPERSEDED** (its sovereignty invariant kept and strengthened); `maintainers/README.md`
  index updated.
- **Study — `plans/engine-packaging-study.md`**: the four-part model, the enablers (ADR 0006 stable MCP
  port, ADR 0007 index identity), the coupling to break, four non-exclusive tracks (A re-pull / B npm /
  C plugin / D decouple-now), and a phased recommendation.
- **Phase 0 action plan — `plans/engine-packaging-phase0-action.md`**: the first, smallest, fully
  reversible increment (relocatable paths · observable version vector · ownership manifest keyed by
  regime), with the **survival test** as acceptance gate #0.

## Not in this PR

The **implementation** (real runtime code: `config.ts`, `vault_stats`, the manifest) ships separately on
a dedicated branch / PR and is **not merged before the demos**. This PR is the decision record only.

https://claude.ai/code/session_01T2ry5746akXnJAdMRS7Lj8

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2ry5746akXnJAdMRS7Lj8)_