### PR TITLE
fix(update-engine): deliver engine skills + MCP servers on update — v3.2.1 "The One Where Updating Finally Brings The Mirror Along"

### DIFF
--- a/.claude/skills/update-engine/SKILL.md
+++ b/.claude/skills/update-engine/SKILL.md
@@ -41,7 +41,8 @@ code on disk and may trigger a reindex; it must always be a conscious, accepted 
 | `rag/launch.*`, `scripts/run-node.*` launchers | `.env` (your keys) |
 | engine scripts (`auto-commit`, `auto-push`, `status-line`, `verify-rag`) | `CLAUDE.md` (your constitution) |
 | `update-engine` itself (it self-updates) | `.claude/settings.json` |
-|  | your custom `.claude/skills/**` |
+| **missing** engine skills (e.g. `local-mirror`) — _added if absent_ (ADR 0025) | your custom skills **and any engine skill you already have** (`.claude/skills/**`) |
+| **missing** engine MCP servers in `.mcp.json` — _added if absent_ (ADR 0025) | any server you added yourself to `.mcp.json` |
 
 ## Procedure
 
@@ -80,3 +81,9 @@ exactly the engine-owned files, regenerates the launchers, runs `npm install`, r
   half-applied past the failure.
 - **Already up to date** → re-pulling the same version is harmless; the engine is swapped
   again and, since the index format didn't move, **no reindex** runs.
+- **A new engine skill/server doesn't appear after a single update on a pre-3.2.1 brain**
+  (ADR 0025) → expected. The apply runs from the brain's **installed** code, and the skill/MCP
+  install logic only landed *during* this update. Simply **run the update once more** (or it
+  arrives on the brain's next update): run 1 lays down the new engine code, run 2 executes it
+  and installs the missing skill + registers the server. This affects only brains installed
+  **before v3.2.1**; from v3.2.1 on, a new engine skill/server lands in a single update.

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 1,
-  "engineVersion": { "rag": "1.1.0", "local-mirror": "0.1.0", "constitutionTemplate": "1.0.0", "scripts": "1.0.0" },
+  "engineVersion": { "rag": "1.1.1", "local-mirror": "0.1.0", "constitutionTemplate": "1.0.0", "scripts": "1.0.0" },
   "indexSchemaVersion": 1,
   "regimes": {
     "replace": [

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 1,
-  "engineVersion": { "rag": "1.1.1", "local-mirror": "0.1.0", "constitutionTemplate": "1.0.0", "scripts": "1.0.0" },
+  "engineVersion": { "rag": "1.1.1", "local-mirror": "0.1.1", "constitutionTemplate": "1.0.0", "scripts": "1.0.0" },
   "indexSchemaVersion": 1,
   "regimes": {
     "replace": [

--- a/local-mirror/package-lock.json
+++ b/local-mirror/package-lock.json
@@ -12,10 +12,12 @@
         "@notionhq/client": "^5.22.0",
         "dotenv": "^16.6.1",
         "gray-matter": "^4.0.3",
+        "js-yaml": "^4.2.0",
         "notion-to-md": "^3.1.9",
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
@@ -527,6 +529,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
@@ -584,13 +593,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -882,19 +888,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1272,13 +1265,22 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -1748,12 +1750,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/local-mirror/package.json
+++ b/local-mirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-mirror",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "engines": {
@@ -16,10 +16,15 @@
     "@notionhq/client": "^5.22.0",
     "dotenv": "^16.6.1",
     "gray-matter": "^4.0.3",
+    "js-yaml": "^4.2.0",
     "notion-to-md": "^3.1.9",
     "zod": "^4.4.3"
   },
+  "overrides": {
+    "js-yaml": "^4.2.0"
+  },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"

--- a/local-mirror/src/lib/markdown.ts
+++ b/local-mirror/src/lib/markdown.ts
@@ -3,7 +3,22 @@
 // writes*, not a RAG requirement. Frontmatter via gray-matter (js-yaml under the hood).
 
 import matter from 'gray-matter';
+import { load as yamlLoad, dump as yamlDump } from 'js-yaml';
 import type { SourceItem } from '../domain/ports.js';
+
+// gray-matter 4.x defaults to js-yaml 3's `safeLoad`/`safeDump`, both removed in
+// js-yaml 4. We force the patched js-yaml >=4.2.0 (GHSA-h67p-54hq-rp68 DoS, all
+// <=4.1.1 vulnerable, no patched 3.x) and route gray-matter's YAML through js-yaml
+// 4's `load`/`dump` — safe by default. `stringify` (write) is the production path;
+// `parse` (read) backs the round-trip assertions in tests.
+const YAML_ENGINE = {
+  engines: {
+    yaml: {
+      parse: (input: string) => yamlLoad(input) as object,
+      stringify: (obj: object) => yamlDump(obj),
+    },
+  },
+} as const;
 
 /** The frontmatter stamped on every produced note (PRD §6). */
 export interface LocalMirrorFrontmatter {
@@ -29,5 +44,11 @@ export function toLocalMirrorMarkdown(
     source_url: item.url,
     last_edited_time: item.lastEditedTime,
   };
-  return matter.stringify(body, frontmatter);
+  return matter.stringify(body, frontmatter, YAML_ENGINE);
+}
+
+/** Read back a local-mirror note (frontmatter + body) using the same js-yaml-4 engine. */
+export function parseLocalMirrorMarkdown(raw: string): { data: Record<string, unknown>; content: string } {
+  const { data, content } = matter(raw, YAML_ENGINE);
+  return { data, content };
 }

--- a/local-mirror/src/test/sync-writes-vault.test.ts
+++ b/local-mirror/src/test/sync-writes-vault.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import matter from 'gray-matter';
+import { parseLocalMirrorMarkdown } from '../lib/markdown.js';
 import { aLocalMirror, aNotionPage } from './builder.js';
 
 // Acceptance test at the API port (ILocalMirror), driven by the Builder with a
@@ -23,7 +23,7 @@ test('syncing a source writes one local-mirror .md per page, with mandatory fron
   assert.equal(report.written, 1);
   const file = harness.vaultFiles().get('mirrors/pa-sc/abc123.md');
   assert.ok(file, 'expected a .md written at mirrors/pa-sc/abc123.md');
-  const { data, content } = matter(file);
+  const { data, content } = parseLocalMirrorMarkdown(file);
   assert.equal(data.source_url, 'https://www.notion.so/inqom/abc123');
   assert.equal(data.last_edited_time, '2026-06-12T14:21:00.000Z');
   assert.equal(data.mirror, 'pa-sc');

--- a/maintainers/decisions/0025-update-engine-installs-missing-engine-skills-and-servers.md
+++ b/maintainers/decisions/0025-update-engine-installs-missing-engine-skills-and-servers.md
@@ -1,0 +1,84 @@
+# ADR 0025 — An engine update installs MISSING engine-owned skills and MCP servers (additive, never clobbering)
+
+- **STATUS:** ACCEPTED (2026-06-19).
+- **Scope:** Second brain (runtime) — a behavior of `update-engine` (engine-owned code in
+  `scripts/`); it reaches ≥3.1.0 brains via the update itself and ships in fresh installs (where the
+  installer already delivers skills + `.mcp.json` by construction). **Index format unchanged** → no
+  schema bump, no forced reindex.
+- **Related:** [`0003-...`] / [`0012-...`] (the write-allowlist safety core — this ADR adds one
+  additive, conditional bucket without weakening it),
+  [`0016-update-engine-is-a-skill-not-an-mcp.md`](0016-update-engine-is-a-skill-not-an-mcp.md)
+  (the conversational layer), [`0022-golden-source-sync-separate-file-writing-mcp.md`](0022-golden-source-sync-separate-file-writing-mcp.md)
+  (the `local-mirror` MCP, ex `golden-source-sync`). QA finding #1:
+  [`../qa/qa-v3.2.0.md`](../qa/qa-v3.2.0.md); fix plan:
+  [`../plans/fix-update-engine-skills-mcp-action.md`](../plans/fix-update-engine-skills-mcp-action.md).
+
+## Context
+
+Post-v3.2.0 QA, run as a real v3.1.0→v3.2.0 upgrader on a golden master, surfaced a **major** gap:
+`update-engine` delivered the `local-mirror/` **code** (it is in the `replace` regime) but **neither**
+its skill **nor** its MCP server. So an upgrader did not get the flagship feature; only a **fresh
+install** did. Two root causes:
+
+- **Skills are blanket-sacred.** `engine-apply-plan.mjs` scrubs everything under `.claude/skills/`
+  (`SACRED_TREES`) so the engine never overwrites a user's custom skill. Correct as a default — but it
+  also blocked a **brand-new engine skill** (`local-mirror`) that the user could not possibly have
+  customized because it did not exist on their brain.
+- **`engineMcpServers` was declared but never consumed.** The manifest lists
+  `engineMcpServers: ["vault-rag","local-mirror"]`, but `update-engine` never reconciled the brain's
+  `.mcp.json` against it, so the `local-mirror` stdio server was never registered.
+
+A second fact constrains the design: **the apply runs from the brain's *installed* `update-engine`
+code**, not the fetched launcher (static imports + Node module caching — self-replacement only takes
+effect on the *next* run). So a logic fix only governs brains already running it (v3.2.1 → future); the
+current ≤v3.2.0 cohort self-heals on the **subsequent** update (run 1 lays down the new engine code,
+run 2 executes it). Given a tiny, reachable cohort, we accept that one-cycle lag rather than add a
+re-exec-from-fetched mechanism (rejected below).
+
+## Decision
+
+**On update, additively install the engine-owned skills and MCP servers the manifest declares, but only
+where they are ABSENT — never overwrite, never touch anything the manifest does not declare.**
+
+1. **`installSkills` bucket (skills).** `computeApplyPlan` carves the manifest-declared engine-skill
+   paths (`merge` entries matching `.claude/skills/<name>/**`) out of the blanket skills scrub into a
+   new `installSkills` bucket. At apply, each declared skill dir is **installed only if absent** on the
+   brain. An absent skill has no user state to preserve, so this is unambiguously safe; an
+   already-present engine skill (possibly user-customized, e.g. `prepare-1-1`) is **left byte-identical**.
+2. **`.mcp.json` reconcile (servers).** `update-engine` reads the **fetched** `.mcp.json.template`,
+   substitutes `{{PROJECT_ROOT}}` → the brain dir, and **adds only the `engineMcpServers` that are
+   missing** from the brain's `.mcp.json`. User-added servers are preserved; re-running is idempotent.
+3. **The destructive buckets stay scrubbed.** `overwrite`/`regenerate` still refuse any
+   `.claude/skills/**` path, so a buggy/hostile manifest can never overwrite a skill — only the
+   additive, install-if-absent `installSkills` path can ever write one, and only when none exists.
+
+### Safety invariant (every new test asserts it)
+
+> Only skills and MCP servers the manifest declares as engine-owned are ever written, and only when
+> ABSENT. Everything else under `.claude/skills/` (any non-declared / custom skill), every user-added
+> `.mcp.json` server, the vault, `.env`, the constitution and settings are untouchable.
+
+## Consequences
+
+- **Upgraders get `local-mirror`** (skill + MCP) — QA finding #1 closed for every brain running this
+  code or newer; the ≤v3.2.0 cohort heals on its next update (documented, no extra code).
+- **Zero clobber risk.** Install-if-absent means a user-customized engine skill (the `prepare-1-1`
+  "refine to your own KPIs" case) is never overwritten. Refreshing the *content* of an
+  already-installed engine skill remains out of scope (it belongs to a future 3-way merge, same as the
+  other `merge` files).
+- **The safety core is unchanged in spirit**: still a write-allowlist; the one new bucket is additive
+  and conditional, and the sacred scrub on the destructive buckets is intact.
+- **No schema change, no forced reindex.**
+
+## Rejected alternatives
+
+- **Re-exec the fetched `update-engine` so the target version drives the update (one-cycle for future
+  logic fixes).** More "correct" in principle, but it does **not** help the current ≤v3.2.0 cohort
+  (their installed code lacks the re-exec, so they still need two cycles) and costs real complexity:
+  anti-loop guard, cross-platform spawn, seam re-wiring + tests. Over-engineering against a rare,
+  bounded risk; revisit with a dedicated ADR if engine-logic changes ever become frequent.
+- **Overwrite engine skills wholesale on every update (replace-like).** Would clobber legitimate user
+  customization of meta-skills (`prepare-1-1`, etc.). Install-if-absent delivers the missing flagship
+  skill with none of that risk.
+- **Hardcode `local-mirror` as a special case.** Brittle and non-general; driving everything off the
+  manifest's declared engine skills + `engineMcpServers` keeps the next engine skill/server automatic.

--- a/maintainers/plans/fix-update-engine-skills-mcp-action.md
+++ b/maintainers/plans/fix-update-engine-skills-mcp-action.md
@@ -18,7 +18,7 @@
 - [x] **Lot 0 — Investigation & design decisions** _(2026-06-19 · branch created; decisions below + ADR 0025)_
 - [x] **Lot A — Install engine-declared skills on update** (TDD) _(2026-06-19 · commit pending)_
 - [x] **Lot B — Reconcile `.mcp.json` from `engineMcpServers`** (TDD) _(2026-06-19 · commit pending)_
-- [ ] **Lot C — Self-heal path for already-broken v3.2.0 brains** (decided in Lot 0)
+- [x] **Lot C — Self-heal path for already-broken ≤v3.2.0 brains** (doc only, decided in Lot 0) _(2026-06-19)_
 - [ ] **Lot D — npm vulnerability remediation** (TDD where it touches behavior)
 - [ ] **Lot Ship — verify green, `/code-review`, merge, tag v3.2.1, archive, re-run QA §3**
 
@@ -87,11 +87,11 @@
 
 ## Lot C — Self-heal for already-broken v3.2.0 brains
 
-- [ ] Based on Q1: if apply runs from fetched code → confirm self-heal is automatic (add a test that
-      simulates the broken→fixed transition). If it runs from installed code → implement a one-shot
-      idempotent heal in the v3.2.1 update, **or** document a manual heal for the few v3.2.0 early
-      adopters (re-install toward a fresh brain, or copy the skill + add the MCP entry).
-- [ ] Record the chosen path in the plan + ADR.
+- [x] Q1 resolved: apply runs from **installed** code → no automatic one-cycle self-heal possible for
+      the existing cohort. **Chosen path: two-cycle self-heal, documented** (no extra code): run 1 lays
+      down the new engine logic, run 2 executes it. Tiny reachable cohort → acceptable.
+- [x] Documented in the brain-side `update-engine` skill (new edge case + the touches table now lists
+      additive skill/MCP install) and in ADR 0025 ("Rejected alternatives" covers re-exec-from-fetched).
 
 ## Lot D — npm vulnerability remediation
 

--- a/maintainers/plans/fix-update-engine-skills-mcp-action.md
+++ b/maintainers/plans/fix-update-engine-skills-mcp-action.md
@@ -105,6 +105,11 @@
       pre-existing frontmatter test was the fail-first; green after the engine wiring.
 - [x] `npm audit` → **0 vulnerabilities**. RAG suite **178/178**, `tsc` clean.
 - [x] Bumped `rag` engine version `1.1.0 → 1.1.1` (`rag/package.json` + `engine-manifest.json`).
+- [x] **`local-mirror` carried the same advisories** (mcp-sdk→hono, gray-matter→js-yaml). Same fix:
+      audit fix + js-yaml `^4.2.0` override; a js-yaml-4 engine (`parse`+`stringify` via `load`/`dump`)
+      in `markdown.ts` (its `stringify` write path is exercised across the acceptance suite), with a
+      `parseLocalMirrorMarkdown` reader the round-trip test now uses. `local-mirror` **84/84**, `tsc`
+      clean, **0 vulnerabilities**. Bumped `local-mirror` `0.1.0 → 0.1.1`.
 
 ## Lot Ship
 

--- a/maintainers/plans/fix-update-engine-skills-mcp-action.md
+++ b/maintainers/plans/fix-update-engine-skills-mcp-action.md
@@ -19,7 +19,7 @@
 - [x] **Lot A — Install engine-declared skills on update** (TDD) _(2026-06-19 · commit pending)_
 - [x] **Lot B — Reconcile `.mcp.json` from `engineMcpServers`** (TDD) _(2026-06-19 · commit pending)_
 - [x] **Lot C — Self-heal path for already-broken ≤v3.2.0 brains** (doc only, decided in Lot 0) _(2026-06-19)_
-- [ ] **Lot D — npm vulnerability remediation** (TDD where it touches behavior)
+- [x] **Lot D — npm vulnerability remediation** (TDD where it touches behavior) _(2026-06-19 · commit pending)_
 - [ ] **Lot Ship — verify green, `/code-review`, merge, tag v3.2.1, archive, re-run QA §3**
 
 ---
@@ -95,11 +95,16 @@
 
 ## Lot D — npm vulnerability remediation
 
-- [ ] `npm audit fix` in `rag/` for the **non-breaking** ones (`hono`, `protobufjs`); re-run audit.
-- [ ] `gray-matter` 1.x→2.x (js-yaml fix) is **breaking** → bump behind the **full RAG test suite**
-      (frontmatter parsing is core); fix any fallout, tests green.
-- [ ] Re-run `npm audit` → confirm clean (or document any residual + rationale).
-- [ ] Bump `rag` engine version + manifest accordingly.
+- [x] `npm audit fix` (non-breaking) in `rag/` → patched **hono** (high) + **protobufjs** (moderate)
+      via the lock (4 → 2 vulns); `package.json` untouched by it.
+- [x] **js-yaml** DoS (GHSA-h67p-54hq-rp68, all `<=4.1.1`; **no patched 3.x** exists). The plan's
+      "downgrade gray-matter" was wrong (it's at `^4.0.3`; `audit fix --force` would drop it to 2.0.1).
+      Instead: **`overrides: { js-yaml: ^4.2.0 }`** + js-yaml as a direct dep. The **full RAG suite
+      caught** that gray-matter 4.x calls the removed `yaml.safeLoad` → fixed by routing gray-matter's
+      YAML through js-yaml 4's safe `load` (`frontmatter-parser.ts`, `GRAY_MATTER_OPTIONS`). The
+      pre-existing frontmatter test was the fail-first; green after the engine wiring.
+- [x] `npm audit` → **0 vulnerabilities**. RAG suite **178/178**, `tsc` clean.
+- [x] Bumped `rag` engine version `1.1.0 → 1.1.1` (`rag/package.json` + `engine-manifest.json`).
 
 ## Lot Ship
 

--- a/maintainers/plans/fix-update-engine-skills-mcp-action.md
+++ b/maintainers/plans/fix-update-engine-skills-mcp-action.md
@@ -15,7 +15,7 @@
 
 ## Tracking
 
-- [ ] **Lot 0 — Investigation & design decisions** (no code; resolve the open questions below)
+- [x] **Lot 0 — Investigation & design decisions** _(2026-06-19 · branch created; decisions below + ADR 0025)_
 - [ ] **Lot A — Install engine-declared skills on update** (TDD)
 - [ ] **Lot B — Reconcile `.mcp.json` from `engineMcpServers`** (TDD)
 - [ ] **Lot C — Self-heal path for already-broken v3.2.0 brains** (decided in Lot 0)
@@ -24,26 +24,39 @@
 
 ---
 
-## Lot 0 — Investigation & design decisions
+## Lot 0 — Investigation & design decisions — ✅ RESOLVED (2026-06-19)
 
-- [ ] **Q1 — Where does the apply run from?** Read the `update-engine` execution flow and confirm
-      whether the apply plan is computed/executed by the brain's **currently-installed** code or by
-      the **freshly-fetched** engine code. This decides whether a broken v3.2.0 brain self-heals on
-      the v3.2.1 update, or stays broken for one extra cycle (chicken-and-egg). → drives Lot C.
-- [ ] **Q2 — Engine-skill regime semantics.** Engine skills are listed under `merge` in the manifest
-      but are **engine-owned** (the user isn't expected to edit `local-mirror/SKILL.md`). Decide:
-      install/overwrite the manifest-declared skill paths wholesale (like `replace`, but scoped to
-      declared engine-skill paths), keeping true `merge` only for genuinely user-editable files
-      (CLAUDE.md, settings). Record the decision.
-- [ ] **Q3 — MCP server source of truth.** Confirm the engine server definitions come from the
-      fetched `.mcp.json.template` (so the update reads the new template, extracts the
-      `engineMcpServers` defs, substitutes `{{PROJECT_ROOT}}` → brain dir, merges only the missing
-      ones). Verify `.mcp.json.template` is reachable from the fetched engine.
-- [ ] **Q4 — Safety invariant, written down.** "Only skills/servers the manifest declares as
-      engine-owned are ever written; everything else under `.claude/skills/` and any user-added MCP
-      server is untouchable." This is the property every new test asserts.
-- [ ] **ADR** — capture the engine-owned-vs-user distinction in the sacred scrub (new ADR, Scope:
-      *Second brain (runtime) + Installer*).
+- [x] **Q1 — Where does the apply run from? → the brain's INSTALLED code.** `update-engine.mjs`
+      statically imports `computeApplyPlan` from the brain's own `scripts/lib/`; the in-flight comment
+      (`update-engine.mjs:127-130`) confirms self-replacement only takes effect on the *next* run (Node
+      module caching). The fetched launcher supplies **data** (manifest + files), not logic. ⟹ a logic
+      fix governs only brains already running it (v3.2.1 → future). The ≤v3.2.0 cohort **self-heals on
+      the subsequent update** (run 1 lays down the new engine code via the `replace` regime; run 2
+      executes the new logic). → drives Lot C.
+- [x] **Q2 — Engine-skill regime semantics → install-if-ABSENT (additive), never overwrite.**
+      `computeApplyPlan` carves the manifest-declared engine-skill paths (`merge` entries matching
+      `.claude/skills/<name>/**`) into a new **`installSkills`** bucket; at apply, each declared skill
+      dir is installed **only if absent**. An absent skill (e.g. `local-mirror` on an upgrader) has no
+      user state to clobber; an already-present engine skill (possibly user-customized, e.g.
+      `prepare-1-1`) is left **byte-identical**. Content-refresh of an already-installed engine skill =
+      **out of scope** (future Phase 2 3-way, like the other `merge` files).
+- [x] **Q3 — MCP server source of truth → the fetched `.mcp.json.template`.** Confirmed it exists at
+      launcher root, carries both `vault-rag` + `local-mirror` with the `{{PROJECT_ROOT}}` placeholder,
+      and is reachable from the fetched source (the installer already substitutes it,
+      `installer.mjs:453`). The update reads it, substitutes `{{PROJECT_ROOT}}` → brain dir, and **adds
+      only the missing `engineMcpServers`**. Reuse `connectors-merge.mjs:addServerToMcpJson` as the
+      idempotent primitive.
+- [x] **Q4 — Safety invariant (asserted by every new test):** _Only skills/servers the manifest
+      declares as engine-owned are ever written, and only when ABSENT; everything else under
+      `.claude/skills/` (any non-declared/custom skill), every user-added `.mcp.json` server, the vault,
+      `.env`, the constitution and settings are untouchable._ The destructive buckets
+      (`overwrite`/`regenerate`) stay sacred-scrubbed → only the additive `installSkills` path can ever
+      write a skill, and only when none exists.
+- [x] **Lot C decision → two-cycle self-heal, doc only** (no extra code; confirmed with Thomas, given a
+      tiny reachable cohort). Re-exec-from-fetched **rejected** (doesn't help the current cohort, real
+      complexity) — see ADR 0025 "Rejected alternatives".
+- [x] **ADR** — [`0025-update-engine-installs-missing-engine-skills-and-servers.md`](../decisions/0025-update-engine-installs-missing-engine-skills-and-servers.md)
+      (ACCEPTED 2026-06-19, Scope: *Second brain (runtime)*).
 
 ## Lot A — Install engine-declared skills on update
 

--- a/maintainers/plans/fix-update-engine-skills-mcp-action.md
+++ b/maintainers/plans/fix-update-engine-skills-mcp-action.md
@@ -16,7 +16,7 @@
 ## Tracking
 
 - [x] **Lot 0 — Investigation & design decisions** _(2026-06-19 · branch created; decisions below + ADR 0025)_
-- [ ] **Lot A — Install engine-declared skills on update** (TDD)
+- [x] **Lot A — Install engine-declared skills on update** (TDD) _(2026-06-19 · commit pending)_
 - [ ] **Lot B — Reconcile `.mcp.json` from `engineMcpServers`** (TDD)
 - [ ] **Lot C — Self-heal path for already-broken v3.2.0 brains** (decided in Lot 0)
 - [ ] **Lot D — npm vulnerability remediation** (TDD where it touches behavior)
@@ -60,14 +60,18 @@
 
 ## Lot A — Install engine-declared skills on update
 
-- [ ] RED: test — given a manifest declaring `.claude/skills/local-mirror/**` as engine-owned and a
-      brain without it, the apply plan **installs** the skill.
-- [ ] RED: test — a **user** skill (`.claude/skills/zzz-mine/**`, NOT in the manifest) is **never**
-      written/removed (sacred preserved).
-- [ ] GREEN: carve the manifest-declared engine-skill paths out of the blanket `SACRED_TREES` scrub
-      in `engine-apply-plan.mjs`; route them to the chosen regime (per Q2).
-- [ ] Refactor; full `scripts/lib` suite green.
-- [ ] Verify empirically on the golden master: after update, `.claude/skills/local-mirror/` exists.
+- [x] RED→GREEN: `computeApplyPlan` exposes an `installSkills` bucket = the manifest-declared
+      engine-skill paths (`merge` entries matching `.claude/skills/<name>/**`), carved out of the
+      blanket skills scrub (`engine-apply-plan.mjs`).
+- [x] SAFETY test: a skill mis-declared in `replace`/`regenerate` is still scrubbed — only the additive
+      `merge`→`installSkills` path can ever carry a skill; a custom/non-declared skill is never in it.
+- [x] RED→GREEN (apply): `updateEngine()` installs a **missing** engine-declared skill from the fetched
+      source (install-if-absent at the **skill-dir** level); the gate's SACRED set (incl. the custom
+      `zzz-mine` skill) stays byte-identical.
+- [x] Triangulation: an **already-present** (user-customized) engine skill is preserved byte-identical
+      (never clobbered).
+- [x] Refactor; full harness suite green (300/300).
+- [ ] Verify empirically on the golden master (grouped with Lot B — single restore cycle).
 
 ## Lot B — Reconcile `.mcp.json` from `engineMcpServers`
 

--- a/maintainers/plans/fix-update-engine-skills-mcp-action.md
+++ b/maintainers/plans/fix-update-engine-skills-mcp-action.md
@@ -20,7 +20,7 @@
 - [x] **Lot B — Reconcile `.mcp.json` from `engineMcpServers`** (TDD) _(2026-06-19 · commit pending)_
 - [x] **Lot C — Self-heal path for already-broken ≤v3.2.0 brains** (doc only, decided in Lot 0) _(2026-06-19)_
 - [x] **Lot D — npm vulnerability remediation** (TDD where it touches behavior) _(2026-06-19 · commit pending)_
-- [ ] **Lot Ship — verify green, `/code-review`, merge, tag v3.2.1, archive, re-run QA §3**
+- [~] **Lot Ship — verify green, `/code-review`, merge, tag v3.2.1, archive, re-run QA §3** _(in progress: suites green + code-review + golden-master QA done; merge/tag pending green light)_
 
 ---
 
@@ -113,9 +113,15 @@
 
 ## Lot Ship
 
-- [ ] All three suites green (harness / rag / local-mirror) + `tsc` clean.
-- [ ] `/code-review` on the branch; fix findings in TDD (commit-only-green).
-- [ ] Re-run QA `§3 local-mirror` on the golden master end-to-end (the campaign that was BLOCKED).
+- [x] All three suites green (harness **305** / rag **178** / local-mirror **84**) + `tsc` clean + **0 vulns**. _(2026-06-19)_
+- [x] `/code-review` on the branch; no correctness bugs. Finding **A** (the update summary never
+      named the newly-installed engine skill / registered MCP server) fixed in TDD: `updateEngine`
+      now returns `installedSkills` + `mcpServersAdded`, `formatReport` names both _(commit `442658e`)_.
+      Findings B (minor dup) / C (planTouches oracle, no runtime hole) logged as backlog, not blocking.
+- [x] Verified empirically end-to-end on the v3.1.0 golden master (working-tree `updateEngine` logic,
+      source = `git archive` snapshot of the branch): `.claude/skills/local-mirror/` installed,
+      `.mcp.json` gained `local-mirror` (cwd = brain dir) with `vault-rag` + all custom skills
+      preserved byte-identical, manifest advanced to rag 1.1.1 / local-mirror 0.1.1 / ref v3.2.1. _(2026-06-19)_
 - [ ] Push, PR, merge to `main` on Thomas's explicit green light.
 - [ ] Tag **v3.2.1** + codename; update README `latest` expectation.
 - [ ] Archive this plan (`plans/archived/`, ✅ status + proof); tick QA finding #1 + #2 as resolved.

--- a/maintainers/plans/fix-update-engine-skills-mcp-action.md
+++ b/maintainers/plans/fix-update-engine-skills-mcp-action.md
@@ -17,7 +17,7 @@
 
 - [x] **Lot 0 — Investigation & design decisions** _(2026-06-19 · branch created; decisions below + ADR 0025)_
 - [x] **Lot A — Install engine-declared skills on update** (TDD) _(2026-06-19 · commit pending)_
-- [ ] **Lot B — Reconcile `.mcp.json` from `engineMcpServers`** (TDD)
+- [x] **Lot B — Reconcile `.mcp.json` from `engineMcpServers`** (TDD) _(2026-06-19 · commit pending)_
 - [ ] **Lot C — Self-heal path for already-broken v3.2.0 brains** (decided in Lot 0)
 - [ ] **Lot D — npm vulnerability remediation** (TDD where it touches behavior)
 - [ ] **Lot Ship — verify green, `/code-review`, merge, tag v3.2.1, archive, re-run QA §3**
@@ -75,16 +75,15 @@
 
 ## Lot B — Reconcile `.mcp.json` from `engineMcpServers`
 
-- [ ] RED: test — given a brain `.mcp.json` with only `vault-rag`, reconciling against
-      `engineMcpServers: ["vault-rag","local-mirror"]` **adds** `local-mirror` (cwd = brain dir).
-- [ ] RED: test — a **user-added** server in `.mcp.json` is **preserved** (never clobbered).
-- [ ] RED: test — re-running is **idempotent** (already-present engine server → no duplicate, no diff).
-- [ ] GREEN: implement the reconcile step (read fetched `.mcp.json.template`, substitute path, merge
-      missing engine servers) and wire it into `update-engine`.
-- [ ] Refactor; suite green.
-- [ ] Verify empirically on the golden master: after update, `.mcp.json` has `local-mirror`, and the
-      conversation routes "wire up a Notion zone" → the **local-mirror** skill (asks the
-      mirror-vs-native disambiguation), not `sync-sources`.
+- [x] RED→GREEN: new pure lib `mcp-reconcile.mjs` — `reconcileMcpServers({brainMcp, templateMcp,
+      engineServerIds})` ADDS only the missing engine servers from the (path-substituted) template.
+- [x] Tests: a **user-added** server is preserved; re-running is **idempotent** (no duplicate, no diff).
+- [x] GREEN (wiring): `update-engine` reads the fetched `.mcp.json.template`, substitutes
+      `{{PROJECT_ROOT}}` → brain dir (posix, cf. installer `toPosix`), reconciles the brain's
+      `.mcp.json`, writes it back. Gate test proves `local-mirror` registered (cwd = brain dir) +
+      `vault-rag` and a user server preserved.
+- [x] Refactor; full harness suite green (304/304).
+- [ ] Verify empirically on the golden master (grouped with Lot A, run once pre-ship — Lot Ship §QA).
 
 ## Lot C — Self-heal for already-broken v3.2.0 brains
 

--- a/maintainers/qa/qa-v3.2.0.md
+++ b/maintainers/qa/qa-v3.2.0.md
@@ -1,8 +1,10 @@
 # QA — post-v3.2.0 (throwaway brain, then purge)
 
-> **Status: HALTED at Finding #1 (blocker).** The upgrade path (v3.1.0 → v3.2.0) does not deliver
-> the flagship `local-mirror` feature → no point continuing §3 until the v3.2.1 fix lands. Resume
-> this campaign after the fix (see `maintainers/plans/fix-update-engine-skills-mcp-action.md`).
+> **Status: Finding #1 + #2 RESOLVED in v3.2.1** (PR #13, plan
+> `maintainers/plans/archived/fix-update-engine-skills-mcp-action.md`). The upgrade path now
+> delivers the flagship `local-mirror` skill + MCP server to upgraders and ships 0 npm vulns —
+> proven empirically on the golden master (skill installed, `.mcp.json` reconciled, sacred files
+> byte-identical). §3 local-mirror remains to be exercised live on a fresh post-fix brain.
 > Tested on a frozen golden master `~/legacy-brain` (v3.1.0), restored from `~/legacy-brain.tgz`.
 
 ## 0. Setup
@@ -60,7 +62,7 @@
 
 ## Findings
 
-- [ ] 🔴 **MAJOR — `update-engine` does not deliver the v3.2.0 feature to upgraders.**
+- [x] 🔴 **MAJOR — `update-engine` does not deliver the v3.2.0 feature to upgraders.** _(FIXED v3.2.1, PR #13)_
       Empirically proven on a v3.1.0→v3.2.0 upgraded brain: the `local-mirror/` **code** is copied
       (replace regime ✓) but (a) the **skill** `.claude/skills/local-mirror/` is **NOT installed**
       (`.claude/skills/` is a sacred tree → `update-engine` never touches it) and (b) the
@@ -70,7 +72,7 @@
       has it because the installer drops the skill + registers the MCP). Root cause = the deferred
       "update-skills" gap, now biting.
       **Fix:** see `maintainers/plans/fix-update-engine-skills-mcp-action.md`. Ship as v3.2.1.
-- [ ] 🟡 **npm — engine ships with 4 vulnerabilities** (3 moderate, 1 high): `hono` (high, unused
+- [x] 🟡 **npm — engine ships with 4 vulnerabilities** (3 moderate, 1 high): `hono` (high, unused
       attack surface here), `protobufjs` (moderate, transitive), `js-yaml` via `gray-matter`
       (moderate DoS on crafted YAML). Real-world risk **low** for a local stdio MCP over the user's
       own notes. Patch in the generator (hono+protobufjs non-breaking; gray-matter 2.x is breaking →

--- a/rag/package-lock.json
+++ b/rag/package-lock.json
@@ -15,13 +15,18 @@
         "chokidar": "^5.0.0",
         "dotenv": "^16.4.0",
         "gray-matter": "^4.0.3",
+        "js-yaml": "^4.2.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
+        "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1084,12 +1089,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -1117,6 +1116,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.19",
@@ -1198,13 +1204,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1723,19 +1726,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -2192,9 +2182,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2330,13 +2320,22 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -2748,9 +2747,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2760,7 +2759,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -3236,12 +3234,6 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/rag/package.json
+++ b/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "second-brain-rag",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "engines": {
     "node": ">=20"
@@ -20,10 +20,15 @@
     "chokidar": "^5.0.0",
     "dotenv": "^16.4.0",
     "gray-matter": "^4.0.3",
+    "js-yaml": "^4.2.0",
     "zod": "^4.4.3"
+  },
+  "overrides": {
+    "js-yaml": "^4.2.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
+    "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"

--- a/rag/src/lib/frontmatter-parser.ts
+++ b/rag/src/lib/frontmatter-parser.ts
@@ -1,4 +1,13 @@
 import matter from "gray-matter";
+import { load as yamlLoad } from "js-yaml";
+
+// gray-matter 4.x defaults to js-yaml 3's `safeLoad`, removed in js-yaml 4. We force
+// the patched js-yaml >=4.2.0 (GHSA-h67p-54hq-rp68: quadratic-complexity DoS in merge
+// keys, all <=4.1.1 vulnerable, no patched 3.x) and route YAML through `load`, which
+// is safe by default in js-yaml 4 — so frontmatter parsing keeps working, patched.
+const GRAY_MATTER_OPTIONS = {
+  engines: { yaml: (input: string) => yamlLoad(input) as object },
+} as const;
 
 export interface ParsedDocument {
   frontmatter: Record<string, unknown>;
@@ -49,7 +58,7 @@ function extractTitle(
 }
 
 export function parseDocument(raw: string, relativePath: string): ParsedDocument {
-  const { data: frontmatter, content } = matter(raw);
+  const { data: frontmatter, content } = matter(raw, GRAY_MATTER_OPTIONS);
   const type = detectType(relativePath, frontmatter);
   const tags = Array.isArray(frontmatter.tags)
     ? frontmatter.tags.map(String)

--- a/scripts/lib/engine-apply-plan.mjs
+++ b/scripts/lib/engine-apply-plan.mjs
@@ -19,6 +19,13 @@ import { matchesAny } from "./glob-match.mjs";
 // the user's, deliberately out of Phase 1 Option 1 scope.
 const ENGINE_SCRIPT = /^scripts\/[^/]+\.mjs$/;
 
+// An engine-owned SKILL within the `merge` regime: a `.claude/skills/<name>/**`
+// entry the manifest declares (coach, local-mirror, …). These are carved OUT of the
+// blanket skills scrub into an ADDITIVE install-if-absent bucket (ADR 0025): a
+// brand-new engine skill reaches upgraders, while a custom/non-declared skill stays
+// untouchable (it is never in the manifest) and an already-present one is preserved.
+const ENGINE_SKILL = /^\.claude\/skills\/[^/]+\//;
+
 // The user's sovereign territory — NEVER writable by the engine (ADR 0003/0012),
 // whatever a manifest declares. Exact files + whole subtrees. The vault has no
 // fixed manifest entry, but `vault/` is denied too as belt-and-suspenders.
@@ -50,5 +57,6 @@ export function computeApplyPlan(targetManifest) {
     overwrite: scrub([...(regimes.replace ?? [])]),
     regenerate: scrub([...(regimes.regenerate ?? [])]),
     replaceScripts: scrub((regimes.merge ?? []).filter((entry) => ENGINE_SCRIPT.test(entry))),
+    installSkills: (regimes.merge ?? []).filter((entry) => ENGINE_SKILL.test(entry)),
   };
 }

--- a/scripts/lib/engine-apply-plan.test.mjs
+++ b/scripts/lib/engine-apply-plan.test.mjs
@@ -52,6 +52,34 @@ test("computeApplyPlan — `replaceScripts` = the engine-owned merge scripts (sc
   ]);
 });
 
+test("computeApplyPlan — manifest-declared engine skills (.claude/skills/<name>/**) become the `installSkills` bucket", () => {
+  const target = {
+    regimes: {
+      merge: [
+        "CLAUDE.md",                          // user-sovereign → not a skill
+        ".claude/settings.json",              // user-sovereign → not a skill
+        ".claude/skills/local-mirror/**",     // an engine-owned skill → installSkills
+        "scripts/auto-commit.mjs",            // an engine script → replaceScripts, not a skill
+      ],
+    },
+  };
+  assert.deepEqual(computeApplyPlan(target).installSkills, [".claude/skills/local-mirror/**"]);
+});
+
+test("computeApplyPlan — SAFETY: a skill can ONLY be delivered additively; mis-declared in `replace`/`regenerate` it is scrubbed (never overwritten)", () => {
+  const hostile = {
+    regimes: {
+      replace: ["rag/src/**", ".claude/skills/local-mirror/**"],  // try to OVERWRITE a skill
+      regenerate: [".claude/skills/coach/**"],                     // try to clobber via regenerate
+      merge: [".claude/skills/local-mirror/**"],                   // the legit additive declaration
+    },
+  };
+  const plan = computeApplyPlan(hostile);
+  assert.deepEqual(plan.overwrite, ["rag/src/**"], "a skill in `replace` is scrubbed — never overwritten");
+  assert.deepEqual(plan.regenerate, [], "a skill in `regenerate` is scrubbed");
+  assert.deepEqual(plan.installSkills, [".claude/skills/local-mirror/**"], "only the additive merge path carries skills");
+});
+
 // A realistic full target manifest, reused by the guard tests below.
 function fullTarget() {
   return {

--- a/scripts/lib/mcp-reconcile.mjs
+++ b/scripts/lib/mcp-reconcile.mjs
@@ -1,0 +1,20 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// mcp-reconcile.mjs — pure, idempotent reconcile of a brain's .mcp.json against the
+// engine's declared servers (ADR 0025). `update-engine` reads the fetched
+// .mcp.json.template (with {{PROJECT_ROOT}} already substituted to the brain dir),
+// then ADDS only the `engineMcpServers` the brain is MISSING — so an upgrader gets a
+// newly-shipped engine server (e.g. local-mirror) registered in .mcp.json. An
+// existing server (engine OR user-added) is NEVER overwritten; re-running is a no-op.
+// Does not MUTATE its input: returns a copy.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function reconcileMcpServers({ brainMcp, templateMcp, engineServerIds }) {
+  const existing = brainMcp.mcpServers ?? {};
+  const fromTemplate = templateMcp.mcpServers ?? {};
+  const added = {};
+  for (const id of engineServerIds) {
+    if (id in existing) continue; // present (engine or user) → preserve, never clobber
+    if (id in fromTemplate) added[id] = fromTemplate[id];
+  }
+  return { ...brainMcp, mcpServers: { ...existing, ...added } };
+}

--- a/scripts/lib/mcp-reconcile.test.mjs
+++ b/scripts/lib/mcp-reconcile.test.mjs
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { reconcileMcpServers } from "./mcp-reconcile.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// mcp-reconcile — pure, idempotent reconcile of a brain's .mcp.json against the
+// engine's declared servers (ADR 0025). ADD only the `engineMcpServers` the brain
+// is MISSING, taking each definition from the (already path-substituted) fetched
+// .mcp.json.template; never clobber an existing server (engine OR user-added).
+// ═══════════════════════════════════════════════════════════════════════════
+
+const templateMcp = {
+  mcpServers: {
+    "vault-rag": { type: "stdio", command: "npx", args: ["tsx", "rag/src/index.ts"], cwd: "/brains/foo", env: {} },
+    "local-mirror": { type: "stdio", command: "npx", args: ["tsx", "local-mirror/src/server.ts"], cwd: "/brains/foo", env: {} },
+  },
+};
+
+test("reconcileMcpServers — adds a missing engine server from the template", () => {
+  const brainMcp = { mcpServers: { "vault-rag": { type: "stdio", command: "npx", args: ["tsx", "rag/src/index.ts"], cwd: "/brains/foo", env: {} } } };
+  const out = reconcileMcpServers({ brainMcp, templateMcp, engineServerIds: ["vault-rag", "local-mirror"] });
+  assert.deepEqual(
+    out.mcpServers["local-mirror"],
+    templateMcp.mcpServers["local-mirror"],
+    "the missing engine server must be added with the template's (path-substituted) definition",
+  );
+  assert.ok(out.mcpServers["vault-rag"], "the already-present engine server is kept");
+});
+
+test("reconcileMcpServers — a USER-added server is preserved (never clobbered, never dropped)", () => {
+  const userServer = { type: "stdio", command: "node", args: ["my-tool.js"], cwd: "/brains/foo", env: {} };
+  const brainMcp = {
+    mcpServers: {
+      "vault-rag": templateMcp.mcpServers["vault-rag"],
+      "my-tool": userServer, // not an engine server
+    },
+  };
+  const out = reconcileMcpServers({ brainMcp, templateMcp, engineServerIds: ["vault-rag", "local-mirror"] });
+  assert.deepEqual(out.mcpServers["my-tool"], userServer, "the user's own server must survive the reconcile");
+  assert.ok(out.mcpServers["local-mirror"], "the missing engine server is still added alongside it");
+});
+
+test("reconcileMcpServers — idempotent: re-running when every engine server is present changes nothing", () => {
+  const brainMcp = {
+    mcpServers: {
+      "vault-rag": templateMcp.mcpServers["vault-rag"],
+      "local-mirror": templateMcp.mcpServers["local-mirror"],
+    },
+  };
+  const out = reconcileMcpServers({ brainMcp, templateMcp, engineServerIds: ["vault-rag", "local-mirror"] });
+  assert.deepEqual(out.mcpServers, brainMcp.mcpServers, "a 2nd pass must be a no-op (no duplicate, no diff)");
+});

--- a/scripts/lib/update-engine.test.mjs
+++ b/scripts/lib/update-engine.test.mjs
@@ -524,6 +524,89 @@ test("gate — an ALREADY-PRESENT engine skill is preserved byte-identical (neve
   );
 });
 
+// ── Lot B (ADR 0025): an engine update RECONCILES .mcp.json against the manifest's
+//    engineMcpServers — registering a newly-shipped engine server (local-mirror) from
+//    the fetched .mcp.json.template (cwd → the brain dir), while preserving every
+//    existing server (vault-rag + any user-added one) and staying idempotent.
+test("gate — registers a missing engine MCP server in .mcp.json (from the template), preserving existing servers", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = mkdtempSync(join(tmpdir(), "sbg-source-mcp-"));
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+
+  // The brain's .mcp.json: only vault-rag + a user-added server (must both survive).
+  writeFile(
+    brainDir,
+    ".mcp.json",
+    JSON.stringify(
+      {
+        mcpServers: {
+          "vault-rag": { type: "stdio", command: "npx", args: ["tsx", "rag/src/index.ts"], cwd: brainDir, env: {} },
+          "my-tool": { type: "stdio", command: "node", args: ["my-tool.js"], cwd: brainDir, env: {} },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // The fetched launcher: engine files (vB) + a .mcp.json.template declaring both
+  // engine servers with the {{PROJECT_ROOT}} placeholder + a manifest listing them.
+  for (const [rel, content] of Object.entries(flat(engineFiles("vB")))) writeFile(sourceDir, rel, content);
+  writeFile(
+    sourceDir,
+    ".mcp.json.template",
+    JSON.stringify(
+      {
+        mcpServers: {
+          "vault-rag": { type: "stdio", command: "npx", args: ["tsx", "rag/src/index.ts"], cwd: "{{PROJECT_ROOT}}", env: {} },
+          "local-mirror": { type: "stdio", command: "npx", args: ["tsx", "local-mirror/src/server.ts"], cwd: "{{PROJECT_ROOT}}", env: {} },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFile(
+    sourceDir,
+    "engine-manifest.json",
+    JSON.stringify(
+      {
+        manifestVersion: 1,
+        engineVersion: { rag: "1.1.0", constitutionTemplate: "1.0.0", scripts: "1.0.0" },
+        indexSchemaVersion: 1,
+        regimes: {
+          replace: ["rag/src/**", "rag/package.json"],
+          regenerate: ["rag/launch.sh", "rag/launch.cmd", "scripts/run-node.sh", "scripts/run-node.cmd"],
+          merge: ["scripts/update-engine.mjs"],
+        },
+        engineMcpServers: ["vault-rag", "local-mirror"],
+        source: { repo: "https://example.test/launcher.git", ref: "v1.1.0" },
+        provenance: {},
+      },
+      null,
+      2,
+    ),
+  );
+
+  await runUpdate({ brainDir, sourceDir, platform: "posix" });
+
+  const mcp = JSON.parse(readFileSync(join(brainDir, ".mcp.json"), "utf8"));
+  // The missing engine server is now registered, with its cwd pointing at THIS brain.
+  assert.ok(mcp.mcpServers["local-mirror"], "the missing engine server must be registered on update");
+  assert.equal(mcp.mcpServers["local-mirror"].cwd, brainDir, "{{PROJECT_ROOT}} must resolve to the brain dir");
+  assert.deepEqual(
+    mcp.mcpServers["local-mirror"].args,
+    ["tsx", "local-mirror/src/server.ts"],
+    "the server definition must come from the fetched template",
+  );
+  // Existing servers — engine AND user-added — are preserved untouched.
+  assert.ok(mcp.mcpServers["vault-rag"], "the existing vault-rag server must be preserved");
+  assert.ok(mcp.mcpServers["my-tool"], "the user-added server must be preserved");
+});
+
 test("gate — no tag resolvable (offline / no semver tag) → fall back to the pinned ref, update still applies", async (t) => {
   const brainDir = buildBrain(); // pinned at v1.0.0
   const sourceDir = buildSource({ indexSchemaVersion: 1 });

--- a/scripts/lib/update-engine.test.mjs
+++ b/scripts/lib/update-engine.test.mjs
@@ -411,6 +411,119 @@ test("gate — F1/F2: dev-only files never land, and the brain keeps its install
   );
 });
 
+// ── Lot A (ADR 0025): an engine update INSTALLS a missing engine-declared skill
+//    (additive, install-if-absent) so the flagship local-mirror skill reaches
+//    upgraders — while never touching a non-declared / custom skill.
+test("gate — installs a MISSING engine-declared skill (install-if-absent); custom skill stays untouched", async (t) => {
+  const brainDir = buildBrain(); // ships zzz-mine (custom), NO local-mirror skill
+  const sourceDir = mkdtempSync(join(tmpdir(), "sbg-source-skill-"));
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const before = snapshotSacred(brainDir);
+
+  // The fetched launcher carries the engine files (vB) + a NEW engine skill, and its
+  // manifest declares that skill path as engine-owned (under `merge`).
+  for (const [rel, content] of Object.entries(flat(engineFiles("vB")))) writeFile(sourceDir, rel, content);
+  const skillBody = "---\nname: local-mirror\n---\nMirror a Notion zone into the vault.\n";
+  writeFile(sourceDir, ".claude/skills/local-mirror/SKILL.md", skillBody);
+  writeFile(
+    sourceDir,
+    "engine-manifest.json",
+    JSON.stringify(
+      {
+        manifestVersion: 1,
+        engineVersion: { rag: "1.1.0", constitutionTemplate: "1.0.0", scripts: "1.0.0" },
+        indexSchemaVersion: 1,
+        regimes: {
+          replace: ["rag/src/**", "rag/package.json"],
+          regenerate: ["rag/launch.sh", "rag/launch.cmd", "scripts/run-node.sh", "scripts/run-node.cmd"],
+          merge: [
+            "CLAUDE.md",
+            ".claude/settings.json",
+            ".claude/skills/local-mirror/**", // the NEW engine skill, declared engine-owned
+            "scripts/auto-commit.mjs",
+            "scripts/auto-push.mjs",
+            "scripts/status-line.mjs",
+            "scripts/verify-rag.mjs",
+            "scripts/update-engine.mjs",
+          ],
+        },
+        engineMcpServers: ["vault-rag"],
+        source: { repo: "https://example.test/launcher.git", ref: "v1.1.0" },
+        provenance: {},
+      },
+      null,
+      2,
+    ),
+  );
+
+  assert.equal(
+    existsSync(join(brainDir, ".claude/skills/local-mirror/SKILL.md")),
+    false,
+    "precondition: the brain must lack the engine skill before the update",
+  );
+
+  await runUpdate({ brainDir, sourceDir, platform: "posix" });
+
+  // The engine installed the missing skill from the fetched source…
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/local-mirror/SKILL.md"), "utf8"),
+    skillBody,
+    "a missing engine-declared skill must be installed on update (so upgraders get local-mirror)",
+  );
+  // …and the user's custom skill + every sacred file stayed byte-identical.
+  assertSacredUntouched(brainDir, before);
+});
+
+test("gate — an ALREADY-PRESENT engine skill is preserved byte-identical (never clobbered, install-if-absent)", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = mkdtempSync(join(tmpdir(), "sbg-source-skill2-"));
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+
+  // The brain already carries a USER-CUSTOMIZED local-mirror skill.
+  const customized = "---\nname: local-mirror\n---\nMY OWN tweaks — do not overwrite.\n";
+  writeFile(brainDir, ".claude/skills/local-mirror/SKILL.md", customized);
+  const beforeHash = sha256(join(brainDir, ".claude/skills/local-mirror/SKILL.md"));
+
+  // The fetched launcher carries a DIFFERENT version of the same skill + declares it.
+  for (const [rel, content] of Object.entries(flat(engineFiles("vB")))) writeFile(sourceDir, rel, content);
+  writeFile(sourceDir, ".claude/skills/local-mirror/SKILL.md", "---\nname: local-mirror\n---\nEngine default.\n");
+  writeFile(
+    sourceDir,
+    "engine-manifest.json",
+    JSON.stringify(
+      {
+        manifestVersion: 1,
+        engineVersion: { rag: "1.1.0", constitutionTemplate: "1.0.0", scripts: "1.0.0" },
+        indexSchemaVersion: 1,
+        regimes: {
+          replace: ["rag/src/**", "rag/package.json"],
+          regenerate: ["rag/launch.sh", "rag/launch.cmd", "scripts/run-node.sh", "scripts/run-node.cmd"],
+          merge: [".claude/skills/local-mirror/**", "scripts/update-engine.mjs"],
+        },
+        engineMcpServers: ["vault-rag"],
+        source: { repo: "https://example.test/launcher.git", ref: "v1.1.0" },
+        provenance: {},
+      },
+      null,
+      2,
+    ),
+  );
+
+  await runUpdate({ brainDir, sourceDir, platform: "posix" });
+
+  assert.equal(
+    sha256(join(brainDir, ".claude/skills/local-mirror/SKILL.md")),
+    beforeHash,
+    "a present (customized) engine skill must be preserved byte-identical — install-if-absent never overwrites",
+  );
+});
+
 test("gate — no tag resolvable (offline / no semver tag) → fall back to the pinned ref, update still applies", async (t) => {
   const brainDir = buildBrain(); // pinned at v1.0.0
   const sourceDir = buildSource({ indexSchemaVersion: 1 });

--- a/scripts/lib/update-engine.test.mjs
+++ b/scripts/lib/update-engine.test.mjs
@@ -74,6 +74,24 @@ test("formatReport — schema unchanged → states no reindex was needed (never 
   assert.doesNotMatch(out, /reindexed —/);
 });
 
+// Finding A (ADR 0025 fix QA): an upgrader must SEE that the update delivered the
+// flagship engine skill + registered its MCP server — that is the whole point of
+// v3.2.1. Silent delivery leaves the user unaware they finally have the feature.
+test("formatReport — names the engine skill(s) it installed and the MCP server(s) it registered", () => {
+  const out = formatReport({
+    ref: "v1.1.0",
+    engineVersion: { rag: "1.1.0" },
+    copied: ["rag/src/index.ts"],
+    regenerated: false,
+    reindexed: false,
+    installedSkills: ["local-mirror"],
+    mcpServersAdded: ["local-mirror"],
+  });
+  assert.match(out, /local-mirror/);
+  assert.match(out, /skill/i);
+  assert.match(out, /server|mcp/i);
+});
+
 function sha256(path) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
@@ -465,13 +483,19 @@ test("gate — installs a MISSING engine-declared skill (install-if-absent); cus
     "precondition: the brain must lack the engine skill before the update",
   );
 
-  await runUpdate({ brainDir, sourceDir, platform: "posix" });
+  const { report } = await runUpdate({ brainDir, sourceDir, platform: "posix" });
 
   // The engine installed the missing skill from the fetched source…
   assert.equal(
     readFileSync(join(brainDir, ".claude/skills/local-mirror/SKILL.md"), "utf8"),
     skillBody,
     "a missing engine-declared skill must be installed on update (so upgraders get local-mirror)",
+  );
+  // …and the report names it (so the user SEES they got the feature, finding A).
+  assert.deepEqual(
+    report.installedSkills,
+    ["local-mirror"],
+    "the report must name the engine skill(s) it installed",
   );
   // …and the user's custom skill + every sacred file stayed byte-identical.
   assertSacredUntouched(brainDir, before);
@@ -591,11 +615,17 @@ test("gate — registers a missing engine MCP server in .mcp.json (from the temp
     ),
   );
 
-  await runUpdate({ brainDir, sourceDir, platform: "posix" });
+  const { report } = await runUpdate({ brainDir, sourceDir, platform: "posix" });
 
   const mcp = JSON.parse(readFileSync(join(brainDir, ".mcp.json"), "utf8"));
   // The missing engine server is now registered, with its cwd pointing at THIS brain.
   assert.ok(mcp.mcpServers["local-mirror"], "the missing engine server must be registered on update");
+  // The report names only the server it actually ADDED (vault-rag was already there).
+  assert.deepEqual(
+    report.mcpServersAdded,
+    ["local-mirror"],
+    "the report must name the MCP server(s) it registered (only the newly-added one)",
+  );
   assert.equal(mcp.mcpServers["local-mirror"].cwd, brainDir, "{{PROJECT_ROOT}} must resolve to the brain dir");
   assert.deepEqual(
     mcp.mcpServers["local-mirror"].args,

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -29,6 +29,7 @@ import {
 } from "./lib/engine-fetch.mjs";
 import { computeApplyPlan } from "./lib/engine-apply-plan.mjs";
 import { matchesAny } from "./lib/glob-match.mjs";
+import { reconcileMcpServers } from "./lib/mcp-reconcile.mjs";
 import { needsReindex } from "./lib/reindex-trigger.mjs";
 import { reseedProvenance } from "./lib/engine-source.mjs";
 import { listFilesRelPosix } from "./lib/fs-walk.mjs";
@@ -143,6 +144,22 @@ export async function updateEngine({
     const skillDir = skillGlob.replace(/\/\*\*?$/, ""); // ".../local-mirror/**" → ".../local-mirror"
     if (existsSync(join(brainDir, skillDir))) continue; // present → preserve, never overwrite
     for (const rel of sourceFiles.filter((f) => matchesAny([skillGlob], f))) copyInto(sourceDir, brainDir, rel);
+  }
+
+  // 3.ter Reconcile .mcp.json against the manifest's engineMcpServers (ADR 0025):
+  //    register a newly-shipped engine server (e.g. local-mirror) the brain is
+  //    MISSING, taking its definition from the fetched .mcp.json.template with
+  //    {{PROJECT_ROOT}} substituted to this brain dir. Existing servers (engine OR
+  //    user-added) are preserved; absent template → nothing to reconcile.
+  const engineServerIds = target.engineMcpServers ?? [];
+  const templatePath = join(sourceDir, ".mcp.json.template");
+  const brainMcpPath = join(brainDir, ".mcp.json");
+  if (engineServerIds.length > 0 && existsSync(templatePath) && existsSync(brainMcpPath)) {
+    const projectRoot = brainDir.split("\\").join("/"); // {{PROJECT_ROOT}} is posix (cf. installer toPosix)
+    const templateMcp = JSON.parse(readFileSync(templatePath, "utf8").split("{{PROJECT_ROOT}}").join(projectRoot));
+    const brainMcp = JSON.parse(readFileSync(brainMcpPath, "utf8"));
+    const reconciled = reconcileMcpServers({ brainMcp, templateMcp, engineServerIds });
+    writeFileSync(brainMcpPath, JSON.stringify(reconciled, null, 2) + "\n");
   }
 
   // 4. Regenerate the launchers (both halves, ADR 0015).

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -82,15 +82,23 @@ async function defaultRegenerateLaunchers({ brainDir }) {
 // Human summary the brain-side `update-engine` skill shows the user (Step 6, ADR
 // 0016). Pure so the wording is unit-tested; the CLI entry only wires the I/O.
 export function formatReport(report) {
-  const { ref, engineVersion, copied, regenerated, reindexed } = report;
+  const { ref, engineVersion, copied, regenerated, reindexed, installedSkills = [], mcpServersAdded = [] } = report;
   const lines = [
     `✅ Engine updated to ${ref} (rag ${engineVersion?.rag}).`,
     `   • ${copied.length} engine file(s) swapped` + (regenerated ? " + launchers regenerated" : ""),
     reindexed
       ? `   • reindexed — the index format changed (your notes were re-encoded, nothing lost)`
       : `   • index format unchanged — no reindex needed`,
-    `   Your notes, .env, constitution, settings and custom skills were left untouched.`,
   ];
+  // Surface newly-delivered engine skills / MCP servers (ADR 0025) — the whole point
+  // of an additive update: an upgrader must SEE they finally have the feature.
+  if (installedSkills.length > 0) {
+    lines.push(`   • new engine skill(s) installed: ${installedSkills.join(", ")}`);
+  }
+  if (mcpServersAdded.length > 0) {
+    lines.push(`   • new MCP server(s) registered: ${mcpServersAdded.join(", ")}`);
+  }
+  lines.push(`   Your notes, .env, constitution, settings and custom skills were left untouched.`);
   return lines.join("\n");
 }
 
@@ -140,10 +148,12 @@ export async function updateEngine({
   //    (possibly user-customized, e.g. prepare-1-1) is left byte-identical; a
   //    brand-new engine skill (e.g. local-mirror) is copied in so upgraders get it.
   //    Non-declared / custom skills are never in `installSkills` → untouchable.
+  const installedSkills = [];
   for (const skillGlob of plan.installSkills) {
     const skillDir = skillGlob.replace(/\/\*\*?$/, ""); // ".../local-mirror/**" → ".../local-mirror"
     if (existsSync(join(brainDir, skillDir))) continue; // present → preserve, never overwrite
     for (const rel of sourceFiles.filter((f) => matchesAny([skillGlob], f))) copyInto(sourceDir, brainDir, rel);
+    installedSkills.push(skillDir.split("/").pop()); // the skill name, for the report
   }
 
   // 3.ter Reconcile .mcp.json against the manifest's engineMcpServers (ADR 0025):
@@ -154,12 +164,15 @@ export async function updateEngine({
   const engineServerIds = target.engineMcpServers ?? [];
   const templatePath = join(sourceDir, ".mcp.json.template");
   const brainMcpPath = join(brainDir, ".mcp.json");
+  const mcpServersAdded = [];
   if (engineServerIds.length > 0 && existsSync(templatePath) && existsSync(brainMcpPath)) {
     const projectRoot = brainDir.split("\\").join("/"); // {{PROJECT_ROOT}} is posix (cf. installer toPosix)
     const templateMcp = JSON.parse(readFileSync(templatePath, "utf8").split("{{PROJECT_ROOT}}").join(projectRoot));
     const brainMcp = JSON.parse(readFileSync(brainMcpPath, "utf8"));
+    const before = new Set(Object.keys(brainMcp.mcpServers ?? {}));
     const reconciled = reconcileMcpServers({ brainMcp, templateMcp, engineServerIds });
     writeFileSync(brainMcpPath, JSON.stringify(reconciled, null, 2) + "\n");
+    mcpServersAdded.push(...Object.keys(reconciled.mcpServers).filter((id) => !before.has(id)));
   }
 
   // 4. Regenerate the launchers (both halves, ADR 0015).
@@ -195,7 +208,7 @@ export async function updateEngine({
   };
   writeFileSync(manifestPath, JSON.stringify(updated, null, 2) + "\n");
 
-  return { ref: updated.source.ref, engineVersion: updated.engineVersion, copied, regenerated, reindexed };
+  return { ref: updated.source.ref, engineVersion: updated.engineVersion, copied, regenerated, reindexed, installedSkills, mcpServersAdded };
 }
 
 // ── CLI entry (the command the brain-side `update-engine` skill runs) ─────────

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -28,6 +28,7 @@ import {
   readTargetManifest,
 } from "./lib/engine-fetch.mjs";
 import { computeApplyPlan } from "./lib/engine-apply-plan.mjs";
+import { matchesAny } from "./lib/glob-match.mjs";
 import { needsReindex } from "./lib/reindex-trigger.mjs";
 import { reseedProvenance } from "./lib/engine-source.mjs";
 import { listFilesRelPosix } from "./lib/fs-walk.mjs";
@@ -128,12 +129,21 @@ export async function updateEngine({
   //    (`regenerate`) are NOT copied — they are rebuilt below. Self-replacement mid-run
   //    is safe: Node caches imported modules, so overwriting the .mjs on disk never
   //    perturbs this process.
+  const sourceFiles = listFilesRelPosix(sourceDir);
   const copyGlobs = [...plan.overwrite, ...plan.replaceScripts];
-  const copied = selectEngineFilesToCopy({
-    sourceFiles: listFilesRelPosix(sourceDir),
-    copyGlobs,
-  });
+  const copied = selectEngineFilesToCopy({ sourceFiles, copyGlobs });
   for (const rel of copied) copyInto(sourceDir, brainDir, rel);
+
+  // 3.bis Install engine-declared skills the brain is MISSING (ADR 0025): additive,
+  //    install-if-absent at the SKILL-DIR level. A skill dir that already exists
+  //    (possibly user-customized, e.g. prepare-1-1) is left byte-identical; a
+  //    brand-new engine skill (e.g. local-mirror) is copied in so upgraders get it.
+  //    Non-declared / custom skills are never in `installSkills` → untouchable.
+  for (const skillGlob of plan.installSkills) {
+    const skillDir = skillGlob.replace(/\/\*\*?$/, ""); // ".../local-mirror/**" → ".../local-mirror"
+    if (existsSync(join(brainDir, skillDir))) continue; // present → preserve, never overwrite
+    for (const rel of sourceFiles.filter((f) => matchesAny([skillGlob], f))) copyInto(sourceDir, brainDir, rel);
+  }
 
   // 4. Regenerate the launchers (both halves, ADR 0015).
   const regenerated = plan.regenerate.length > 0;


### PR DESCRIPTION
## Why

QA campaign post-v3.2.0 (golden master, a fresh brain installed at **v3.1.0** on purpose) surfaced a **major** gap, proven empirically:

> `update-engine` (v3.1.0 → v3.2.0) copies the `local-mirror/` **code** (replace regime ✓) but (a) **never installs the skill** `.claude/skills/local-mirror/` (the whole `.claude/skills/` tree is a blanket sacred zone — it protects custom skills) and (b) **never registers the MCP server** `local-mirror` in `.mcp.json` (`engineMcpServers` is declared in `engine-manifest.json` but was never consumed).

Net effect: anyone who **updates** to v3.2.x did **not** get the flagship feature; only a **fresh install** did. On the ground, "mirror a Notion zone" fell back to the native connector + `sync-sources` instead of the `local-mirror` skill.

A second, minor finding: the engine shipped with npm vulnerabilities.

## What

- **Install missing engine skills on update** (ADR 0025) — `computeApplyPlan` carves the manifest-declared engine-skill paths into an additive **`installSkills`** bucket; `updateEngine` installs a declared skill **only if absent** (an already-present, possibly user-customized engine skill stays byte-identical; non-declared/custom skills are never in the bucket → untouchable).
- **Reconcile `.mcp.json` from `engineMcpServers`** — a pure, idempotent `mcp-reconcile.mjs` reads the fetched `.mcp.json.template` (with `{{PROJECT_ROOT}}` substituted to the brain dir) and **adds only the missing engine servers**; existing engine/user servers are preserved.
- **Two-cycle self-heal documented** — the apply runs from the brain's *installed* code, so the ≤v3.2.0 cohort self-heals on the *next* update (run 1 lays down the new logic, run 2 executes it). Documented in the `update-engine` skill + ADR 0025 (re-exec-from-fetched rejected).
- **npm vulnerabilities cleared (0 vulns)** on both `rag/` and `local-mirror/` — `npm audit fix` for hono/protobufjs; js-yaml DoS (no patched 3.x) fixed by an `overrides: { js-yaml: ^4.2.0 }` + routing gray-matter's YAML through js-yaml 4's `load`/`dump` (v4 removed `safeLoad`/`safeDump`). Engine versions bumped: rag `1.1.0 → 1.1.1`, local-mirror `0.1.0 → 0.1.1`.
- **Update summary names what it delivered** (code-review finding A) — `updateEngine` returns `installedSkills` + `mcpServersAdded`, and `formatReport` tells the upgrader they finally have the feature.

## Safety invariant

Only skills/servers the manifest declares as engine-owned are ever written, and only when **absent**. The destructive buckets stay sacred-scrubbed; the vault, `.env`, the constitution, settings and custom skills are untouchable by construction.

## Proof

- Suites green: **harness 305 · rag 178 · local-mirror 84**, `tsc` clean everywhere, **0 vulns**.
- `/code-review` (high): no correctness bugs; finding A folded in (TDD), findings B/C logged as backlog.
- **Empirical golden-master end-to-end** (v3.1.0 brain, working-tree `updateEngine` logic against a `git archive` snapshot of this branch): `.claude/skills/local-mirror/` installed, `.mcp.json` gained `local-mirror` (cwd = brain dir) while `vault-rag` + all custom skills stayed byte-identical, manifest advanced to rag 1.1.1 / local-mirror 0.1.1 / ref v3.2.1.

Closes QA finding #1 (major) + #2 (npm vulns) from `maintainers/qa/qa-v3.2.0.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)