### PR TITLE
Mutation-hardening: lift engine test quality across all three packages + retro rules

### DIFF
--- a/local-mirror/src/adapters/notion-gateway.ts
+++ b/local-mirror/src/adapters/notion-gateway.ts
@@ -65,14 +65,27 @@ export async function queryNotionDatabaseRows(
   return rows;
 }
 
-class NotionSdkGateway implements NotionGateway {
-  private readonly n2m: NotionToMarkdown;
+/** The slice of notion-to-md the gateway drives — injected so the wiring is unit-testable. */
+export interface Notion2Md {
+  setCustomTransformer(type: string, transformer: (block: unknown) => Promise<string> | string): void;
+  pageToMarkdown(pageId: string): Promise<unknown>;
+  toMarkdownString(blocks: unknown): { parent?: string };
+}
+type Notion2MdInit = ConstructorParameters<typeof NotionToMarkdown>[0];
+export type Notion2MdFactory = (init: Notion2MdInit) => Notion2Md;
+const defaultNotion2Md: Notion2MdFactory = (init) => new NotionToMarkdown(init) as unknown as Notion2Md;
 
-  constructor(private readonly client: Client) {
+export class NotionSdkGateway implements NotionGateway {
+  private readonly n2m: Notion2Md;
+
+  constructor(
+    private readonly client: Client,
+    makeN2m: Notion2MdFactory = defaultNotion2Md,
+  ) {
     // B1 (R2-5): `parseChildPages` must be on or notion-to-md drops `child_page` blocks before
     // any custom transformer runs (it skips them in the outer loop). With it on, our transformer
     // takes precedence and emits a clickable link instead of inlining the sub-page's content.
-    this.n2m = new NotionToMarkdown({ notionClient: client, config: { parseChildPages: true } });
+    this.n2m = makeN2m({ notionClient: client, config: { parseChildPages: true } });
     // B1: internal Notion navigation blocks render empty / with a literal "link_to_page" label by
     // default — emit clickable www.notion.so links so a mirrored hub keeps its sub-tree navigable.
     this.n2m.setCustomTransformer('child_page', (block) =>

--- a/local-mirror/src/adapters/notion-gateway.ts
+++ b/local-mirror/src/adapters/notion-gateway.ts
@@ -18,9 +18,21 @@ import {
 } from '../lib/notion-transformers.js';
 
 /** A row as the child-database transformer consumes it (raw Notion page slice). */
-interface NotionDatabaseRow {
+export interface NotionDatabaseRow {
   id: string;
   properties: Record<string, { type: string }>;
+}
+
+/** The slice of the Notion SDK client the database-row query depends on (injected for tests). */
+export interface NotionDbClient {
+  databases: { retrieve(args: { database_id: string }): Promise<unknown> };
+  dataSources: {
+    query(args: {
+      data_source_id: string;
+      start_cursor?: string;
+      page_size: number;
+    }): Promise<unknown>;
+  };
 }
 
 // B2 (R2-7a): resolve a `child_database` block id to its rows. Notion API 2025-09-03 split a
@@ -28,7 +40,10 @@ interface NotionDatabaseRow {
 // page through each data source. Falls back to querying the block id directly as a data source if
 // the retrieve response carries no `data_sources` (older shapes). Errors bubble to the transformer,
 // which degrades to a link rather than failing the page.
-async function queryNotionDatabaseRows(client: Client, databaseId: string): Promise<NotionDatabaseRow[]> {
+export async function queryNotionDatabaseRows(
+  client: NotionDbClient,
+  databaseId: string,
+): Promise<NotionDatabaseRow[]> {
   const db = (await client.databases.retrieve({ database_id: databaseId })) as unknown as {
     data_sources?: { id: string }[];
   };

--- a/local-mirror/src/domain/local-mirror.ts
+++ b/local-mirror/src/domain/local-mirror.ts
@@ -359,19 +359,19 @@ function unknownReport(checkName: string, detail: string): HealthReport {
 }
 
 /** Aggregate verdict: any broken → broken; else any unknown → unknown; else ok (ADR 0030). */
-function aggregateHealth(checks: HealthCheckEntry[]): HealthReport['status'] {
+export function aggregateHealth(checks: HealthCheckEntry[]): HealthReport['status'] {
   if (checks.some((c) => c.status === 'broken')) return 'broken';
   if (checks.some((c) => c.status === 'unknown')) return 'unknown';
   return 'ok';
 }
 
 /** A source that threw during the fan-out — reported failed, never aborting the batch. */
-function failedReport(name: string): SyncReport {
+export function failedReport(name: string): SyncReport {
   return { name, status: 'failed', written: 0, deleted: 0, unchanged: 0 };
 }
 
 /** Aggregate the per-source reports into the `sync("all")` summary (sums + worst-of status). */
-function aggregateReports(sources: SyncReport[]): SyncReport {
+export function aggregateReports(sources: SyncReport[]): SyncReport {
   const sum = (pick: (r: SyncReport) => number) => sources.reduce((acc, r) => acc + pick(r), 0);
   return {
     name: 'all',
@@ -384,7 +384,7 @@ function aggregateReports(sources: SyncReport[]): SyncReport {
 }
 
 /** `ok` iff every source is ok; `failed` iff every source failed; otherwise `partial`. */
-function aggregateStatus(sources: SyncReport[]): SyncStatus {
+export function aggregateStatus(sources: SyncReport[]): SyncStatus {
   if (sources.length === 0) return 'ok';
   if (sources.every((r) => r.status === 'ok')) return 'ok';
   if (sources.every((r) => r.status === 'failed')) return 'failed';
@@ -392,7 +392,7 @@ function aggregateStatus(sources: SyncReport[]): SyncStatus {
 }
 
 /** The max `last_edited_time` over a perimeter (the watermark), or null if it is empty (PRD §16). */
-function maxLastEditedTime(items: readonly { lastEditedTime: string }[]): string | null {
+export function maxLastEditedTime(items: readonly { lastEditedTime: string }[]): string | null {
   let max: string | null = null;
   for (const item of items) {
     if (max === null || item.lastEditedTime > max) max = item.lastEditedTime;
@@ -417,12 +417,12 @@ export function toSourceState(
 }
 
 /** The source's stable Notion root page id — from prior state, else extracted from the URL. */
-function rootPageIdOf(config: LocalMirrorConfig, previous: PersistedState | null): string {
+export function rootPageIdOf(config: LocalMirrorConfig, previous: PersistedState | null): string {
   return previous?.rootPageId ?? extractPageId(config.connector.config.root_page_url);
 }
 
 /** Assembles a declared config from the onboarding request — the token's env-var name only (§11). */
-function configFromRequest(req: SetupRequest): LocalMirrorConfig {
+export function configFromRequest(req: SetupRequest): LocalMirrorConfig {
   return {
     name: req.name,
     title: req.title,
@@ -436,6 +436,6 @@ function configFromRequest(req: SetupRequest): LocalMirrorConfig {
 }
 
 /** A readable message from a thrown value, never leaking a token (connectors name the env var). */
-function errorMessage(error: unknown): string {
+export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/local-mirror/src/lib/notion-transformers.ts
+++ b/local-mirror/src/lib/notion-transformers.ts
@@ -5,7 +5,7 @@
 // Links use the stable `www.notion.so/<id32>` form (same canonical shape as the F6 citation URL).
 
 /** A Notion page id (dashed or bare) → the stable clickable `www.notion.so/<id32>` URL. */
-function notionPageUrl(id: string): string {
+export function notionPageUrl(id: string): string {
   return `https://www.notion.so/${id.replace(/-/g, '')}`;
 }
 
@@ -49,7 +49,7 @@ interface NotionPropertyValue {
   phone_number?: string | null;
 }
 
-interface DatabaseRow {
+export interface DatabaseRow {
   id: string;
   properties: Record<string, NotionPropertyValue>;
 }
@@ -60,14 +60,14 @@ interface ChildDatabaseBlock {
 }
 
 /** The (single) `title`-typed property holds a row's name in a Notion database. */
-function rowTitle(row: DatabaseRow): string {
+export function rowTitle(row: DatabaseRow): string {
   const titleProp = Object.values(row.properties).find((p) => p.type === 'title');
   const text = (titleProp?.title ?? []).map((t) => t.plain_text).join('');
   return text || 'Untitled';
 }
 
 /** A single Notion property → a readable scalar string ('' when empty / unsupported). */
-function propertyToText(prop: NotionPropertyValue): string {
+export function propertyToText(prop: NotionPropertyValue): string {
   switch (prop.type) {
     case 'rich_text':
       return (prop.rich_text ?? []).map((t) => t.plain_text).join('');
@@ -93,7 +93,7 @@ function propertyToText(prop: NotionPropertyValue): string {
 }
 
 /** Non-title, non-empty properties of a row, rendered as `key: value` and joined by ` · `. */
-function rowFields(row: DatabaseRow): string {
+export function rowFields(row: DatabaseRow): string {
   return Object.entries(row.properties)
     .filter(([, prop]) => prop.type !== 'title')
     .map(([key, prop]) => [key, propertyToText(prop)] as const)

--- a/local-mirror/src/server.ts
+++ b/local-mirror/src/server.ts
@@ -6,10 +6,17 @@
 // the boot here — and OUT of index.ts — means the tool surface stays unit-testable
 // against an injected port, while "where to deploy" remains a packaging variable
 // (PRD §4/§5). The .mcp.json entry points at THIS file.
+//
+// The wiring seams (buildDeps / buildApi / boot / fatal) are exported and unit-tested
+// (server-boot.test.ts); only the top-level `bootReal().catch(fatal)` invocation runs
+// solely when this file IS the process entry point (import.meta.url guard) — so an
+// import for testing stays side-effect-free.
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { fileURLToPath } from 'node:url';
 import { createMcpServer } from './index.js';
-import { LocalMirror } from './domain/local-mirror.js';
+import { LocalMirror, type LocalMirrorDeps } from './domain/local-mirror.js';
 import { FsConfigStore } from './adapters/fs-config-store.js';
 import { FsStateStore } from './adapters/fs-state-store.js';
 import { FsVaultWriter } from './adapters/fs-vault-writer.js';
@@ -17,24 +24,71 @@ import { SystemClock } from './adapters/system-clock.js';
 import { notionConnectorFactory } from './adapters/notion-gateway.js';
 import { VAULT_DIR, SIDECAR_DIR, CONFIG_PATH } from './lib/config.js';
 
-function buildApi(): LocalMirror {
-  return new LocalMirror({
+/** Wire the real driven adapters — the ONE place bound to the concrete fs/Notion SPI. */
+export function buildDeps(): LocalMirrorDeps {
+  return {
     configStore: new FsConfigStore(CONFIG_PATH),
     stateStore: new FsStateStore(SIDECAR_DIR),
     vaultWriter: new FsVaultWriter(VAULT_DIR),
     clock: new SystemClock(),
     connectorFor: notionConnectorFactory,
-  });
+  };
 }
 
-async function main(): Promise<void> {
-  const server = createMcpServer(buildApi());
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error('[local-mirror] MCP server running on stdio');
+/** Assemble the Domain Service from its driven dependencies (real ones by default). */
+export function buildApi(deps: LocalMirrorDeps = buildDeps()): LocalMirror {
+  return new LocalMirror(deps);
 }
 
-main().catch((err) => {
-  console.error('[local-mirror] Fatal:', err);
-  process.exit(1);
-});
+/** The minimal server contract boot() drives — lets the transport wiring be stubbed. */
+export interface BootServer {
+  connect(transport: unknown): Promise<void>;
+}
+
+/** Everything boot() needs, injected so the glue is exercisable without real stdio. */
+export interface BootDeps {
+  createServer(): BootServer;
+  createTransport(): unknown;
+  log(message: string): void;
+}
+
+/** Boot glue: connect the tool surface over a transport, then announce readiness. */
+export async function boot(deps: BootDeps): Promise<void> {
+  const server = deps.createServer();
+  await server.connect(deps.createTransport());
+  deps.log('[local-mirror] MCP server running on stdio');
+}
+
+/** Fatal handler for the top-level boot: report the error and exit non-zero. */
+export function fatal(
+  err: unknown,
+  log: (message: string, err: unknown) => void = console.error,
+  exit: (code: number) => void = process.exit,
+): void {
+  log('[local-mirror] Fatal:', err);
+  exit(1);
+}
+
+/** The real tool surface, wired to the real driven adapters. */
+export function createRealServer(): McpServer {
+  return createMcpServer(buildApi());
+}
+
+/** The real stdio transport (connected by boot(), not here). */
+export function createRealTransport(): StdioServerTransport {
+  return new StdioServerTransport();
+}
+
+/** Named factories so the real wiring is inspectable (no un-mutable inline arrows). */
+export const realBootDeps: BootDeps = {
+  createServer: createRealServer,
+  createTransport: createRealTransport,
+  log: console.error,
+};
+
+// Boot only when run as the entry point — importing for tests stays side-effect-free.
+// This guard (and the boot invocation it wraps) is the sole integration-only line: it is
+// exercised when server.ts IS the process, not under the unit suite.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  boot(realBootDeps).catch(fatal);
+}

--- a/local-mirror/src/test/builder.ts
+++ b/local-mirror/src/test/builder.ts
@@ -29,10 +29,12 @@ class LocalMirrorBuilder {
   private enumerationError: string | undefined;
   /** When true, the sidecar state store cannot be read (a corrupt/unreachable store). */
   private unreachableStore = false;
+  /** When true, the config store itself cannot be read (health-check "config unreadable"). */
+  private unreadableConfig = false;
   /** Stable reference so tests can inspect the vault after build()/sync(). */
   private readonly vault = new RecordingVaultWriter();
   /** Stable reference so tests can inspect what `setup_source` declared. */
-  private readonly configs = new InMemoryConfigStore(this.declared);
+  private readonly configs = new InMemoryConfigStore(this.declared, () => this.unreadableConfig);
 
   /** Declare local mirrors, as if already written to the config file. */
   withDeclaredSources(...configs: LocalMirrorConfig[]): this {
@@ -95,6 +97,12 @@ class LocalMirrorBuilder {
   /** Make the sidecar state store unreadable — a corrupt/unreachable mirror store. */
   withUnreachableStore(): this {
     this.unreachableStore = true;
+    return this;
+  }
+
+  /** Make the config store itself throw on read — the health-check "config unreadable" path. */
+  withUnreadableConfig(): this {
+    this.unreadableConfig = true;
     return this;
   }
 
@@ -178,8 +186,12 @@ export function aNotionLocalMirror(
 }
 
 class InMemoryConfigStore implements IConfigStore {
-  constructor(private readonly configs: LocalMirrorConfig[]) {}
+  constructor(
+    private readonly configs: LocalMirrorConfig[],
+    private readonly unreadable: () => boolean = () => false,
+  ) {}
   async loadAll(): Promise<LocalMirrorConfig[]> {
+    if (this.unreadable()) throw new Error('config file unreadable (EACCES)');
     return [...this.configs];
   }
   async upsert(config: LocalMirrorConfig): Promise<void> {

--- a/local-mirror/src/test/health-check.test.ts
+++ b/local-mirror/src/test/health-check.test.ts
@@ -6,7 +6,7 @@ import { aLocalMirror, aNotionPage, aNotionLocalMirror } from './builder.js';
 // reports whether the OPTIONAL Notion mirror is operational, in the standard
 // { status, checks[] } contract — and NEVER cries "broken" when nothing is set up.
 
-function checkNamed(report: { checks: { name: string; status: string }[] }, name: string) {
+function checkNamed(report: { checks: { name: string; status: string; detail: string }[] }, name: string) {
   const entry = report.checks.find((c) => c.name === name);
   assert.ok(entry, `expected a "${name}" check`);
   return entry;
@@ -19,6 +19,24 @@ test('nothing configured → status unknown, never broken', async () => {
 
   assert.equal(report.status, 'unknown');
   assert.ok(report.checks.every((c) => c.status !== 'broken'));
+  // The single "config" check spells out WHY it is unknown (nothing set up ≠ a failure).
+  const config = checkNamed(report, 'config');
+  assert.equal(config.status, 'unknown');
+  assert.equal(config.detail, 'no local mirror configured');
+});
+
+test('config unreadable → status unknown (couldn\'t determine, not broken)', async () => {
+  const lm = aLocalMirror()
+    .withDeclaredSources(aNotionLocalMirror())
+    .withUnreadableConfig()
+    .build();
+
+  const report = await lm.healthCheck();
+
+  assert.equal(report.status, 'unknown');
+  const config = checkNamed(report, 'config');
+  assert.equal(config.status, 'unknown');
+  assert.match(config.detail, /config unreadable: config file unreadable/);
 });
 
 test('a declared, synced source with readable state → status ok', async () => {
@@ -30,7 +48,9 @@ test('a declared, synced source with readable state → status ok', async () => 
 
   assert.equal(report.status, 'ok');
   assert.equal(checkNamed(report, 'config').status, 'ok');
+  assert.match(checkNamed(report, 'config').detail, /1 mirror\(s\) declared/);
   assert.equal(checkNamed(report, 'store').status, 'ok');
+  assert.equal(checkNamed(report, 'store').detail, 'mirror state readable');
 });
 
 test('a declared source whose state store is unreachable → status broken', async () => {
@@ -43,4 +63,5 @@ test('a declared source whose state store is unreachable → status broken', asy
 
   assert.equal(report.status, 'broken');
   assert.equal(checkNamed(report, 'store').status, 'broken');
+  assert.match(checkNamed(report, 'store').detail, /mirror store unreachable/);
 });

--- a/local-mirror/src/test/local-mirror-helpers.test.ts
+++ b/local-mirror/src/test/local-mirror-helpers.test.ts
@@ -1,0 +1,131 @@
+// @ts-nocheck
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  aggregateHealth,
+  aggregateStatus,
+  aggregateReports,
+  failedReport,
+  maxLastEditedTime,
+  rootPageIdOf,
+  configFromRequest,
+  errorMessage,
+} from '../domain/local-mirror.js';
+import { aNotionLocalMirror } from './builder.js';
+
+// Unit tests for the Domain Service's pure helpers. Several of their branches are NOT reachable
+// through the public API (e.g. aggregateHealth's `unknown` verdict never arises from healthCheck,
+// which only ever produces `ok`/`broken` sub-checks; aggregateStatus's mixed verdicts need
+// per-source rejections that the fan-out swallows). Testing the glue directly, per the
+// "test the glue too" convention, is how those verdicts get pinned.
+
+// aggregateHealth: any broken → broken; else any unknown → unknown; else ok (ADR 0030).
+test('aggregateHealth: a broken sub-check dominates', () => {
+  assert.equal(aggregateHealth([{ status: 'ok' }, { status: 'broken' }]), 'broken');
+});
+
+test('aggregateHealth: an unknown sub-check (no broken) yields unknown', () => {
+  assert.equal(aggregateHealth([{ status: 'ok' }, { status: 'unknown' }]), 'unknown');
+});
+
+test('aggregateHealth: all ok yields ok', () => {
+  assert.equal(aggregateHealth([{ status: 'ok' }, { status: 'ok' }]), 'ok');
+});
+
+// aggregateStatus: ok iff every source ok; failed iff every source failed; else partial.
+test('aggregateStatus: an empty batch is ok', () => {
+  assert.equal(aggregateStatus([]), 'ok');
+});
+
+test('aggregateStatus: every source ok → ok', () => {
+  assert.equal(aggregateStatus([{ status: 'ok' }, { status: 'ok' }]), 'ok');
+});
+
+test('aggregateStatus: every source failed → failed', () => {
+  assert.equal(aggregateStatus([{ status: 'failed' }, { status: 'failed' }]), 'failed');
+});
+
+test('aggregateStatus: a mix of ok and failed → partial (not failed, not ok)', () => {
+  assert.equal(aggregateStatus([{ status: 'ok' }, { status: 'failed' }]), 'partial');
+});
+
+test('aggregateStatus: a partial anywhere → partial', () => {
+  assert.equal(aggregateStatus([{ status: 'partial' }, { status: 'ok' }]), 'partial');
+});
+
+// aggregateReports: name 'all', worst-of status, and per-count SUMS (not just written).
+test('aggregateReports sums every count and reports the per-source breakdown', () => {
+  const a = { name: 'a', status: 'ok', written: 2, deleted: 1, unchanged: 3 };
+  const b = { name: 'b', status: 'partial', written: 1, deleted: 4, unchanged: 5 };
+
+  const report = aggregateReports([a, b]);
+
+  assert.equal(report.name, 'all');
+  assert.equal(report.status, 'partial');
+  assert.equal(report.written, 3);
+  assert.equal(report.deleted, 5);
+  assert.equal(report.unchanged, 8);
+  assert.deepEqual(report.sources, [a, b]);
+});
+
+// failedReport: the exact "this source threw" shape.
+test('failedReport is a fully-zeroed failed report carrying the source name', () => {
+  assert.deepEqual(failedReport('beta'), {
+    name: 'beta',
+    status: 'failed',
+    written: 0,
+    deleted: 0,
+    unchanged: 0,
+  });
+});
+
+// maxLastEditedTime: the MAX over the perimeter (order-independent), null when empty.
+test('maxLastEditedTime returns null for an empty perimeter', () => {
+  assert.equal(maxLastEditedTime([]), null);
+});
+
+test('maxLastEditedTime returns the max even when it is NOT the last item', () => {
+  const max = maxLastEditedTime([
+    { lastEditedTime: '2026-06-15T09:00:00.000Z' },
+    { lastEditedTime: '2026-06-10T08:00:00.000Z' },
+  ]);
+
+  assert.equal(max, '2026-06-15T09:00:00.000Z');
+});
+
+// rootPageIdOf: prefer the stored id; only extract from the URL when there is no prior state.
+test('rootPageIdOf keeps the previously-persisted root page id', () => {
+  const stored = 'aaaabbbb-cccc-dddd-eeee-ffff00001111';
+
+  assert.equal(rootPageIdOf(aNotionLocalMirror(), { rootPageId: stored }), stored);
+});
+
+test('rootPageIdOf extracts the id from the config URL when there is no prior state', () => {
+  assert.equal(rootPageIdOf(aNotionLocalMirror(), null), '0123abc0-b1c2-4d6e-8f0a-1b2c3d4e5f60');
+});
+
+// configFromRequest: assembles the declared config; the connector is always Notion, files land
+// under mirrors/<name>, and only the token's ENV VAR NAME is stored (never the token).
+test('configFromRequest builds a Notion config under mirrors/<name>, storing only the token env var', () => {
+  const config = configFromRequest({
+    name: 'team-x',
+    title: 'Team X',
+    description: 'topics',
+    rootPageUrl: 'https://www.notion.so/acme/Page-0123abc0b1c24d6e8f0a1b2c3d4e5f60',
+    tokenEnv: 'TEAM_X_TOKEN',
+  });
+
+  assert.equal(config.connector.type, 'notion');
+  assert.equal(config.target_dir, 'mirrors/team-x');
+  assert.equal(config.connector.config.root_page_url, 'https://www.notion.so/acme/Page-0123abc0b1c24d6e8f0a1b2c3d4e5f60');
+  assert.equal(config.connector.config.token_env, 'TEAM_X_TOKEN');
+});
+
+// errorMessage: an Error's message; anything else stringified.
+test('errorMessage unwraps an Error message', () => {
+  assert.equal(errorMessage(new Error('boom')), 'boom');
+});
+
+test('errorMessage stringifies a non-Error thrown value', () => {
+  assert.equal(errorMessage('plain string'), 'plain string');
+});

--- a/local-mirror/src/test/local-mirror-sync-edge.test.ts
+++ b/local-mirror/src/test/local-mirror-sync-edge.test.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  aLocalMirror,
+  aNotionPage,
+  anUnreadableNotionPage,
+  aNotionLocalMirror,
+} from './builder.js';
+
+// Acceptance tests at the API port (ILocalMirror) covering the sync/freshness EDGE branches the
+// happy-path suites don't reach: an unknown source, an empty perimeter with no prior state (which
+// must NOT trip the wholesale-vanish guard), the per-item write-error persistence rules, the
+// frozen watermark on a partial run, the fan-out over rejecting sources, and freshness with an
+// empty remote perimeter.
+//
+// Documented EQUIVALENT mutants on local-mirror.ts (effective 100% on non-equivalents):
+//   - L110 `ok: report.status !== 'failed'` → `ok: true` / `ok: … !== ""` (×2): once setupSource
+//     has proven the scope and upsert-ed the config, the immediately-following sync of THAT config
+//     can never return 'failed' (that status only arises for an unknown source), so the guard's
+//     false branch is unreachable and the mutants are behaviour-identical.
+//   - L388 `if (sources.length === 0) return 'ok'` → `if (false)`: the guard is a shortcut for
+//     `every([]) === true` which already returns 'ok', so removing it changes nothing.
+//   - L398 `item.lastEditedTime > max` → `>= max`: on an equal value both assign the same string,
+//     so the computed max is identical.
+
+// sync of an unknown source is a clean failed report (not a throw, not a partial write).
+test('syncing an unknown source returns a fully-zeroed failed report', async () => {
+  const gss = aLocalMirror().withDeclaredSources(aNotionLocalMirror()).build();
+
+  const report = await gss.sync('does-not-exist');
+
+  assert.deepEqual(report, {
+    name: 'does-not-exist',
+    status: 'failed',
+    written: 0,
+    deleted: 0,
+    unchanged: 0,
+  });
+});
+
+// The wholesale-vanish guard (§7/§12) freezes ONLY when a non-empty corpus goes to zero. A
+// genuinely empty first sync (no prior state) must stay `ok`, not be mistaken for a lost scope.
+test('an empty perimeter on a never-synced source is a clean ok sync, not a frozen partial', async () => {
+  const gss = aLocalMirror().withDeclaredSources(aNotionLocalMirror()).build();
+
+  const report = await gss.sync('team-a');
+
+  assert.equal(report.status, 'ok');
+  assert.equal(report.written, 0);
+  assert.equal(report.deleted, 0);
+});
+
+// Write-error persistence, case NEW item: an untracked page that fails to fetch/write is NOT
+// recorded in the state map (there is no prior version to keep) — itemCount excludes it.
+test('a NEW page that fails to fetch is left out of the state map (nothing to keep)', async () => {
+  const harness = aLocalMirror().withNotionPages(anUnreadableNotionPage({ id: 'p1' }));
+  const gss = harness.build();
+
+  const report = await gss.sync('team-a');
+
+  assert.equal(report.status, 'partial');
+  assert.equal(report.written, 0);
+  const [source] = await gss.listSources();
+  assert.equal(source.itemCount, 0);
+});
+
+// Write-error persistence, case TRACKED item: a page that synced before but now fails to fetch
+// KEEPS its last-good tracked entry (incremental persistence) — itemCount stays, run is partial.
+test('a TRACKED page that later fails to fetch keeps its last-good state entry', async () => {
+  const harness = aLocalMirror().withNotionPages(aNotionPage({ id: 'p1', content: 'good\n' }));
+  const gss = harness.build();
+  await gss.sync('team-a');
+
+  harness.withRevisedPage(anUnreadableNotionPage({ id: 'p1' }));
+  const report = await gss.sync('team-a');
+
+  assert.equal(report.status, 'partial');
+  assert.equal(report.written, 0);
+  assert.ok(harness.vaultFiles().has('mirrors/team-a/p1.md'), 'the last-good .md stays on disk');
+  const [source] = await gss.listSources();
+  assert.equal(source.itemCount, 1, 'the tracked page is kept, not dropped');
+});
+
+// On a partial run the watermark FREEZES at the prior value — it is not reset to null. This pins
+// the `?? null` fallback (keep the prior watermark) against a `&& null` (would wipe it).
+test('a partial sync freezes the watermark at the prior value, never nulling it', async () => {
+  const harness = aLocalMirror().withNotionPages(
+    aNotionPage({ id: 'p1', lastEditedTime: '2026-06-10T08:00:00.000Z', content: 'good\n' }),
+  );
+  const gss = harness.build();
+  await gss.sync('team-a'); // watermark advances to 2026-06-10T08:00
+
+  harness.withRevisedPage(anUnreadableNotionPage({ id: 'p1' }));
+  await gss.sync('team-a'); // now partial
+
+  const [source] = await gss.listSources();
+  assert.equal(source.watermark, '2026-06-10T08:00:00.000Z');
+  assert.equal(source.lastSyncStatus, 'partial');
+});
+
+// sync("all") over sources whose sidecar store is unreachable: every source rejects, so the
+// fan-out reports each as a failed entry (never a bare undefined) and the aggregate is failed.
+test('sync("all") reports every rejecting source as a failed entry', async () => {
+  const gss = aLocalMirror()
+    .withDeclaredSources(aNotionLocalMirror({ name: 'a' }), aNotionLocalMirror({ name: 'b' }))
+    .withUnreachableStore()
+    .build();
+
+  const report = await gss.sync('all');
+
+  assert.equal(report.status, 'failed');
+  assert.equal((report.sources ?? []).length, 2);
+  assert.ok((report.sources ?? []).every((r) => r.status === 'failed'));
+});
+
+// check_freshness with an EMPTY remote perimeter and no local watermark is NOT behind: there is
+// simply nothing upstream. This pins the `remoteWatermark !== null` guard.
+test('check_freshness with an empty remote perimeter is not behind', async () => {
+  const gss = aLocalMirror().withDeclaredSources(aNotionLocalMirror()).build();
+
+  const fr = await gss.checkFreshness('team-a');
+
+  assert.equal(fr.behind, false);
+  assert.equal(fr.remoteWatermark, null);
+  assert.equal(fr.localWatermark, null);
+});

--- a/local-mirror/src/test/mcp-tools.test.ts
+++ b/local-mirror/src/test/mcp-tools.test.ts
@@ -1,0 +1,201 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../index.js';
+import type { ILocalMirror } from '../domain/local-mirror.js';
+
+// The driving adapter (index.ts) is a 1:1 translation of the API port: each MCP tool
+// validates its args, calls the matching port method, and serializes via asText. These
+// tests drive the REAL registered surface through an in-memory client (SDK transport
+// pair) — so tool names, descriptions, arg mappings, handlers and the asText envelope
+// are all exercised end-to-end (mutation: index.ts 2.2 % → hardened).
+
+/** A spy ILocalMirror: records the (method, args) it receives, returns a canned result. */
+function spyApi() {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+  const record =
+    (method: string, result: unknown) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+      return Promise.resolve(result);
+    };
+  const results = {
+    setupSource: { setup: 'ok' },
+    listSources: [{ name: 'team-a' }],
+    sync: { synced: 3 },
+    checkFreshness: { behind: false },
+    status: { name: 'team-a', items: 7 },
+    removeSource: { removed: true },
+    healthCheck: { status: 'ok', checks: [] },
+  };
+  const api = {
+    setupSource: record('setupSource', results.setupSource),
+    listSources: record('listSources', results.listSources),
+    sync: record('sync', results.sync),
+    checkFreshness: record('checkFreshness', results.checkFreshness),
+    status: record('status', results.status),
+    removeSource: record('removeSource', results.removeSource),
+    healthCheck: record('healthCheck', results.healthCheck),
+  } as unknown as ILocalMirror;
+  return { api, calls, results };
+}
+
+/** Wire a client to the server over an in-memory transport pair. */
+async function connect(api: ILocalMirror) {
+  const server = createMcpServer(api);
+  const client = new Client({ name: 'test', version: '0.0.0' });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverT), client.connect(clientT)]);
+  return { client, close: () => client.close() };
+}
+
+/** The asText envelope the handlers must produce for a given port result. */
+function envelope(result: unknown) {
+  return [{ type: 'text', text: JSON.stringify(result, null, 2) }];
+}
+
+test('the server advertises its name and version', async () => {
+  const { api } = spyApi();
+  const { client, close } = await connect(api);
+
+  assert.deepEqual(client.getServerVersion(), { name: 'local-mirror', version: '0.2.0' });
+
+  await close();
+});
+
+test('exactly the 7 tools are registered, each with a name and a non-empty description', async () => {
+  const { api } = spyApi();
+  const { client, close } = await connect(api);
+
+  const { tools } = await client.listTools();
+  const byName = new Map(tools.map((t) => [t.name, t]));
+
+  assert.deepEqual(
+    [...byName.keys()].sort(),
+    ['check_freshness', 'health_check', 'list_sources', 'remove_source', 'setup_source', 'status', 'sync'],
+  );
+  for (const t of tools) {
+    assert.ok(t.description && t.description.length > 0, `${t.name} has a description`);
+    // Every input field carries a non-empty description — it is published in the tool's
+    // inputSchema and steers how the LLM fills the argument, so it is part of the contract.
+    const properties = (t.inputSchema?.properties ?? {}) as Record<string, { description?: string }>;
+    for (const [field, schema] of Object.entries(properties)) {
+      assert.ok(
+        schema.description && schema.description.length > 0,
+        `${t.name}.${field} has a description`,
+      );
+    }
+  }
+
+  await close();
+});
+
+test('setup_source maps snake_case args to the port request and returns the asText envelope', async () => {
+  const { api, calls, results } = spyApi();
+  const { client, close } = await connect(api);
+
+  const res = await client.callTool({
+    name: 'setup_source',
+    arguments: {
+      name: 'team-a',
+      title: 'Team A',
+      description: 'roadmap + specs',
+      root_page_url: 'https://notion.so/root',
+      token_env: 'TEAM_A_TOKEN',
+    },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      method: 'setupSource',
+      args: [
+        {
+          name: 'team-a',
+          title: 'Team A',
+          description: 'roadmap + specs',
+          rootPageUrl: 'https://notion.so/root',
+          tokenEnv: 'TEAM_A_TOKEN',
+        },
+      ],
+    },
+  ]);
+  assert.deepEqual(res.content, envelope(results.setupSource));
+
+  await close();
+});
+
+test('list_sources calls the port with no argument', async () => {
+  const { api, calls, results } = spyApi();
+  const { client, close } = await connect(api);
+
+  const res = await client.callTool({ name: 'list_sources', arguments: {} });
+
+  assert.deepEqual(calls, [{ method: 'listSources', args: [] }]);
+  assert.deepEqual(res.content, envelope(results.listSources));
+
+  await close();
+});
+
+test('sync forwards the source name (incl. the literal "all")', async () => {
+  const { api, calls, results } = spyApi();
+  const { client, close } = await connect(api);
+
+  const res = await client.callTool({ name: 'sync', arguments: { name: 'all' } });
+
+  assert.deepEqual(calls, [{ method: 'sync', args: ['all'] }]);
+  assert.deepEqual(res.content, envelope(results.sync));
+
+  await close();
+});
+
+test('check_freshness forwards the source name', async () => {
+  const { api, calls, results } = spyApi();
+  const { client, close } = await connect(api);
+
+  const res = await client.callTool({ name: 'check_freshness', arguments: { name: 'team-a' } });
+
+  assert.deepEqual(calls, [{ method: 'checkFreshness', args: ['team-a'] }]);
+  assert.deepEqual(res.content, envelope(results.checkFreshness));
+
+  await close();
+});
+
+test('status forwards the source name', async () => {
+  const { api, calls, results } = spyApi();
+  const { client, close } = await connect(api);
+
+  const res = await client.callTool({ name: 'status', arguments: { name: 'team-a' } });
+
+  assert.deepEqual(calls, [{ method: 'status', args: ['team-a'] }]);
+  assert.deepEqual(res.content, envelope(results.status));
+
+  await close();
+});
+
+test('remove_source forwards the name and the optional cleanup flag', async () => {
+  const { api, calls, results } = spyApi();
+  const { client, close } = await connect(api);
+
+  const res = await client.callTool({
+    name: 'remove_source',
+    arguments: { name: 'team-a', cleanup: true },
+  });
+
+  assert.deepEqual(calls, [{ method: 'removeSource', args: ['team-a', true] }]);
+  assert.deepEqual(res.content, envelope(results.removeSource));
+
+  await close();
+});
+
+test('health_check calls the port with no argument', async () => {
+  const { api, calls, results } = spyApi();
+  const { client, close } = await connect(api);
+
+  const res = await client.callTool({ name: 'health_check', arguments: {} });
+
+  assert.deepEqual(calls, [{ method: 'healthCheck', args: [] }]);
+  assert.deepEqual(res.content, envelope(results.healthCheck));
+
+  await close();
+});

--- a/local-mirror/src/test/notion-gateway.test.ts
+++ b/local-mirror/src/test/notion-gateway.test.ts
@@ -2,14 +2,24 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   queryNotionDatabaseRows,
+  NotionSdkGateway,
   type NotionDbClient,
   type NotionDatabaseRow,
+  type Notion2Md,
 } from '../adapters/notion-gateway.js';
+import type { Client } from '@notionhq/client';
+import {
+  childPageToMarkdown,
+  linkToPageToMarkdown,
+} from '../lib/notion-transformers.js';
 
-// notion-gateway.ts is the real @notionhq/client adapter. The pure pagination logic
-// (queryNotionDatabaseRows) is exported and injected with a minimal client slice so it is
-// unit-testable without the SDK; the real Client/NotionToMarkdown construction stays an
-// integration-only equivalent (documented in the header of the gateway wiring tests below).
+// notion-gateway.ts is the real @notionhq/client adapter. Its seams are extracted and
+// injected: queryNotionDatabaseRows takes a minimal NotionDbClient slice, and the gateway
+// takes a notion-to-md factory — so pagination, the transformer wiring, search arg-mapping
+// and the pageToMarkdown fallback are all unit-testable without the SDK. Mutation:
+// 21 % → 97.44 %. The single residual survivor is a documented equivalent: the
+// `new Client({ auth: token })` real-SDK construction in buildNotionConnector, observable
+// only through a live network call → effective 38/38 = 100 % on non-equivalents.
 
 /** A scripted NotionDbClient: records the calls it receives, replays canned responses. */
 function fakeDbClient(opts: {
@@ -98,4 +108,99 @@ test('queryNotionDatabaseRows stops after one page when has_more is false', asyn
     rows.map((r) => r.id),
     ['only'],
   );
+});
+
+// ── NotionSdkGateway wiring (notion-to-md injected via a recording factory) ───────────
+
+/** A fake notion-to-md that records the transformers it is given and replays a scripted body. */
+function fakeN2m(body: { blocks?: unknown; markdown?: { parent?: string } } = {}) {
+  const transformers = new Map<string, (block: unknown) => Promise<string> | string>();
+  const n2m: Notion2Md = {
+    setCustomTransformer(type, transformer) {
+      transformers.set(type, transformer);
+    },
+    async pageToMarkdown() {
+      return body.blocks ?? [];
+    },
+    toMarkdownString() {
+      return body.markdown ?? {};
+    },
+  };
+  return { n2m, transformers };
+}
+
+test('the gateway turns parseChildPages ON and registers the 3 custom transformers', async () => {
+  const { n2m, transformers } = fakeN2m();
+  let init: { config: { parseChildPages: boolean } } | undefined;
+  // A client that can answer the child_database transformer's row query.
+  const client = {
+    databases: { async retrieve() { return {}; } },
+    dataSources: {
+      async query() {
+        return { results: [{ id: 'r1', properties: {} }], has_more: false, next_cursor: null };
+      },
+    },
+  } as unknown as Client;
+
+  new NotionSdkGateway(client, (opts) => {
+    init = opts as unknown as { config: { parseChildPages: boolean } };
+    return n2m;
+  });
+
+  assert.equal(init?.config.parseChildPages, true);
+  assert.deepEqual([...transformers.keys()].sort(), ['child_database', 'child_page', 'link_to_page']);
+
+  // Each wrapper delegates to the matching pure transformer (invoke and compare).
+  const childPageBlock = { id: 'p1', child_page: { title: 'Design' } };
+  assert.equal(
+    await transformers.get('child_page')!(childPageBlock),
+    childPageToMarkdown(childPageBlock as never),
+  );
+  const linkBlock = { id: 'l1', link_to_page: { type: 'page_id', page_id: 'l1' } };
+  assert.equal(
+    await transformers.get('link_to_page')!(linkBlock),
+    linkToPageToMarkdown(linkBlock as never),
+  );
+  // child_database delegates to a fetcher wired to THIS client — a served row proves it.
+  const dbBlock = { id: 'DB-9', child_database: { title: 'Roadmap' } };
+  const rendered = await transformers.get('child_database')!(dbBlock);
+  assert.match(rendered as string, /\*\*Roadmap\*\*/);
+  assert.match(rendered as string, /r1/);
+});
+
+test('search scopes to pages, pins page_size, threads the cursor, and maps the response', async () => {
+  const searchCalls: unknown[] = [];
+  const client = {
+    async search(args: unknown) {
+      searchCalls.push(args);
+      return { results: [{ id: 'page-1' }], has_more: true, next_cursor: 'next-1' };
+    },
+  } as unknown as Client;
+  const { n2m } = fakeN2m();
+  const gateway = new NotionSdkGateway(client, () => n2m);
+
+  const res = await gateway.search('cursor-0');
+
+  assert.deepEqual(searchCalls, [
+    { filter: { property: 'object', value: 'page' }, page_size: 100, start_cursor: 'cursor-0' },
+  ]);
+  assert.deepEqual(res, {
+    results: [{ id: 'page-1' }],
+    has_more: true,
+    next_cursor: 'next-1',
+  });
+});
+
+test('pageToMarkdown returns the rendered parent body', async () => {
+  const { n2m } = fakeN2m({ markdown: { parent: '# Body\n' } });
+  const gateway = new NotionSdkGateway({} as unknown as Client, () => n2m);
+
+  assert.equal(await gateway.pageToMarkdown('any'), '# Body\n');
+});
+
+test('pageToMarkdown falls back to an empty string when there is no parent body', async () => {
+  const { n2m } = fakeN2m({ markdown: {} });
+  const gateway = new NotionSdkGateway({} as unknown as Client, () => n2m);
+
+  assert.equal(await gateway.pageToMarkdown('any'), '');
 });

--- a/local-mirror/src/test/notion-gateway.test.ts
+++ b/local-mirror/src/test/notion-gateway.test.ts
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  queryNotionDatabaseRows,
+  type NotionDbClient,
+  type NotionDatabaseRow,
+} from '../adapters/notion-gateway.js';
+
+// notion-gateway.ts is the real @notionhq/client adapter. The pure pagination logic
+// (queryNotionDatabaseRows) is exported and injected with a minimal client slice so it is
+// unit-testable without the SDK; the real Client/NotionToMarkdown construction stays an
+// integration-only equivalent (documented in the header of the gateway wiring tests below).
+
+/** A scripted NotionDbClient: records the calls it receives, replays canned responses. */
+function fakeDbClient(opts: {
+  retrieve: unknown;
+  query: (args: { data_source_id: string; start_cursor?: string }) => unknown;
+}) {
+  const retrieveCalls: Array<{ database_id: string }> = [];
+  const queryCalls: Array<{ data_source_id: string; start_cursor?: string; page_size: number }> = [];
+  const client: NotionDbClient = {
+    databases: {
+      async retrieve(args) {
+        retrieveCalls.push(args);
+        return opts.retrieve;
+      },
+    },
+    dataSources: {
+      async query(args) {
+        queryCalls.push(args);
+        return opts.query(args);
+      },
+    },
+  };
+  return { client, retrieveCalls, queryCalls };
+}
+
+const row = (id: string): NotionDatabaseRow => ({ id, properties: {} });
+
+test('queryNotionDatabaseRows pages through every data source and aggregates the rows', async () => {
+  const { client, retrieveCalls, queryCalls } = fakeDbClient({
+    retrieve: { data_sources: [{ id: 'ds1' }, { id: 'ds2' }] },
+    query: ({ data_source_id, start_cursor }) => {
+      if (data_source_id === 'ds1' && start_cursor === undefined) {
+        return { results: [row('a')], has_more: true, next_cursor: 'cur1' };
+      }
+      if (data_source_id === 'ds1' && start_cursor === 'cur1') {
+        return { results: [row('b')], has_more: false, next_cursor: null };
+      }
+      return { results: [row('c')], has_more: false, next_cursor: null };
+    },
+  });
+
+  const rows = await queryNotionDatabaseRows(client, 'DB-1');
+
+  assert.deepEqual(
+    rows.map((r) => r.id),
+    ['a', 'b', 'c'],
+  );
+  assert.deepEqual(retrieveCalls, [{ database_id: 'DB-1' }]);
+  // Cursor is threaded across pages; page_size is pinned to 100.
+  assert.deepEqual(queryCalls, [
+    { data_source_id: 'ds1', start_cursor: undefined, page_size: 100 },
+    { data_source_id: 'ds1', start_cursor: 'cur1', page_size: 100 },
+    { data_source_id: 'ds2', start_cursor: undefined, page_size: 100 },
+  ]);
+});
+
+test('queryNotionDatabaseRows falls back to the block id when the db carries no data_sources', async () => {
+  const { client, queryCalls } = fakeDbClient({
+    retrieve: {}, // older shape: no data_sources
+    query: () => ({ results: [row('x')], has_more: false, next_cursor: null }),
+  });
+
+  const rows = await queryNotionDatabaseRows(client, 'DB-2');
+
+  assert.deepEqual(
+    rows.map((r) => r.id),
+    ['x'],
+  );
+  assert.deepEqual(queryCalls, [{ data_source_id: 'DB-2', start_cursor: undefined, page_size: 100 }]);
+});
+
+test('queryNotionDatabaseRows stops after one page when has_more is false', async () => {
+  let queryCount = 0;
+  const { client } = fakeDbClient({
+    retrieve: { data_sources: [{ id: 'ds1' }] },
+    query: () => {
+      queryCount += 1;
+      return { results: [row('only')], has_more: false, next_cursor: 'ignored-when-not-has_more' };
+    },
+  });
+
+  const rows = await queryNotionDatabaseRows(client, 'DB-3');
+
+  assert.equal(queryCount, 1);
+  assert.deepEqual(
+    rows.map((r) => r.id),
+    ['only'],
+  );
+});

--- a/local-mirror/src/test/notion-transformers.test.ts
+++ b/local-mirror/src/test/notion-transformers.test.ts
@@ -4,7 +4,20 @@ import {
   childPageToMarkdown,
   linkToPageToMarkdown,
   makeChildDatabaseTransformer,
+  notionPageUrl,
+  rowTitle,
+  propertyToText,
+  rowFields,
 } from '../lib/notion-transformers.js';
+
+// Mutation score 94.87 % — the 6 residual survivors are all documented equivalents:
+//   • the three `?? []` fallbacks (titleProp.title / rich_text / multi_select) mutated to a
+//     one-element sentinel array: its element is a bare string, so `.map(t => t.plain_text)` /
+//     `.map(o => o.name)` yields `[undefined]` which `.join('')`s back to '' — identical to [];
+//   • the `rowFields` `.filter(prop.type !== 'title')` (whole filter removed, or `!== 'title'`
+//     forced true / `!== ''`): a title property's propertyToText is '' anyway, so it is dropped by
+//     the downstream `value !== ''` filter regardless — the title filter is a defensive-but-
+//     functionally-redundant guard. Effective 111/111 = 100 % on non-equivalent mutants.
 
 // B1 (R2-5): notion-to-md renders a `child_page` block as EMPTY by default (unless
 // parseChildPages is on, and even then only as a heading — never a link). A page that is
@@ -54,6 +67,130 @@ test('linkToPageToMarkdown labels a database_id target as a linked database', ()
   assert.equal(
     md,
     '[Linked Notion database](https://www.notion.so/0123abc0b1c24d6e8f0a1b2c3d4e5f60)',
+  );
+});
+
+test('linkToPageToMarkdown falls back to an empty id (bare www.notion.so) when neither id is present', () => {
+  const md = linkToPageToMarkdown({ link_to_page: { type: 'page_id' } });
+  assert.equal(md, '[Linked Notion page](https://www.notion.so/)');
+});
+
+test('linkToPageToMarkdown prefers page_id over database_id when both are present', () => {
+  const md = linkToPageToMarkdown({
+    link_to_page: { type: 'page_id', page_id: 'pppppppp-0000-0000-0000-000000000000', database_id: 'dddddddd-0000-0000-0000-000000000000' },
+  });
+  assert.equal(md, '[Linked Notion page](https://www.notion.so/pppppppp000000000000000000000000)');
+});
+
+// ── notionPageUrl: strips ALL dashes to the canonical 32-char form ────────────
+test('notionPageUrl strips every dash from a dashed id', () => {
+  assert.equal(
+    notionPageUrl('0123abc0-b1c2-4d6e-8f0a-1b2c3d4e5f60'),
+    'https://www.notion.so/0123abc0b1c24d6e8f0a1b2c3d4e5f60',
+  );
+});
+
+test('notionPageUrl leaves an already-bare id untouched', () => {
+  assert.equal(notionPageUrl('abc123'), 'https://www.notion.so/abc123');
+});
+
+// ── rowTitle: the single title-typed property, joined across rich-text runs ───
+test('rowTitle joins the plain_text runs of the title-typed property', () => {
+  const title = rowTitle({
+    id: 'x',
+    properties: {
+      Status: { type: 'select', select: { name: 'Active' } },
+      Name: { type: 'title', title: [{ plain_text: 'Hello ' }, { plain_text: 'World' }] },
+    },
+  });
+  assert.equal(title, 'Hello World');
+});
+
+test('rowTitle falls back to "Untitled" when there is no title property', () => {
+  assert.equal(rowTitle({ id: 'x', properties: { N: { type: 'rich_text', rich_text: [] } } }), 'Untitled');
+});
+
+test('rowTitle falls back to "Untitled" when the title property is empty', () => {
+  assert.equal(rowTitle({ id: 'x', properties: { Name: { type: 'title', title: [] } } }), 'Untitled');
+});
+
+// ── propertyToText: one assertion per supported property type (+ empties) ─────
+test('propertyToText — rich_text joins its runs', () => {
+  assert.equal(propertyToText({ type: 'rich_text', rich_text: [{ plain_text: 'a' }, { plain_text: 'b' }] }), 'ab');
+});
+
+test('propertyToText — rich_text with no runs is empty', () => {
+  assert.equal(propertyToText({ type: 'rich_text', rich_text: [] }), '');
+  assert.equal(propertyToText({ type: 'rich_text' }), '');
+});
+
+test('propertyToText — select uses the option name, empty when unset', () => {
+  assert.equal(propertyToText({ type: 'select', select: { name: 'Active' } }), 'Active');
+  assert.equal(propertyToText({ type: 'select', select: null }), '');
+});
+
+test('propertyToText — status uses the status name, empty when unset', () => {
+  assert.equal(propertyToText({ type: 'status', status: { name: 'In progress' } }), 'In progress');
+  assert.equal(propertyToText({ type: 'status', status: null }), '');
+});
+
+test('propertyToText — multi_select joins option names with ", "', () => {
+  assert.equal(
+    propertyToText({ type: 'multi_select', multi_select: [{ name: 'x' }, { name: 'y' }] }),
+    'x, y',
+  );
+  assert.equal(propertyToText({ type: 'multi_select' }), '');
+});
+
+test('propertyToText — number renders as a string, incl. 0, but empty when null', () => {
+  assert.equal(propertyToText({ type: 'number', number: 42 }), '42');
+  assert.equal(propertyToText({ type: 'number', number: 0 }), '0');
+  assert.equal(propertyToText({ type: 'number', number: null }), '');
+  assert.equal(propertyToText({ type: 'number' }), '');
+});
+
+test('propertyToText — date shows start, and start→end when there is an end', () => {
+  assert.equal(propertyToText({ type: 'date', date: { start: '2026-07-15' } }), '2026-07-15');
+  assert.equal(
+    propertyToText({ type: 'date', date: { start: '2026-07-15', end: '2026-07-20' } }),
+    '2026-07-15→2026-07-20',
+  );
+  assert.equal(propertyToText({ type: 'date', date: { start: '2026-07-15', end: null } }), '2026-07-15');
+  assert.equal(propertyToText({ type: 'date', date: null }), '');
+});
+
+test('propertyToText — url / email / phone_number pass through, empty when null', () => {
+  assert.equal(propertyToText({ type: 'url', url: 'https://x.dev' }), 'https://x.dev');
+  assert.equal(propertyToText({ type: 'url', url: null }), '');
+  assert.equal(propertyToText({ type: 'email', email: 'a@b.io' }), 'a@b.io');
+  assert.equal(propertyToText({ type: 'email', email: null }), '');
+  assert.equal(propertyToText({ type: 'phone_number', phone_number: '+33 6' }), '+33 6');
+  assert.equal(propertyToText({ type: 'phone_number', phone_number: null }), '');
+});
+
+test('propertyToText — an unsupported type is empty', () => {
+  assert.equal(propertyToText({ type: 'files' }), '');
+  assert.equal(propertyToText({ type: 'formula' }), '');
+});
+
+// ── rowFields: drops title + empties, renders `key: value` joined by ` · ` ────
+test('rowFields renders non-title non-empty props as "key: value" joined by " · "', () => {
+  const fields = rowFields({
+    id: 'x',
+    properties: {
+      Name: { type: 'title', title: [{ plain_text: 'Ignored' }] },
+      SIRET: { type: 'rich_text', rich_text: [{ plain_text: '123' }] },
+      Empty: { type: 'rich_text', rich_text: [] },
+      Status: { type: 'select', select: { name: 'Active' } },
+    },
+  });
+  assert.equal(fields, 'SIRET: 123 · Status: Active');
+});
+
+test('rowFields is empty when the row has only its title', () => {
+  assert.equal(
+    rowFields({ id: 'x', properties: { Name: { type: 'title', title: [{ plain_text: 'Solo' }] } } }),
+    '',
   );
 });
 

--- a/local-mirror/src/test/notion-url.test.ts
+++ b/local-mirror/src/test/notion-url.test.ts
@@ -27,8 +27,13 @@ test('accepts an already-dashed id and leaves it canonical', () => {
   assert.equal(id, '0123abc0-b1c2-4d6e-8f0a-1b2c3d4e5f60');
 });
 
-test('throws when no page id can be found', () => {
-  assert.throws(() => extractPageId('https://www.notion.so/acme/no-id-here'));
+// A descriptive throw is the contract: a bare TypeError from a null-deref (or an empty
+// message) would leave the caller blind to WHICH url failed, so pin the wording.
+test('throws a descriptive error naming the offending url when no page id can be found', () => {
+  assert.throws(
+    () => extractPageId('https://www.notion.so/acme/no-id-here'),
+    /Cannot extract a Notion page id from:/,
+  );
 });
 
 // F6: the Notion API returns share URLs of the form `app.notion.com/p/<slug>-<id32>` that
@@ -74,6 +79,51 @@ test('absolutizes a relative Notion page-mention link `/<id32>` to www.notion.so
   );
 });
 
+// The relative match is anchored at BOTH ends (`^\/…$`): only a bare `/<id>` target is a
+// Notion mention. A hex run that merely appears after some other prefix, or a `/<id>/child`
+// deeper path, is a real site route and must be left alone.
+test('leaves a non-relative `foo/<id32>` path untouched (relative match anchored at start)', () => {
+  const url = 'foo/0123abc0b1c24d6e8f0a1b2c3d4e5f60';
+
+  assert.equal(canonicalizeNotionUrl(url), url);
+});
+
+test('leaves a deeper `/<id32>/child` path untouched (relative match anchored at end)', () => {
+  const url = '/0123abc0b1c24d6e8f0a1b2c3d4e5f60/child';
+
+  assert.equal(canonicalizeNotionUrl(url), url);
+});
+
+// The relative form also accepts the 36-char DASHED uuid; the output strips the dashes to the
+// canonical 32-hex slug notion.so expects.
+test('absolutizes a DASHED relative page-mention `/<uuid>` and strips its dashes', () => {
+  const url = '/0123abc0-b1c2-4d6e-8f0a-1b2c3d4e5f60';
+
+  assert.equal(canonicalizeNotionUrl(url), 'https://www.notion.so/0123abc0b1c24d6e8f0a1b2c3d4e5f60');
+});
+
+// The app.notion.com guard is anchored (`^https?://app.notion.com/`): a foreign URL that merely
+// EMBEDS an app.notion.com fragment is not a Notion share link and stays untouched. And the
+// scheme is optional-s (`https?`), so an http:// share URL is rewritten just like https://.
+test('leaves a non-Notion URL that merely embeds app.notion.com untouched (anchored at start)', () => {
+  const url = 'https://example.com/https://app.notion.com/p/Page-0123abc0b1c24d6e8f0a1b2c3d4e5f60';
+
+  assert.equal(canonicalizeNotionUrl(url), url);
+});
+
+test('canonicalizes an http:// (not https) app.notion.com share URL too', () => {
+  const url = canonicalizeNotionUrl(
+    'http://app.notion.com/p/Some-Page-0123abc0b1c24d6e8f0a1b2c3d4e5f60',
+  );
+
+  assert.equal(url, 'https://www.notion.so/0123abc0b1c24d6e8f0a1b2c3d4e5f60');
+});
+
+// Documented EQUIVALENT mutant (notion-url.ts:33 `canonical === url ? whole : …` → `false ? …`):
+// the `=== url` branch only returns the original matched slice `whole` as a micro-optimisation.
+// When `canonical === url`, the else branch rebuilds `](${canonical})`, which is byte-for-byte the
+// same string as `whole` — so no assertion can distinguish the two. Effective 46/46 on the
+// non-equivalent mutants.
 test('rewrites broken app.notion.com inline links in the body, preserving stable ones', () => {
   const md =
     'See [Spec](https://app.notion.com/p/Spec-0123abc0b1c24d6e8f0a1b2c3d4e5f60) ' +

--- a/local-mirror/src/test/remove-source.test.ts
+++ b/local-mirror/src/test/remove-source.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { aLocalMirror, aNotionPage } from './builder.js';
+import { aLocalMirror, aNotionPage, aNotionLocalMirror } from './builder.js';
 
 // Acceptance tests at the API port (ILocalMirror). `remove_source` (PRD §9) de-registers a
 // source from the config (the versioned source of truth). With `cleanup`, it also deletes the
@@ -35,11 +35,46 @@ test('removing a source with cleanup also deletes its files', async () => {
   assert.equal(harness.vaultFiles().size, 0, 'cleanup deletes every synced .md');
 });
 
-test('removing an unknown source is a graceful no-op', async () => {
-  const gss = aLocalMirror().build();
+test('removing an unknown source is a graceful no-op — even when OTHER sources exist', async () => {
+  // A non-empty config list is what makes this bite: the `some(c.name === name)` membership test
+  // must key on the NAME, not merely "is the list non-empty".
+  const harness = aLocalMirror().withNotionPages(aNotionPage({ id: 'p1' }));
+  const gss = harness.build();
+  await gss.sync('team-a');
 
   const result = await gss.removeSource('nope', true);
 
   assert.equal(result.removed, false);
   assert.equal(result.cleanedUp, false);
+  const remaining = await gss.listSources();
+  assert.deepEqual(remaining.map((s) => s.name), ['team-a'], 'the real source is untouched');
+});
+
+test('removing one of several declared sources removes only it, leaving the rest', async () => {
+  // With more than one source, membership must be ANY-match (some), not ALL-match (every):
+  // removing an existing source while others remain must still succeed.
+  const gss = aLocalMirror()
+    .withDeclaredSources(
+      aNotionLocalMirror({ name: 'team-a' }),
+      aNotionLocalMirror({ name: 'team-b' }),
+    )
+    .build();
+
+  const result = await gss.removeSource('team-a');
+
+  assert.equal(result.removed, true);
+  const remaining = await gss.listSources();
+  assert.deepEqual(remaining.map((s) => s.name), ['team-b']);
+});
+
+test('cleanup on a declared-but-never-synced source is a no-throw no-op delete', async () => {
+  // persisted state is null here (never synced); cleanup must iterate an empty item map, not
+  // dereference null — and still report cleanedUp true.
+  const gss = aLocalMirror().withDeclaredSources(aNotionLocalMirror()).build();
+
+  const result = await gss.removeSource('team-a', true);
+
+  assert.equal(result.removed, true);
+  assert.equal(result.cleanedUp, true);
+  assert.deepEqual(await gss.listSources(), []);
 });

--- a/local-mirror/src/test/server-boot.test.ts
+++ b/local-mirror/src/test/server-boot.test.ts
@@ -1,0 +1,95 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  buildDeps,
+  buildApi,
+  boot,
+  fatal,
+  createRealServer,
+  createRealTransport,
+  realBootDeps,
+  type BootServer,
+} from '../server.js';
+import { LocalMirror } from '../domain/local-mirror.js';
+import { FsConfigStore } from '../adapters/fs-config-store.js';
+import { FsStateStore } from '../adapters/fs-state-store.js';
+import { FsVaultWriter } from '../adapters/fs-vault-writer.js';
+import { SystemClock } from '../adapters/system-clock.js';
+import { notionConnectorFactory } from '../adapters/notion-gateway.js';
+
+// The composition root (server.ts) is boot glue, so its seams are extracted and exported:
+// buildDeps wires the real driven adapters, buildApi assembles the Domain Service,
+// createRealServer/createRealTransport/realBootDeps name the real wiring, boot() connects
+// the tool surface over a transport, fatal() reports + exits. Mutation: 0 % → 85.71 %
+// (10 killed + 2 timeout / 14). The 2 residual survivors are documented equivalents — the
+// `if (process.argv[1] === fileURLToPath(import.meta.url))` entry-point guard and its
+// `boot(realBootDeps).catch(fatal)` body: they run ONLY when server.ts IS the process, so
+// they are integration-only (the real stdio connect can't run under the unit suite without
+// hanging). Effective 12/12 = 100 % on non-equivalents.
+
+test('buildDeps wires each driven adapter to its concrete implementation', () => {
+  const deps = buildDeps();
+
+  assert.ok(deps.configStore instanceof FsConfigStore);
+  assert.ok(deps.stateStore instanceof FsStateStore);
+  assert.ok(deps.vaultWriter instanceof FsVaultWriter);
+  assert.ok(deps.clock instanceof SystemClock);
+  assert.equal(deps.connectorFor, notionConnectorFactory);
+});
+
+test('buildApi assembles the Domain Service from the (defaulted) real deps', () => {
+  const api = buildApi();
+
+  assert.ok(api instanceof LocalMirror);
+});
+
+test('boot connects the tool surface over the transport, then announces readiness', async () => {
+  const transport = { sentinel: true };
+  let connectedTo: unknown;
+  const server: BootServer = {
+    async connect(t) {
+      connectedTo = t;
+    },
+  };
+  const logged: string[] = [];
+
+  await boot({
+    createServer: () => server,
+    createTransport: () => transport,
+    log: (message) => logged.push(message),
+  });
+
+  assert.equal(connectedTo, transport);
+  assert.deepEqual(logged, ['[local-mirror] MCP server running on stdio']);
+});
+
+test('fatal reports the error and exits non-zero', () => {
+  const boom = new Error('stdio gone');
+  const logCalls: Array<[string, unknown]> = [];
+  const exitCodes: number[] = [];
+
+  fatal(
+    boom,
+    (message, err) => logCalls.push([message, err]),
+    (code) => exitCodes.push(code),
+  );
+
+  assert.deepEqual(logCalls, [['[local-mirror] Fatal:', boom]]);
+  assert.deepEqual(exitCodes, [1]);
+});
+
+test('createRealServer builds the real tool surface', () => {
+  assert.ok(createRealServer() instanceof McpServer);
+});
+
+test('createRealTransport builds the real stdio transport', () => {
+  assert.ok(createRealTransport() instanceof StdioServerTransport);
+});
+
+test('realBootDeps wires the named real factories (not inline arrows)', () => {
+  assert.equal(realBootDeps.createServer, createRealServer);
+  assert.equal(realBootDeps.createTransport, createRealTransport);
+  assert.equal(realBootDeps.log, console.error);
+});

--- a/local-mirror/src/test/setup-source.test.ts
+++ b/local-mirror/src/test/setup-source.test.ts
@@ -23,6 +23,11 @@ test('setting up a connectable source declares it and runs a first sync', async 
   const result = await gss.setupSource(aSetupRequest());
 
   assert.equal(result.ok, true);
+  // The success message walks the user through what happened, step by step.
+  assert.match(result.message, /Source "team-a" set up: scope confirmed \(1 page\(s\) in the zone\)/);
+  assert.match(result.message, /first sync ok — 1 written, 0 unchanged/);
+  assert.match(result.message, /Files live under mirrors\/team-a\//);
+  assert.match(result.message, /clickable citations/);
   const declared = await harness.declaredSources();
   assert.equal(declared.length, 1, 'the source must be written to the config file');
   assert.equal(declared[0].name, 'team-a');
@@ -39,6 +44,10 @@ test('setting up a zone whose root is not connected returns a clear message and 
 
   assert.equal(result.ok, false);
   assert.match(result.message, /not connected/i);
+  // The message tells the user exactly how to fix it: connect the root, then re-run setup.
+  assert.match(result.message, /Connections → add your\s+integration/);
+  assert.match(result.message, /run setup again/);
+  assert.match(result.message, /Access cascades over the whole sub-tree/);
   assert.equal((await harness.declaredSources()).length, 0, 'a failed scope test declares nothing');
   assert.equal(harness.vaultFiles().size, 0, 'no .md written when the scope test fails');
 });
@@ -52,7 +61,10 @@ test('setting up a zone whose token is invalid distinguishes auth error from "0 
   const result = await gss.setupSource(aSetupRequest());
 
   assert.equal(result.ok, false);
-  assert.match(result.message, /401|valid .*token/i);
+  // The error surfaces the connector's own message AND names the token env var + fix.
+  assert.match(result.message, /Could not reach the "team-a" zone: notion: 401 unauthorized/);
+  assert.match(result.message, /"GOLDEN_TEAM_A_NOTION_TOKEN" holds a valid Read-content token/);
+  assert.match(result.message, /connected to the integration in Notion \(••• → Connections\)/);
   assert.doesNotMatch(result.message, /returned 0 pages/, 'an auth error is not "root not connected"');
   assert.equal((await harness.declaredSources()).length, 0, 'a failed scope test declares nothing');
 });

--- a/local-mirror/src/test/status.test.ts
+++ b/local-mirror/src/test/status.test.ts
@@ -1,9 +1,25 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { aLocalMirror, aNotionPage } from './builder.js';
+import { aLocalMirror, aNotionPage, aNotionLocalMirror } from './builder.js';
 
 // Acceptance tests at the API port (ILocalMirror). `status` (PRD §9) reports a single
 // source's state — last sync, watermark, item count, lateness — without pulling anything.
+
+test('status resolves the RIGHT source by name when several are declared', async () => {
+  // With two declared sources, the lookup must match on the requested name — not just return
+  // the first declared source regardless.
+  const gss = aLocalMirror()
+    .withDeclaredSources(
+      aNotionLocalMirror({ name: 'team-a', title: 'Team A' }),
+      aNotionLocalMirror({ name: 'team-b', title: 'Team B' }),
+    )
+    .build();
+
+  const status = await gss.status('team-b');
+
+  assert.equal(status.name, 'team-b');
+  assert.equal(status.title, 'Team B');
+});
 
 test('status of a synced source reports watermark, item count and last sync status', async () => {
   const harness = aLocalMirror().withNotionPages(

--- a/maintainers/CONVENTIONS.md
+++ b/maintainers/CONVENTIONS.md
@@ -126,12 +126,62 @@ dismissal is the bug. I/O glue still hides logic — a `.md` filter, a `.obsidia
   When the obstacle is a real boundary (filesystem, chokidar, network), **extract the logic behind a
   small port / DI seam** and unit-test that; cover the thin adapter itself with one deterministic test
   (e.g. "the default factory builds a live, closeable watcher" — no event-timing).
+- **"Unreachable" is the diagnosis, not the exemption (broadened 2026-07).** The 2026-07 retrospective
+  found the same 0 %-driver beyond plain I/O: **pure branches unreachable via the public API**
+  (`aggregateHealth`'s `unknown` verdict), **top-level side-effect scripts never imported**
+  (`clear-example-notes`/`auto-push`/`auto-commit`), and **composition roots** (`server.ts` boot). Same
+  fix everywhere: **if a test can't reach a branch, that's a design smell** — extract a pure seam,
+  inject a port, or name every wiring factory (no inline arrows) until every branch is reachable. For a
+  top-level script: extract an injectable core (`runX(argv, deps)` + a `realXDeps` default) and shrink
+  the entry guard to one line; keep **one subprocess integration test** to kill the entry-body mutants a
+  pure import cannot.
 - **Coverage ≠ verification.** A suite can show high line coverage and still kill ~0 % of mutants. The
   objective signal is the **mutation score**, not coverage. See the plan
   [`plans/prospective/mutation-testing-stryker.md`](plans/prospective/mutation-testing-stryker.md).
 - **Two durable guardrails back this up** (Step 4 of that plan): a deterministic **sibling-test guard**
   (`rag/src/lib/lib-coverage-guard.test.ts` fails loud if a `src/lib` module has no `*.test.ts`), and a
   targeted **non-regression re-run** (`npm --prefix maintainers/mutation run mutate:changed`).
+
+## 5ter. Assertion quality — what the mutation retrospective taught (2026-07)
+
+The mutation audit + hardening of all three packages (plan
+[`plans/prospective/mutation-testing-stryker.md`](plans/prospective/mutation-testing-stryker.md),
+Step 6) found **recurring shapes** of surviving mutant. Two homes:
+
+- **The 5 language-agnostic assertion habits** (assert the message not the fact; assert the whole
+  object/call-sequence not one field; triangulate boundaries **and** operators; feed the null/absent
+  twin of every `?.`/`??`/default-arg; test collections with ≥2 unsorted elements + a decoy) live in
+  the **global `tdd-discipline` skill** (§ "Qualité des assertions") — they apply to every project.
+- **The repo-specific / infra-shaped ones** are recorded **here**:
+
+  1. **CLI/script fakes must key on the FULL command, and assert the whole call sequence.** A fake git
+     keyed on `args[0]` lets every *later* arg-string mutant survive (`--get`, `@{u}..HEAD`, the commit
+     `-m <message>`). Key the fake on `args.join(" ")` and `deepEqual` the full command list, message
+     included. Mirror real trailing-newline output so the production `.trim()`s are pinned.
+  2. **Composition roots / entry guards.** Name every wiring seam (no inline arrows Stryker can't
+     observe), inject a `BootDeps`, and guard the boot behind `import.meta.url` so the module is
+     import-testable. The entry guard itself is an **accepted equivalent** (runs only when the file IS
+     the process) — earn it back with **one** subprocess integration test where it matters (that lone
+     test is the whole gap between `auto-commit` 98 % and `auto-push` 92 %).
+  3. **LLM-facing string surfaces** (MCP tool names + every tool/field description) never affect a
+     return value, so behavioural tests miss them — **assert them explicitly** (drive the real
+     registered surface via an in-memory `Client`/`InMemoryTransport`, assert names + non-empty
+     descriptions). They steer the model; a blanked description is a silent contract regression.
+
+**Equivalent-mutant literacy — don't chase these** (document + count as "effective 100 % on
+non-equivalents"): the default-wiring of an injected port (only exercised in a real I/O run), a
+`?? []`/`?? null` whose result is immediately `.map().join('')`ed back to the same string, a greedy
+regex masked by a downstream `.trim()`, real-SDK/real-network construction (`new Client({auth})`),
+`import.meta.url` entry guards, and `Number()`/parse that already trims. **Tooling trap:** Stryker
+**inflates** the score via false timeouts (a bogus 87.5–100 % that masks the honest ~56 %) — bridle
+`concurrency`/`timeout` in the config before trusting a run.
+
+**Deterministic guard (ADR 0009 spirit).** Only one cluster is cheaply catchable mechanically — C1
+(bare `throws`/`rejects`). [`scripts/lib/assert-matcher-lint.mjs`](../scripts/lib/assert-matcher-lint.mjs)
++ its `*.test.mjs` guard fail CI loud if any engine test file calls `assert.throws(…)`/`assert.rejects(…)`
+with no matcher/2nd argument (dev-only, excluded from the brain copy via `DEV_ONLY_PREFIXES`). The
+other clusters stay **written rules** (no cheap reliable check) — the on-demand net is
+`npm --prefix maintainers/mutation run mutate:changed`.
 
 ## 6. ADRs carry a `Scope:` field
 

--- a/maintainers/CONVENTIONS.md
+++ b/maintainers/CONVENTIONS.md
@@ -115,6 +115,24 @@ language** → respect the locale. A PR or comment left in French is a **defect 
   the suite stays green at `exit 0`; the flag is removed at the apply step. No history rewriting —
   green-only from here on.
 
+## 5bis. Test the glue too — "pure I/O" is not an exemption
+
+The 2026-06-23 mutation audit found `document-scanner` and `vault-watcher` at a **0 % mutation score**:
+they had **no test at all**, waved off in their own comments as *"pure I/O glue, not unit-tested"*. That
+dismissal is the bug. I/O glue still hides logic — a `.md` filter, a `.obsidian` exclusion, an
+`isIgnoredPath` predicate, event wiring — and untested logic is where silent regressions live.
+
+- **No "it's just glue" pass.** Anything with a branch, a filter, a mapping or a wiring gets a test.
+  When the obstacle is a real boundary (filesystem, chokidar, network), **extract the logic behind a
+  small port / DI seam** and unit-test that; cover the thin adapter itself with one deterministic test
+  (e.g. "the default factory builds a live, closeable watcher" — no event-timing).
+- **Coverage ≠ verification.** A suite can show high line coverage and still kill ~0 % of mutants. The
+  objective signal is the **mutation score**, not coverage. See the plan
+  [`plans/prospective/mutation-testing-stryker.md`](plans/prospective/mutation-testing-stryker.md).
+- **Two durable guardrails back this up** (Step 4 of that plan): a deterministic **sibling-test guard**
+  (`rag/src/lib/lib-coverage-guard.test.ts` fails loud if a `src/lib` module has no `*.test.ts`), and a
+  targeted **non-regression re-run** (`npm --prefix maintainers/mutation run mutate:changed`).
+
 ## 6. ADRs carry a `Scope:` field
 
 Every ADR carries a `- **Scope:**` line right under `STATUS`, with an **explicit** value (never the

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -4,6 +4,8 @@
 > brain copy** (`scripts/lib/tracked-files.mjs` → `DEV_ONLY_PREFIXES` has `maintainers/`),
 > so neither the tooling nor these results are ever deployed into a generated brain.
 > See the plan: [`../plans/prospective/mutation-testing-stryker.md`](../plans/prospective/mutation-testing-stryker.md).
+> For **what the survivors taught us** (recurring shapes → durable rules), see the
+> retrospective: [`RETROSPECTIVE.md`](RETROSPECTIVE.md).
 
 ## Baseline run — 2026-06-23 (engine at v3.4.0, commit `49e46a9`)
 

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -35,6 +35,27 @@ StrykerJS `node:test` runner). Scores are the durable test-quality signal the pr
 - `auto-commit.mjs` **47.5 %** (21 survivors)
 - → all three are the git/vault **side-effect** scripts, hard to unit-test.
 
+## Step 3 hardening — local-mirror re-audit — 2026-07-15
+
+After hardening the three Step-2 worst-files, a full-package re-audit lifts **local-mirror
+from 67.63 % → 78.69 %** (550 killed + 4 timeout / 704 covered, 150 survived). Per-file:
+
+| Area | File | Before | After | Note |
+|---|---|---|---|---|
+| entry | `index.ts` | 2.2 % | **100 %** | in-memory Client drives the 7 tools end-to-end |
+| entry | `server.ts` | 0 % | **85.71 %** | boot seams extracted; 2 equiv. = the entry-point guard |
+| adapters | `notion-gateway.ts` | 21.1 % | **97.44 %** | seams injected; 1 equiv. = `new Client({auth})` |
+| adapters | `notion-connector.ts` | — | 85.29 % | already decent |
+| adapters | (fs-*, system-clock) | — | 81–100 % | already decent |
+| domain | `local-mirror.ts` | — | **77.41 %** | 61 survivors — the big Domain Service, next tier |
+| lib | `notion-transformers.ts` | 57.3 % | **57.26 %** | 50 survivors — now the weakest, next tier |
+| lib | `notion-url.ts` | — | 74.47 % | 12 survivors |
+| lib | `fresh-env.ts` / `config.ts` | — | 62.5 % / 71.4 % | small |
+
+Enumerated Step-2 worst-files (`server.ts`, `index.ts`, `notion-gateway.ts`) are **done**.
+The remaining weak tier (`notion-transformers.ts` 57 %, `local-mirror.ts` 77 %, `notion-url.ts`
+74 %) was not flagged in the Step-2 worst-first list; hardening it is optional follow-up.
+
 ## How each package is run (and why)
 
 | Package | Isolation | Why |

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -47,6 +47,10 @@ StrykerJS `node:test` runner). Scores are the durable test-quality signal the pr
 - **Concurrency must be tuned for big suites.** The 513-test `scripts` suite at Stryker's default
   13 concurrent runners → CPU oversubscription → **mass FALSE timeouts** (a bogus 99.97 % score).
   Fixed with `concurrency: 5`, `timeoutMS: 30000`, `timeoutFactor: 4` → genuine 97.27 %.
+  **`rag` hits the same trap** (the command runner re-runs the whole rag suite per mutant): hardening
+  `embedder` scored a bogus **100 %** at defaults (98/111 FALSE timeouts) vs an honest **81.98 %**
+  once tuned. `stryker.rag.config.mjs` now carries `concurrency: 4` / `timeoutMS: 30000` /
+  `timeoutFactor: 4` — a timeout there now means a real infinite loop, not a starved runner.
 - **Orphaned children.** Mutants that broke `child-cleanup` left `stub-mcp-server.mjs` fixtures
   spinning at 100 % CPU after the run. Kill leftovers: `pkill -f stub-mcp-server.mjs`.
 - **Stryker only mutates files under its project root** → all configs run from the **repo root**

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -35,6 +35,22 @@ StrykerJS `node:test` runner). Scores are the durable test-quality signal the pr
 - `auto-commit.mjs` **47.5 %** (21 survivors)
 - → all three are the git/vault **side-effect** scripts, hard to unit-test.
 
+## Step 3 hardening — scripts worst-files — 2026-07-15
+
+The three git/vault side-effect scripts, hardened by extracting an injectable core
+(git runner / cwd / spawn behind a port) and TDD-ing the glue. Measured per file in a
+**fresh disposable worktree** (`--inPlace`) — never reused (a `clear-example-notes`
+mutant deletes the worktree's `vault/`, so run-1 corrupts run-2's baseline).
+
+| File | Before | After | Note |
+|---|---|---|---|
+| `clear-example-notes.mjs` | 28.6 % | **100 %** | 46/46, no equivalents — `runClear(argv, deps)` + `realClearDeps` |
+| `auto-push.mjs` | 41.4 % | **92.39 %** | 85/92, 7 equiv. (redundant `.trim()` under `Number()` + the `import.meta.url` guard) |
+| `auto-commit.mjs` | 47.5 % | **98.21 %** | 55/56, 1 equiv. (the `if (isEntryPoint(...))→if(true)` guard) |
+
+`scripts/lib/**` was already 100 % → **`scripts/**` is now fully hardened**. Enumerated
+Step-2 worst-files across all three packages are done (see the plan's Step 3).
+
 ## Step 3 hardening — local-mirror re-audit — 2026-07-15
 
 After hardening the three Step-2 worst-files, a full-package re-audit lifts **local-mirror

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -64,7 +64,7 @@ from 67.63 % → 78.69 %** (550 killed + 4 timeout / 704 covered, 150 survived).
 | adapters | `notion-connector.ts` | — | 85.29 % | already decent |
 | adapters | (fs-*, system-clock) | — | 81–100 % | already decent |
 | domain | `local-mirror.ts` | — | **77.41 %** | 61 survivors — the big Domain Service, next tier |
-| lib | `notion-transformers.ts` | 57.3 % | **57.26 %** | 50 survivors — now the weakest, next tier |
+| lib | `notion-transformers.ts` | 57.3 % | **94.87 %** | hardened 2026-07-15 (helpers exported + case-tested; 6 equiv.) |
 | lib | `notion-url.ts` | — | 74.47 % | 12 survivors |
 | lib | `fresh-env.ts` / `config.ts` | — | 62.5 % / 71.4 % | small |
 

--- a/maintainers/mutation/RETROSPECTIVE.md
+++ b/maintainers/mutation/RETROSPECTIVE.md
@@ -1,0 +1,110 @@
+# Mutation testing — retrospective: what the survivors taught us (Step 6)
+
+> **Dev-only.** This whole folder lives under `maintainers/` and is **excluded from the brain copy**
+> (`scripts/lib/tracked-files.mjs` → `DEV_ONLY_PREFIXES`), so none of it ever reaches a generated brain.
+> Sister docs: the scores in [`RESULTS.md`](RESULTS.md); the plan
+> [`../plans/prospective/mutation-testing-stryker.md`](../plans/prospective/mutation-testing-stryker.md) (Step 6).
+
+**Why this doc exists.** The point of the whole mutation exercise was never the score — it was to name
+**what was systematically weak in our tests / TDD discipline** so the same gaps stop recurring. This is the
+durable trace of that diagnosis, of the rules it produced, and of where they were engraved so they act as a
+net going forward.
+
+**Method.** We read across all 14 `test(...)` hardening commits on `test/rag-mutation-hardening`
+(rag 8 files, local-mirror 6, scripts 3) with three parallel readers, classifying, for every survivor that
+was killed, the mutant shape and the assertion/seam that killed it. **All 6 candidate clusters were
+confirmed, none refuted, plus 3 new infra-shaped clusters.**
+
+---
+
+## The diagnosis — recurring survivor shapes
+
+### The 6 language-agnostic assertion habits
+
+| # | Survivor shape (what stayed alive) | Root-cause TDD habit | The rule that would have prevented it |
+|---|---|---|---|
+| **C6** *(most frequent — 8/8 rag files)* | `?.` / `??` / default-arg / `&&`‑`\|\|` never broken by a test | happy-path-only inputs; the present case written, the absent one never | For every optional, write the **null/absent twin** next to the present one. |
+| **C3** *(2nd)* | `>` vs `>=`, `&&` vs `\|\|`, regex `^`/`$` anchors survive | one-sided example that doesn't distinguish the operator | **Triangulate** boundaries *and* operators: the on-the-boundary (equal) case, the just-outside case, an asymmetric discriminator (`a·b ≠ b·a`, contains-but-not-a-segment, mid-line `#`). |
+| **C4** *(the #1 score driver — every 0% file)* | whole branches unreachable through the public API | "it's pure glue / a top-level script — not worth a test" | **Unreachable is the diagnosis, not the exemption.** Extract a pure seam / inject a port / name every wiring factory until every branch is reachable. |
+| **C2** | mutants on the *other* fields survive | asserting the one field I cared about | `deepEqual` the **whole object / the whole call sequence** (args included), not one field. |
+| **C5** | `some`/`every`/`find`/sort identical on a 0–1 element or pre-sorted list | trivial collection under test | Test with **≥2 elements, deliberately unsorted, + an out-of-scope decoy**. |
+| **C1** *(least frequent)* | `throw ''` survives a bare `assert.throws` | asserting the fact, not the message | **Matcher mandatory** on `throws`/`rejects` (regex/type); results carry their body; logs their exact payload. |
+
+### The 3 new, infra-shaped clusters
+
+1. **CLI/script fakes keyed on a PARTIAL command.** A fake `git` keyed on `args[0]` lets every *later*
+   arg-string mutant survive (`--get`, `@{u}..HEAD`, the commit `-m <message>`). → key the fake on
+   `args.join(" ")` and `deepEqual` the full command list; mirror real trailing-newline output so the
+   production `.trim()`s are pinned.
+2. **Composition roots / entry guards.** Inline boot arrows and `import.meta.url` guards. → name every
+   wiring seam (no inline arrows Stryker can't observe), inject a `BootDeps`, keep the module
+   import-testable. The entry guard itself is an accepted equivalent — earn it back with **one** subprocess
+   integration test (that lone test is the whole gap between `auto-commit` 98% and `auto-push` 92%).
+3. **LLM-facing string surfaces** (MCP tool names + every tool/field description). They never affect a
+   return value, so behavioural tests miss them. → assert them explicitly (drive the real registered surface
+   via an in-memory `Client`/`InMemoryTransport`; assert names + non-empty descriptions).
+
+### Two pieces of mutation literacy (so we don't waste effort)
+
+- **Equivalent mutants — do NOT chase them** (document + count "effective 100% on non-equivalents"): the
+  default-wiring of an injected port (real-I/O-only), a `?? []`/`?? null` immediately `.map().join('')`ed
+  back to the same string, a greedy regex masked by a downstream `.trim()`, real-SDK/real-network
+  construction (`new Client({auth})`), `import.meta.url` guards, `Number()`/parse that already trims.
+- **Tooling trap:** Stryker **inflates** the score via false timeouts (a bogus 87.5–100% masking the honest
+  ~56%). Bridle `concurrency`/`timeout` in the config before trusting a run.
+
+> **The objective signal is the mutation score, not line coverage** — a suite can cover 100% of lines and
+> kill ~0% of mutants (exactly what `document-scanner`/`vault-watcher` did at 0%).
+
+---
+
+## What was done — so it can't recur
+
+Rules engraved with a **belt-and-suspenders split** (mirroring the `language.md` model), agreed with Thomas
+on 2026-07-15:
+
+- **Global (all projects)** — the 5 language-agnostic habits (C1/C2/C3/C5/C6 + reachability-as-design-smell)
+  live in the **`tdd-discipline` skill**, § "Qualité des assertions — leçons du mutation testing"; the global
+  `use-case-driven-harness/rules/testing.md` points to it.
+- **Repo-local** — [`../CONVENTIONS.md`](../CONVENTIONS.md) **§5ter** carries the 3 infra-shaped clusters +
+  the equivalent-mutant literacy + the Stryker false-timeout trap; **§5bis** ("test the glue too") was
+  **broadened** to cover C4 beyond plain I/O (pure unreachable branches, top-level scripts, composition roots).
+- **Deterministic guard (ADR 0009 spirit)** — only C1 is cheaply mechanical, so it got a lint:
+  [`../../scripts/lib/assert-matcher-lint.mjs`](../../scripts/lib/assert-matcher-lint.mjs) + its repo-wide
+  `*.test.mjs` guard **fail CI loud** if any engine test file calls `assert.throws(…)`/`assert.rejects(…)`
+  with no matcher/2nd argument. Built in TDD baby-steps (paren-depth + string-aware scanner; the
+  trailing-comma edge was caught fail-first); dev-only (excluded from the brain copy via `DEV_ONLY_PREFIXES`).
+  The other clusters stay **written rules** (no cheap reliable check) — the on-demand net is
+  `npm --prefix maintainers/mutation run mutate:changed`.
+
+The scores that produced this diagnosis are in [`RESULTS.md`](RESULTS.md); every per-file "before → after"
+and its residual equivalents are in the plan's Step 3.
+
+---
+
+## Changes shipped in this retrospective (the full recap)
+
+**In this repo (`second-brain-generator`, branch `test/rag-mutation-hardening`):**
+
+- **`scripts/lib/assert-matcher-lint.mjs`** *(new)* — the deterministic C1 guard: a paren-depth +
+  string-aware scanner exposing `findLooseAssertions(source)`.
+- **`scripts/lib/assert-matcher-lint.test.mjs`** *(new)* — 8 unit tests (TDD baby-steps) + a repo-wide
+  guard that fails CI loud on any loose `assert.throws/rejects` across the engine test suites.
+- **`scripts/lib/tracked-files.mjs`** — added `scripts/lib/assert-matcher-lint` to `DEV_ONLY_PREFIXES`
+  so the guard (and its test) never ship into a generated brain.
+- **`maintainers/CONVENTIONS.md`** — **§5bis** broadened ("unreachable is the diagnosis, not the
+  exemption" — pure branches, top-level scripts, composition roots); **§5ter** added (the 3 infra-shaped
+  clusters + equivalent-mutant literacy + the Stryker false-timeout trap + the lint).
+- **`maintainers/mutation/RETROSPECTIVE.md`** *(new — this file)*.
+- **`maintainers/mutation/RESULTS.md`** — pointer to this retrospective.
+- **`maintainers/plans/prospective/mutation-testing-stryker.md`** — Step 6 ticked with outcome.
+
+**In the personal harness (`use-case-driven-harness`, separate repo — French corpus):**
+
+- **`skills/tdd-discipline/SKILL.md`** — new § "Qualité des assertions — leçons du mutation testing"
+  (the 5 language-agnostic habits).
+- **`rules/testing.md`** — pointer to that new section.
+
+**Verification:** `scripts/**` suite green (560/560), including the new lint guard and `tracked-files`.
+The doc changes touch only `maintainers/` (never in the rag/local-mirror packages), so no engine re-run
+was needed.

--- a/maintainers/mutation/mutate-changed.mjs
+++ b/maintainers/mutation/mutate-changed.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Targeted mutation re-run for a NON-REGRESSION check: mutate only the production
+// files that changed versus a base ref, grouped by package. Fast feedback on the
+// files you actually touched, instead of the full 30s+ per-package audit.
+//
+//   node maintainers/mutation/mutate-changed.mjs [baseRef]   (default: main)
+//
+// Exit 0 if nothing relevant changed, or if every changed file's mutants are killed
+// to the package threshold; non-zero (Stryker's own) otherwise. `scripts/**` is
+// reported but NOT auto-run here: it is destructive inPlace and must run in a
+// disposable git worktree (see RESULTS.md). Dev-only; never shipped to a brain.
+import { execFileSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const baseRef = process.argv[2] ?? "main";
+
+const strykerBin = resolve(
+  repoRoot,
+  "maintainers/mutation/node_modules/@stryker-mutator/core/bin/stryker.js"
+);
+
+// package key -> { config, match(file) }
+const PACKAGES = [
+  {
+    key: "rag",
+    config: "maintainers/mutation/stryker.rag.config.mjs",
+    match: (f) => f.startsWith("rag/src/lib/"),
+  },
+  {
+    key: "local-mirror",
+    config: "maintainers/mutation/stryker.local-mirror.config.mjs",
+    match: (f) => f.startsWith("local-mirror/src/"),
+  },
+];
+
+const isProdTs = (f) =>
+  f.endsWith(".ts") && !f.endsWith(".test.ts") && !f.endsWith(".d.ts");
+
+function changedFiles() {
+  const out = execFileSync(
+    "git",
+    ["diff", "--name-only", `${baseRef}...HEAD`],
+    { cwd: repoRoot, encoding: "utf8" }
+  );
+  return out.split("\n").map((s) => s.trim()).filter(Boolean);
+}
+
+const changed = changedFiles().filter(isProdTs);
+
+const droppedScripts = changed.filter((f) => f.startsWith("scripts/"));
+if (droppedScripts.length) {
+  console.log(
+    `⚠️  ${droppedScripts.length} scripts/** file(s) changed — run those in a disposable worktree (see RESULTS.md), skipped here:\n   ${droppedScripts.join("\n   ")}`
+  );
+}
+
+let ranSomething = false;
+for (const pkg of PACKAGES) {
+  const files = changed.filter(pkg.match);
+  if (!files.length) continue;
+  ranSomething = true;
+  console.log(`\n▶ Mutating ${files.length} changed ${pkg.key} file(s):\n   ${files.join("\n   ")}`);
+  // --mutate takes ONE comma-separated list (a repeated flag would keep only the
+  // last). Run from repo root (Stryker's project root).
+  const args = [strykerBin, "run", pkg.config, "--mutate", files.join(",")];
+  execFileSync("node", args, { cwd: repoRoot, stdio: "inherit" });
+}
+
+if (!ranSomething && !droppedScripts.length) {
+  console.log(`No changed production files under rag/ or local-mirror/ vs ${baseRef} — nothing to mutate.`);
+}

--- a/maintainers/mutation/package.json
+++ b/maintainers/mutation/package.json
@@ -8,7 +8,8 @@
     "mutate:rag": "cd ../.. && node maintainers/mutation/node_modules/@stryker-mutator/core/bin/stryker.js run maintainers/mutation/stryker.rag.config.mjs",
     "mutate:local-mirror": "cd ../.. && node maintainers/mutation/node_modules/@stryker-mutator/core/bin/stryker.js run maintainers/mutation/stryker.local-mirror.config.mjs",
     "mutate:scripts": "cd ../.. && node maintainers/mutation/node_modules/@stryker-mutator/core/bin/stryker.js run maintainers/mutation/stryker.scripts.config.mjs",
-    "mutate:all": "npm run mutate:rag && npm run mutate:local-mirror && npm run mutate:scripts"
+    "mutate:all": "npm run mutate:rag && npm run mutate:local-mirror && npm run mutate:scripts",
+    "mutate:changed": "node mutate-changed.mjs"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^9.6.1"

--- a/maintainers/mutation/stryker.local-mirror.config.mjs
+++ b/maintainers/mutation/stryker.local-mirror.config.mjs
@@ -11,6 +11,15 @@ export default {
   mutate: ['local-mirror/src/**/*.ts', '!local-mirror/src/**/*.test.ts', '!local-mirror/src/test/**'],
   inPlace: true,
   coverageAnalysis: 'off',
+  // Same tuning as stryker.rag.config.mjs: the command runner re-runs the WHOLE
+  // local-mirror suite per mutant, so Stryker's default 13 runners over-subscribe the
+  // CPU and inflate genuine kills into FALSE timeouts (server.ts scored a bogus 87.5%
+  // with 14/16 "timeouts" at defaults, masking whether the tests truly kill). Fewer
+  // runners + a generous timeout keep a timeout meaning "real infinite loop", not
+  // "starved runner". See RESULTS.md gotchas.
+  concurrency: 4,
+  timeoutMS: 30000,
+  timeoutFactor: 4,
   tempDirName: 'maintainers/mutation/.stryker-tmp',
   reporters: ['clear-text', 'progress', 'html'],
   htmlReporter: { fileName: 'maintainers/mutation/reports/mutation-local-mirror.html' },

--- a/maintainers/mutation/stryker.rag.config.mjs
+++ b/maintainers/mutation/stryker.rag.config.mjs
@@ -15,6 +15,14 @@ export default {
   mutate: ['rag/src/lib/*.ts', '!rag/src/lib/*.test.ts'],
   inPlace: true,
   coverageAnalysis: 'off',
+  // Tuned like the scripts config: the command runner re-runs the WHOLE rag suite per
+  // mutant, so Stryker's default 13 runners over-subscribe the CPU and inflate genuine
+  // kills into FALSE timeouts (embedder scored a bogus 100% at defaults — 98/111 timed
+  // out — vs an honest 81.98% here). Fewer runners + a generous timeout keep timeouts
+  // meaning "real infinite loop", not "starved runner". See RESULTS.md gotchas.
+  concurrency: 4,
+  timeoutMS: 30000,
+  timeoutFactor: 4,
   tempDirName: 'maintainers/mutation/.stryker-tmp',
   reporters: ['clear-text', 'progress', 'html'],
   htmlReporter: { fileName: 'maintainers/mutation/reports/mutation-rag.html' },

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -200,7 +200,19 @@ built-in `node --test`. Two realistic paths, in tension:
       the three the Step 2 audit flagged weak). Remaining weak tier (NOT in the Step-2 worst-first
       list, optional follow-up): `notion-transformers.ts` 57 % (50 survivors), `local-mirror.ts` 77 %
       (61 survivors), `notion-url.ts` 74 %.
-  - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
+  - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory —
+    a `clear-example-notes` mutant deletes the real `vault/`; never reuse a worktree, its vault
+    gets corrupted by run-1 mutants)*. Worst-first: `clear-example-notes` 28.6 %, `auto-push`
+    41.4 %, `auto-commit` 47.5 % (the git/vault side-effect scripts).
+    - [x] `clear-example-notes.mjs` **28.6 % → 100 %** (46/46, no equivalents) — extracted
+      `main` into an injectable `runClear(argv, deps)` with a `realClearDeps` real-wiring default
+      (cwd/clear/spawnSync/platform/log/error behind a port); TDD'd every branch with a
+      recording fake (nothing-to-do, per-file + count report, `npm`/`npm.cmd`+shell by platform,
+      spawn arg shape, reindex-failure → 1, `--no-reindex` skip) + a vault-scope test (an
+      exemple-tagged note OUTSIDE `vault/` is left untouched) + direct `realClearDeps` tests
+      (console forwarding, real fn identity). _(2026-07-15)_
+    - [ ] `auto-push.mjs` **41.4 %** (51 survivors).
+    - [ ] `auto-commit.mjs` **47.5 %** (21 survivors).
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
   "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:
   - [x] **Floor guard (runs every CI test pass, free): a sibling test is mandatory.** `rag/src/lib/lib-coverage-guard.test.ts`

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -200,9 +200,9 @@ built-in `node --test`. Two realistic paths, in tension:
       97.44 %) lifted the package. RESULTS.md refreshed with the per-file table. _(2026-07-15)_
     - **3-local-mirror enumerated worst-files DONE** (`server.ts`, `index.ts`, `notion-gateway.ts` —
       the three the Step 2 audit flagged weak).
-    - [ ] **3-local-mirror OPTIONAL weak tier** (NOT in the Step-2 worst-first list — a follow-up
+    - [x] **3-local-mirror OPTIONAL weak tier DONE** (NOT in the Step-2 worst-first list — a follow-up
       Thomas green-lit 2026-07-15). `local-mirror` runs `inPlace` (non-destructive, files restored),
-      no worktree needed; config bridled (concurrency 4). Worst-first:
+      no worktree needed; config bridled (concurrency 4). Worst-first: _(2026-07-15)_
       - [x] `notion-transformers.ts` **57.26 % → 94.87 %** (111/117, 6 documented equivalents) —
         exported the pure helpers (`notionPageUrl`, `rowTitle`, `propertyToText`, `rowFields`) and
         unit-tested each `propertyToText` switch case (rich_text/select/status/multi_select/number
@@ -219,7 +219,19 @@ built-in `node --test`. Two realistic paths, in tension:
         throw cluster by pinning the error message. The 1 residual survivor is a documented
         equivalent (line 33 `canonical === url ? whole : …` rebuilds the identical string) →
         effective 46/46 = 100 % on non-equivalents. _(2026-07-15)_
-      - [ ] `local-mirror.ts` **77 %** (61 survivors) — the big Domain Service.
+      - [x] `local-mirror.ts` **77 % → 98.52 %** (264 killed + 2 timeout / 4 survived) — the big
+        Domain Service. Exported the pure helpers (`aggregateHealth`, `aggregateStatus`,
+        `aggregateReports`, `failedReport`, `maxLastEditedTime`, `rootPageIdOf`,
+        `configFromRequest`, `errorMessage`) and unit-tested them directly (branches like
+        `aggregateHealth`'s `unknown` verdict are unreachable via the public API); strengthened the
+        `setupSource`/`healthCheck` message + per-check-detail assertions; added sync/freshness edge
+        tests (unknown source, empty-perimeter-never-synced stays `ok`, NEW-vs-TRACKED write-error
+        persistence, frozen watermark on partial, `sync("all")` over rejecting sources, empty remote
+        not-behind); covered `removeSource` some-not-every + null-state cleanup and `configOrThrow`
+        name lookup; added a `withUnreadableConfig` builder seam. The 4 residual survivors are
+        documented equivalents (L110 ×2 post-upsert sync never `failed`; L388 length-0 shortcut ==
+        `every([])`; L398 `>` vs `>=` on equal values) → effective 100 % on non-equivalents.
+        _(2026-07-15)_
   - [x] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory —
     a `clear-example-notes` mutant deletes the real `vault/`; never reuse a worktree, its vault
     gets corrupted by run-1 mutants)*. Worst-first: `clear-example-notes` 28.6 %, `auto-push`

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -184,7 +184,17 @@ built-in `node --test`. Two realistic paths, in tension:
       and each `callTool` maps its (snake_case) args to the right port method and returns the exact
       `asText` envelope. End-to-end kills names, descriptions, zod schemas, handlers and `asText`.
       _(2026-07-15)_
-    - [ ] Next local-mirror survivor: `notion-gateway` (21 %).
+    - [x] `notion-gateway.ts` **21 % → 97.44 %** (38/38, 1 documented equivalent) — the real
+      `@notionhq/client` adapter: exported the pagination logic behind a minimal `NotionDbClient`
+      slice (data-source paging + older-shape fallback) and injected a notion-to-md factory into
+      `NotionSdkGateway` so the transformer wiring (`parseChildPages`, the 3 custom transformers,
+      each invoked to prove delegation), `search` arg-mapping/response and the `pageToMarkdown`
+      `?? ''` fallback are all unit-testable. The 1 residual survivor is the `new Client({auth})`
+      real-SDK construction (live-network-only) → effective 38/38 = 100 % on non-equivalents.
+      _(2026-07-15)_
+    - **3-local-mirror enumerated worst-files DONE** (`server.ts`, `index.ts`, `notion-gateway.ts` —
+      the three the Step 2 audit flagged weak). A full-`local-mirror` re-audit (refresh RESULTS.md)
+      is the natural closer before moving to 3-scripts.
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
   "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -168,6 +168,17 @@ built-in `node --test`. Two realistic paths, in tension:
       not flagged weak by the Step 2 audit; a full-`rag` re-audit (refresh RESULTS.md) is the
       natural closer before moving on.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
+    - [x] `server.ts` **0 % → 85.71 %** (10 killed + 2 timeout / 14) — composition root: extracted
+      + exported the boot seams (`buildDeps`, `buildApi`, `boot(BootDeps)`, `fatal`) and named the
+      real wiring (`createRealServer`, `createRealTransport`, `realBootDeps`) so no inline arrows
+      survive; TDD'd with fakes (connect spy, log/exit spies, `instanceof` on the real factories).
+      Guarded the top-level boot behind an `import.meta.url` entry-point check so importing for tests
+      is side-effect-free. Also tuned `stryker.local-mirror.config.mjs` (concurrency 4 / timeout 30 s)
+      to kill the false-timeout trap (bogus 87.5 % with 14/16 "timeouts" at defaults → honest 56 %
+      pre-refactor). The 2 residual survivors are documented equivalents: the entry-point guard +
+      its `boot(realBootDeps).catch(fatal)` body (run only when server.ts IS the process) → effective
+      12/12 = 100 % on non-equivalents. _(2026-07-15)_
+    - [ ] Next local-mirror survivors: `index.ts` (2.2 %), `notion-gateway` (21 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
   "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -286,49 +286,48 @@ built-in `node --test`. Two realistic paths, in tension:
     (rag/src/lib hardening in progress under Step 3-rag).
 - [ ] **Step 5 (conditional) — Escalate to Vitest (path B)** *only if* the command-runner audit is too
   slow to run regularly. Spin it off as its own migration plan; do not scope-creep it here.
-- [ ] **Step 6 — Retrospective: what the surviving mutants reveal about our TDD practice → durable
-  rules.** _(requested by Thomas 2026-07-15; do NOT start before the current `/clear`.)_ The point of
-  the whole exercise is not the score — it's to name **what was systematically weak in the tests /
-  the TDD discipline** so the same gaps stop recurring. Read across every hardening commit on
-  `test/rag-mutation-hardening` (Step 3 rag/local-mirror/scripts + the local-mirror weak tier), find
-  the RECURRING shapes of survivor, root-cause each to a test-writing / TDD habit, then turn each into
-  a durable rule and engrave it where it belongs.
-  - [ ] **Gather the evidence.** `git log --oneline main..test/rag-mutation-hardening` → for each
-    `test(...)` commit, diff the test files and classify what assertion/seam was ADDED to kill the
-    survivors (the commit bodies already summarise the "before → after" and the residual equivalents).
-  - [ ] **Cluster the survivor patterns** (candidate recurring root causes to CONFIRM or refute — not
-    conclusions yet):
-    - [ ] **Loose outcome assertions** — asserting `throws` without a message matcher, or `ok === true`
-      without the message body → StringLiteral/`throw ''` mutants survive. (Seen in `notion-url`
-      `extractPageId`, `setupSource`/`healthCheck` messages.)
-    - [ ] **Partial return-shape assertions** — checking one field, not the whole object → ObjectLiteral
-      `{}` / `status: ""` mutants survive. (Seen in `sync` failed report, `failedReport`.)
-    - [ ] **No triangulation on boundaries/operators** — a single example value leaves `>` vs `>=`,
-      `> 0` vs `>= 0`, `===` vs `!==` alive. (Seen in `maxLastEditedTime`, the vanish guard.)
-    - [ ] **Untested pure "glue" / logic behind unexported functions** — whole branches unreachable
-      through the public API (the original 0 % root cause + `aggregateHealth`/`aggregateStatus`
-      unknown/mixed verdicts). Cross-check against the existing "test the glue too" convention: is it
-      too narrow (only "extract I/O", not "unreachable pure branches")?
-    - [ ] **Membership/lookup tested only on empty or single-element collections** — `some`/`every`,
-      `find` first-vs-right survive until a 2+ element case exists. (Seen in `removeSource`,
-      `configOrThrow`.)
-    - [ ] **Optional-chaining / default-argument / `??`-vs-`&&` branches never exercised** with the
-      null/absent input. (Seen in null-state cleanup, the frozen-watermark `?? null`.)
-  - [ ] **Root-cause each cluster to a TDD habit** — e.g. "green on the first happy-path assertion,
-    no fail-first on the boundary", "asserted the value I expected, not the contract", "dismissed pure
-    helpers as trivial". Tie back to [[degraded-quality-root-causes-context-loss-and-test-quality]].
-  - [ ] **Draft durable rules** (one per confirmed cluster), each with a *why* and a *how to apply*,
-    phrased so they'd have PREVENTED the survivor. Candidate homes, decide per rule:
-    - [ ] repo-local `maintainers/CONVENTIONS.md` (project-specific testing conventions), and/or
-    - [ ] global `use-case-driven-harness/rules/testing.md` / the `tdd-discipline` skill (if the habit
-      is language-agnostic and applies to every project) — mirror the belt-and-suspenders split used
-      for `language.md`.
-  - [ ] **Engrave + record** the chosen rules in their homes; add a memory pointer only if a rule is a
-    durable cross-session convention (pointer, not a copy — cf. [[checkbox-plans-convention]] style).
-  - [ ] **Consider a lightweight guardrail** beyond convention (in the ADR 0009 deterministic spirit):
-    would a fast lint/property check catch any cluster mechanically (e.g. flag `assert.throws` with no
-    2nd arg, or `deepEqual`-vs-single-field in return-shape tests)? Only if cheap; otherwise leave it
-    as a written rule and say so.
+- [x] **Step 6 — Retrospective: what the surviving mutants reveal about our TDD practice → durable
+  rules.** _(2026-07-15)_ Read across all 14 `test(...)` hardening commits (3 parallel readers, one per
+  package). **All 6 candidate clusters CONFIRMED, none refuted, + 3 new infra-shaped clusters found.**
+  Rules engraved with the belt-and-suspenders split; the one cheaply-mechanical cluster (C1) got a
+  deterministic lint. **Full write-up: [`../../mutation/RETROSPECTIVE.md`](../../mutation/RETROSPECTIVE.md).**
+  - [x] **Gather the evidence.** 3 parallel agents diffed the test files + read the commit bodies for
+    rag (8 files) / local-mirror (6) / scripts (3), classifying each added assertion/seam. _(2026-07-15)_
+  - [x] **Cluster the survivor patterns** — all six confirmed by cross-package evidence:
+    - [x] **C1 Loose outcome assertions** — confirmed (`notion-url` `extractPageId`, `embedder`
+      `buildGeminiClient`, `setupSource`/`healthCheck` messages, exact log payloads). Least frequent but
+      real wherever a throw existed.
+    - [x] **C2 Partial return-shape assertions** — confirmed (`asText` envelope, `aggregateReports`
+      all-counts, `failedReport`, whole request envelope, whole command list). Moderate.
+    - [x] **C3 No triangulation on boundaries/operators** — confirmed, 2nd most frequent (`>`/`>=` on
+      `maxLastEditedTime`/chunker packing, `&&`/`||` filters, regex `^`/`$` anchors, asymmetric cosine,
+      retry off-by-last, `%50` heartbeat).
+    - [x] **C4 Untested pure glue / unreachable branches** — confirmed as the **#1 score driver**
+      (all 0 % files). Existing "test the glue too" convention was **too narrow** → broadened in
+      CONVENTIONS.md §5bis (pure unreachable branches, top-level scripts, composition roots).
+    - [x] **C5 Membership on empty/single collections** — confirmed (`removeSource`/`status`/pagination
+      loop needed ≥2 unsorted elements + a decoy).
+    - [x] **C6 Optional-chaining / default-arg / `??`-vs-`&&`** — confirmed as the **most frequent**
+      (8/8 rag files; every `?.`/`??`/default needed its null/absent twin).
+    - [x] **+ 3 NEW clusters** (not in the candidate list): CLI/script fakes keyed on the FULL command
+      (arg-string mutants), composition-root/entry-guard (one integration test earns the guard back),
+      LLM-facing string surfaces (names/descriptions invisible to behavioural tests).
+  - [x] **Root-cause each cluster to a TDD habit** — happy-path-only inputs (C6), one-sided examples
+    with no boundary triangulation (C3), asserting the value I expected not the whole contract (C2),
+    bare "it threw" (C1), trivial collections (C5), and "pure glue isn't worth a test" as a design
+    dismissal (C4). Tied to [[degraded-quality-root-causes-context-loss-and-test-quality]].
+  - [x] **Draft durable rules** — one per confirmed cluster, each with why + how-to-apply, phrased to
+    have PREVENTED the survivor. Homes (belt-and-suspenders, Thomas 2026-07-15):
+    - [x] global `tdd-discipline` skill § "Qualité des assertions" — the 5 language-agnostic habits
+      (C1/C2/C3/C5/C6 + reachability-as-design-smell); `rules/testing.md` points to it.
+    - [x] repo-local `maintainers/CONVENTIONS.md` §5ter — the 3 infra-shaped clusters + equivalent-mutant
+      literacy + the Stryker false-timeout trap; §5bis broadened for C4.
+  - [x] **Engrave + record** — done in both homes (above). Memory: the durable rules now live in the
+    skill + CONVENTIONS (pointers, not copies); the chantier pointer memory refreshed to reflect Step 6.
+  - [x] **Lightweight guardrail (ADR 0009 spirit)** — only C1 is cheaply mechanical → built
+    `scripts/lib/assert-matcher-lint.mjs` + repo-wide `*.test.mjs` guard (TDD baby-steps; fails CI loud
+    on any `assert.throws/rejects` with no matcher; dev-only via `DEV_ONLY_PREFIXES`). The other clusters
+    stay written rules (no cheap reliable check) — on-demand net is `mutate:changed`. _(2026-07-15)_
 
 ## Why deferred (not gating)
 

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -199,9 +199,21 @@ built-in `node --test`. Two realistic paths, in tension:
       704 covered). Confirms the three hardened files (index 100 %, server 85.71 %, notion-gateway
       97.44 %) lifted the package. RESULTS.md refreshed with the per-file table. _(2026-07-15)_
     - **3-local-mirror enumerated worst-files DONE** (`server.ts`, `index.ts`, `notion-gateway.ts` —
-      the three the Step 2 audit flagged weak). Remaining weak tier (NOT in the Step-2 worst-first
-      list, optional follow-up): `notion-transformers.ts` 57 % (50 survivors), `local-mirror.ts` 77 %
-      (61 survivors), `notion-url.ts` 74 %.
+      the three the Step 2 audit flagged weak).
+    - [ ] **3-local-mirror OPTIONAL weak tier** (NOT in the Step-2 worst-first list — a follow-up
+      Thomas green-lit 2026-07-15). `local-mirror` runs `inPlace` (non-destructive, files restored),
+      no worktree needed; config bridled (concurrency 4). Worst-first:
+      - [x] `notion-transformers.ts` **57.26 % → 94.87 %** (111/117, 6 documented equivalents) —
+        exported the pure helpers (`notionPageUrl`, `rowTitle`, `propertyToText`, `rowFields`) and
+        unit-tested each `propertyToText` switch case (rich_text/select/status/multi_select/number
+        incl. 0/date with→end/url/email/phone/unsupported + empties), `rowTitle` join + fallbacks,
+        `rowFields` title/empty dropping, and `linkToPageToMarkdown`'s `?? ''` id fallback + page_id
+        precedence. The 6 equivalents: the three `?? []` fallbacks mutated to a string-sentinel
+        array (`.map(...).join('')` → '' either way) + the redundant `.filter(type !== 'title')`
+        (title's propertyToText is '' → dropped downstream anyway) → effective 100 % on
+        non-equivalents. _(2026-07-15)_
+      - [ ] `notion-url.ts` **74 %** (12 survivors).
+      - [ ] `local-mirror.ts` **77 %** (61 survivors) — the big Domain Service.
   - [x] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory —
     a `clear-example-notes` mutant deletes the real `vault/`; never reuse a worktree, its vault
     gets corrupted by run-1 mutants)*. Worst-first: `clear-example-notes` 28.6 %, `auto-push`

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -138,7 +138,26 @@ built-in `node --test`. Two realistic paths, in tension:
       landing in a private field observed only through an injected fetch it does not wire) → effective
       91/91 = 100 % on non-equivalents. Also tuned `stryker.rag.config.mjs` (concurrency 4 / timeout)
       to kill the false-timeout bogus-100 % trap — see RESULTS.md. _(2026-07-15 · `5502322`)_
-    - [ ] then `index-manager` / `config`.
+    - [ ] `index-manager.ts` — **baseline re-measured 2026-07-15: 39.44 %** (28 killed / 0 timeout /
+      **43 survived**, tuned rag config). Diagnosis: the whole `runReindex` orchestration + most of
+      `reindex` is unmutated — the 4 existing tests only cover the locked no-op + `runIndexingPhase`.
+      Env redirection is a dead end (`VAULT_DIR`/`DB_PATH` are `const` frozen at import). **Agreed
+      approach = Option B: minimal extraction + injection (the "test the glue too" discipline), TDD
+      baby-steps.** Sub-steps:
+      - [ ] Extract + export pure `shouldSkip(force, existingHash, hash)` (= `!force && existingHash
+        === hash`); truth-table test → kills the L121 cluster (7 mutants).
+      - [ ] Export `classifyWall(errors)`; test the local-cap-over-429 **priority** (both walls
+        present) + a non-matching error → `null` → kills L34 (`.includes("")` always-true).
+      - [ ] Export `sha256(content)`; pin with a known SHA-256 vector → kills L23/L24.
+      - [ ] Add injectable `ReindexStorePorts` (scan, readFile, getDocumentHash, removeDeletedDocs,
+        currentIndexSchemaVersion, currentIndexIdentity, stampIndexIdentity, indexDocument) on
+        `runReindex`, threaded from `reindex` via `ReindexOptions.ports`, defaulted to the real module
+        fns. Then TDD the **unlocked path** with fakes: happy path (scanned/indexed/removed, stamp
+        called, `lock.release()` called, INJECTED embedder used), incremental skip, read-error push,
+        `shouldStamp` gating (stamp vs no-stamp). Kills L58/62/63/67/73/78/80/89/101/106…/155/161-183.
+      - [ ] Re-run `mutate:rag -- --mutate rag/src/lib/index-manager.ts`, document residual equivalents
+        in the test header, commit green, tick this box _(date · commit)_.
+    - [ ] then `config`.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -129,7 +129,16 @@ built-in `node --test`. Two realistic paths, in tension:
       `native-deps.test.ts`), `getDb`'s `if(!db)→if(true)` (harmless on a file-backed DB), and 4
       in `closeDb` (shutdown cleanup, no unit-observable contract) → effective 100 % on
       non-equivalents. _(2026-06-26)_
-    - [ ] then `embedder` / `index-manager` / `config`.
+    - [x] `embedder.ts` **34.6 % → 81.98 %** (89 killed + 2 timeout / 111) — extracted/exported the
+      pure network seams (`embedWithRetry`, `buildGeminiClient`, `shouldLogProgress`) + injectable
+      `sleep` on `EmbedDeps`; pinned request shape, empty-response → `[]`, the 429 backoff cadence
+      (20 s→40 s) and the once-per-50 heartbeat. The 20 survivors are all documented equivalents /
+      integration-only glue (real Gemini/quota wiring, real-timer `sleep`, cosmetic `console.error`
+      text, the unreachable post-loop `return []`, and `selectEmbedder`'s baseURL/apiKey defaults
+      landing in a private field observed only through an injected fetch it does not wire) → effective
+      91/91 = 100 % on non-equivalents. Also tuned `stryker.rag.config.mjs` (concurrency 4 / timeout)
+      to kill the false-timeout bogus-100 % trap — see RESULTS.md. _(2026-07-15 · `5502322`)_
+    - [ ] then `index-manager` / `config`.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -156,7 +156,17 @@ built-in `node --test`. Two realistic paths, in tension:
         default-force omitted.
       - [x] Re-ran `mutate:rag -- --mutate rag/src/lib/index-manager.ts`, documented residual
         equivalents in the test header, committed green. _(2026-07-15 · `b950d6b`)_
-    - [ ] then `config`.
+    - [x] `config.ts` **43.33 % → 86.67 %** (26 killed / 4 survived) — composition root:
+      extracted injectable `loadEnvFile(path, override, deps)` (reused by the import-time load
+      + `readGeminiKey` reload), pinned the frozen path/number constants + a `resolvePath`
+      truth-table + a `GEMINI_API_KEY` empty-string-safe invariant. The 4 residual survivors are
+      documented equivalents (real-dotenv default dep, the unreachable key fallback when a key is
+      present, the `.env` re-read closure exercised only on empty-startup onboarding) → effective
+      26/26 = 100 % on non-equivalents. _(2026-07-15 · `42bda19`)_
+    - **3-rag enumerated worst-files DONE** (document-scanner, vault-watcher, frontmatter-parser,
+      chunker, vector-store, embedder, index-manager, config). The other `rag/src/lib/*.ts` were
+      not flagged weak by the Step 2 audit; a full-`rag` re-audit (refresh RESULTS.md) is the
+      natural closer before moving on.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -286,6 +286,49 @@ built-in `node --test`. Two realistic paths, in tension:
     (rag/src/lib hardening in progress under Step 3-rag).
 - [ ] **Step 5 (conditional) — Escalate to Vitest (path B)** *only if* the command-runner audit is too
   slow to run regularly. Spin it off as its own migration plan; do not scope-creep it here.
+- [ ] **Step 6 — Retrospective: what the surviving mutants reveal about our TDD practice → durable
+  rules.** _(requested by Thomas 2026-07-15; do NOT start before the current `/clear`.)_ The point of
+  the whole exercise is not the score — it's to name **what was systematically weak in the tests /
+  the TDD discipline** so the same gaps stop recurring. Read across every hardening commit on
+  `test/rag-mutation-hardening` (Step 3 rag/local-mirror/scripts + the local-mirror weak tier), find
+  the RECURRING shapes of survivor, root-cause each to a test-writing / TDD habit, then turn each into
+  a durable rule and engrave it where it belongs.
+  - [ ] **Gather the evidence.** `git log --oneline main..test/rag-mutation-hardening` → for each
+    `test(...)` commit, diff the test files and classify what assertion/seam was ADDED to kill the
+    survivors (the commit bodies already summarise the "before → after" and the residual equivalents).
+  - [ ] **Cluster the survivor patterns** (candidate recurring root causes to CONFIRM or refute — not
+    conclusions yet):
+    - [ ] **Loose outcome assertions** — asserting `throws` without a message matcher, or `ok === true`
+      without the message body → StringLiteral/`throw ''` mutants survive. (Seen in `notion-url`
+      `extractPageId`, `setupSource`/`healthCheck` messages.)
+    - [ ] **Partial return-shape assertions** — checking one field, not the whole object → ObjectLiteral
+      `{}` / `status: ""` mutants survive. (Seen in `sync` failed report, `failedReport`.)
+    - [ ] **No triangulation on boundaries/operators** — a single example value leaves `>` vs `>=`,
+      `> 0` vs `>= 0`, `===` vs `!==` alive. (Seen in `maxLastEditedTime`, the vanish guard.)
+    - [ ] **Untested pure "glue" / logic behind unexported functions** — whole branches unreachable
+      through the public API (the original 0 % root cause + `aggregateHealth`/`aggregateStatus`
+      unknown/mixed verdicts). Cross-check against the existing "test the glue too" convention: is it
+      too narrow (only "extract I/O", not "unreachable pure branches")?
+    - [ ] **Membership/lookup tested only on empty or single-element collections** — `some`/`every`,
+      `find` first-vs-right survive until a 2+ element case exists. (Seen in `removeSource`,
+      `configOrThrow`.)
+    - [ ] **Optional-chaining / default-argument / `??`-vs-`&&` branches never exercised** with the
+      null/absent input. (Seen in null-state cleanup, the frozen-watermark `?? null`.)
+  - [ ] **Root-cause each cluster to a TDD habit** — e.g. "green on the first happy-path assertion,
+    no fail-first on the boundary", "asserted the value I expected, not the contract", "dismissed pure
+    helpers as trivial". Tie back to [[degraded-quality-root-causes-context-loss-and-test-quality]].
+  - [ ] **Draft durable rules** (one per confirmed cluster), each with a *why* and a *how to apply*,
+    phrased so they'd have PREVENTED the survivor. Candidate homes, decide per rule:
+    - [ ] repo-local `maintainers/CONVENTIONS.md` (project-specific testing conventions), and/or
+    - [ ] global `use-case-driven-harness/rules/testing.md` / the `tdd-discipline` skill (if the habit
+      is language-agnostic and applies to every project) — mirror the belt-and-suspenders split used
+      for `language.md`.
+  - [ ] **Engrave + record** the chosen rules in their homes; add a memory pointer only if a rule is a
+    durable cross-session convention (pointer, not a copy — cf. [[checkbox-plans-convention]] style).
+  - [ ] **Consider a lightweight guardrail** beyond convention (in the ADR 0009 deterministic spirit):
+    would a fast lint/property check catch any cluster mechanically (e.g. flag `assert.throws` with no
+    2nd arg, or `deepEqual`-vs-single-field in return-shape tests)? Only if cheap; otherwise leave it
+    as a written rule and say so.
 
 ## Why deferred (not gating)
 

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -212,7 +212,13 @@ built-in `node --test`. Two realistic paths, in tension:
         array (`.map(...).join('')` → '' either way) + the redundant `.filter(type !== 'title')`
         (title's propertyToText is '' → dropped downstream anyway) → effective 100 % on
         non-equivalents. _(2026-07-15)_
-      - [ ] `notion-url.ts` **74 %** (12 survivors).
+      - [x] `notion-url.ts` **74.47 % → 97.87 %** (46 killed / 1 survived) — leaf URL lib:
+        killed the relative-mention regex anchors (`foo/<id32>` + `/<id32>/child` untouched,
+        dashed `/<uuid>` absolutized with dashes stripped), the app.notion.com guard (embedded
+        fragment untouched via `^`, `http://` rewritten via `https?`), and the `extractPageId`
+        throw cluster by pinning the error message. The 1 residual survivor is a documented
+        equivalent (line 33 `canonical === url ? whole : …` rebuilds the identical string) →
+        effective 46/46 = 100 % on non-equivalents. _(2026-07-15)_
       - [ ] `local-mirror.ts` **77 %** (61 survivors) — the big Domain Service.
   - [x] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory —
     a `clear-example-notes` mutant deletes the real `vault/`; never reuse a worktree, its vault

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -119,7 +119,17 @@ built-in `node --test`. Two realistic paths, in tension:
       piece trims), title trim + index order, exact packing boundary. The 12 residual
       survivors are documented equivalent mutants (effective 73/73 = 100 % on non-equivalents).
       _(2026-06-25 · `f7f5a6a`)_
-    - [ ] then `vector-store` / `embedder` / `index-manager` / `config`.
+    - [x] `vector-store.ts` **33.8 % → 92.47 %** (134 killed + 1 timeout / 146) — DB-injectable
+      `*In` cores tested in-memory (search ranking/limit/filters, stats, list, hash, remove,
+      source_url round-trip), `cosineSimilarity` pinned by an identical-vector (=1) and an
+      asymmetric pair (=0.8) case, `applySchema` idempotency + out-of-band column migrations, and
+      a real-fs `getDb()` singleton test (`vector-store.singleton.test.ts`) for the thin wrappers.
+      The 11 residual survivors are documented equivalents: 6 in the native-ABI rebuild path
+      (`ragRoot`/`rebuildBetterSqlite`, only on an ABI mismatch — invocation covered by
+      `native-deps.test.ts`), `getDb`'s `if(!db)→if(true)` (harmless on a file-backed DB), and 4
+      in `closeDb` (shutdown cleanup, no unit-observable contract) → effective 100 % on
+      non-equivalents. _(2026-06-26)_
+    - [ ] then `embedder` / `index-manager` / `config`.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -211,7 +211,17 @@ built-in `node --test`. Two realistic paths, in tension:
       spawn arg shape, reindex-failure → 1, `--no-reindex` skip) + a vault-scope test (an
       exemple-tagged note OUTSIDE `vault/` is left untouched) + direct `realClearDeps` tests
       (console forwarding, real fn identity). _(2026-07-15)_
-    - [ ] `auto-push.mjs` **41.4 %** (51 survivors).
+    - [x] `auto-push.mjs` **41.4 % → 92.39 %** (85/92, 7 documented equivalents) —
+      extracted the untested Stop-hook CLI seams (`buildGit(repo, execFile)`, `realSleep`,
+      `runHook({git,sleep,write})`, `repoRoot(metaUrl)`, `realWrite`, `realHookDeps`) so the
+      real git-runner mapping (ok / stdout+stderr on failure / null→''), the warning glue and
+      the repo-root derivation are all unit-tested; rewrote the fake git to key on the FULL
+      command (`args.join(" ")`) so mutating any arg string (`--get`, `@{u}..HEAD`, …) is caught,
+      and mirrored real trailing-newline output to pin the `.trim()`s; added the retry-success
+      path (pause is exactly 3000ms) + the autopush-gating case. The 7 equivalents are the
+      redundant `.trim()` under `Number()` (Number() already trims) + the 6 mutants inside the
+      `import.meta.url` entry-point guard (only run when the file IS the process) → effective
+      100 % on non-equivalents. _(2026-07-15)_
     - [ ] `auto-commit.mjs` **47.5 %** (21 survivors).
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
   "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -178,7 +178,13 @@ built-in `node --test`. Two realistic paths, in tension:
       pre-refactor). The 2 residual survivors are documented equivalents: the entry-point guard +
       its `boot(realBootDeps).catch(fatal)` body (run only when server.ts IS the process) → effective
       12/12 = 100 % on non-equivalents. _(2026-07-15)_
-    - [ ] Next local-mirror survivors: `index.ts` (2.2 %), `notion-gateway` (21 %).
+    - [x] `index.ts` **2.2 % → 100 %** (45/45, no equivalents) — the MCP tool surface: drove the
+      REAL registered tools through an in-memory `Client`/`InMemoryTransport` pair (`mcp-tools.test.ts`),
+      asserting server name/version, the 7 tool names, every tool + input-field description is non-empty,
+      and each `callTool` maps its (snake_case) args to the right port method and returns the exact
+      `asText` envelope. End-to-end kills names, descriptions, zod schemas, handlers and `asText`.
+      _(2026-07-15)_
+    - [ ] Next local-mirror survivor: `notion-gateway` (21 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
   "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -138,25 +138,24 @@ built-in `node --test`. Two realistic paths, in tension:
       landing in a private field observed only through an injected fetch it does not wire) → effective
       91/91 = 100 % on non-equivalents. Also tuned `stryker.rag.config.mjs` (concurrency 4 / timeout)
       to kill the false-timeout bogus-100 % trap — see RESULTS.md. _(2026-07-15 · `5502322`)_
-    - [ ] `index-manager.ts` — **baseline re-measured 2026-07-15: 39.44 %** (28 killed / 0 timeout /
-      **43 survived**, tuned rag config). Diagnosis: the whole `runReindex` orchestration + most of
-      `reindex` is unmutated — the 4 existing tests only cover the locked no-op + `runIndexingPhase`.
-      Env redirection is a dead end (`VAULT_DIR`/`DB_PATH` are `const` frozen at import). **Agreed
-      approach = Option B: minimal extraction + injection (the "test the glue too" discipline), TDD
-      baby-steps.** Sub-steps:
-      - [ ] Extract + export pure `shouldSkip(force, existingHash, hash)` (= `!force && existingHash
-        === hash`); truth-table test → kills the L121 cluster (7 mutants).
-      - [ ] Export `classifyWall(errors)`; test the local-cap-over-429 **priority** (both walls
-        present) + a non-matching error → `null` → kills L34 (`.includes("")` always-true).
-      - [ ] Export `sha256(content)`; pin with a known SHA-256 vector → kills L23/L24.
-      - [ ] Add injectable `ReindexStorePorts` (scan, readFile, getDocumentHash, removeDeletedDocs,
+    - [x] `index-manager.ts` **39.44 % → 94.87 %** (74 killed / 0 timeout / 4 survived) — Option B
+      (minimal extraction + injection, "test the glue too"), TDD baby-steps. The 4 residual survivors
+      are documented equivalents: the `defaultStorePorts` default wiring to the real fs/DB (only
+      exercised in a real reindex) — effective 74/74 = 100 % on non-equivalents. _(2026-07-15 · `b950d6b`)_
+      - [x] Extract + export pure `shouldSkip(force, existingHash, hash)` (= `!force && existingHash
+        === hash`); truth-table test → killed the L121 incremental cluster.
+      - [x] Export `classifyWall(errors)`; tested the local-cap-over-429 **priority** (both walls
+        present) + a non-matching / empty error → `null`.
+      - [x] Export `sha256(content)`; pinned with the NIST `"abc"` SHA-256 vector.
+      - [x] Added injectable `ReindexStorePorts` (scan, readFile, getDocumentHash, removeDeletedDocs,
         currentIndexSchemaVersion, currentIndexIdentity, stampIndexIdentity, indexDocument) on
         `runReindex`, threaded from `reindex` via `ReindexOptions.ports`, defaulted to the real module
-        fns. Then TDD the **unlocked path** with fakes: happy path (scanned/indexed/removed, stamp
-        called, `lock.release()` called, INJECTED embedder used), incremental skip, read-error push,
-        `shouldStamp` gating (stamp vs no-stamp). Kills L58/62/63/67/73/78/80/89/101/106…/155/161-183.
-      - [ ] Re-run `mutate:rag -- --mutate rag/src/lib/index-manager.ts`, document residual equivalents
-        in the test header, commit green, tick this box _(date · commit)_.
+        fns. TDD'd the **unlocked path** with fakes: happy path (scan/index/prune, identity stamp,
+        `lock.release()`, INJECTED embedder used, chunk materialisation, reporter meta), incremental
+        skip, read-error push, `shouldStamp` gating (stamp vs no-stamp on force), source_url wiring,
+        default-force omitted.
+      - [x] Re-ran `mutate:rag -- --mutate rag/src/lib/index-manager.ts`, documented residual
+        equivalents in the test header, committed green. _(2026-07-15 · `b950d6b`)_
     - [ ] then `config`.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -114,7 +114,12 @@ built-in `node --test`. Two realistic paths, in tension:
     - [x] `frontmatter-parser.ts` **11.9 % → 97.6 %** (82/84) — full prefix→type table, title
       precedence, tag coercion; 2 documented equivalent mutants (heading-regex anchors masked by
       greedy `.+` + `.trim()`). _(2026-06-25 · `384e6f7`)_
-    - [ ] `chunker.ts` (27.1 %), then `vector-store` / `embedder` / `index-manager` / `config`.
+    - [x] `chunker.ts` **27.1 % → 85.9 %** (73/85) — section/heading structure, `(intro)`
+      default, empty-section drop, long-content `splitAtParagraphs` (blank-line collapse +
+      piece trims), title trim + index order, exact packing boundary. The 12 residual
+      survivors are documented equivalent mutants (effective 73/73 = 100 % on non-equivalents).
+      _(2026-06-25 · `f7f5a6a`)_
+    - [ ] then `vector-store` / `embedder` / `index-manager` / `config`.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -167,7 +167,8 @@ built-in `node --test`. Two realistic paths, in tension:
       chunker, vector-store, embedder, index-manager, config). The other `rag/src/lib/*.ts` were
       not flagged weak by the Step 2 audit; a full-`rag` re-audit (refresh RESULTS.md) is the
       natural closer before moving on.
-  - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
+  - [x] **3-local-mirror** — harden `local-mirror/src/**` survivors. Enumerated worst-files done +
+    re-audit closer (67.63 % → 78.69 %). _(2026-07-15)_
     - [x] `server.ts` **0 % → 85.71 %** (10 killed + 2 timeout / 14) — composition root: extracted
       + exported the boot seams (`buildDeps`, `buildApi`, `boot(BootDeps)`, `fatal`) and named the
       real wiring (`createRealServer`, `createRealTransport`, `realBootDeps`) so no inline arrows
@@ -192,9 +193,13 @@ built-in `node --test`. Two realistic paths, in tension:
       `?? ''` fallback are all unit-testable. The 1 residual survivor is the `new Client({auth})`
       real-SDK construction (live-network-only) → effective 38/38 = 100 % on non-equivalents.
       _(2026-07-15)_
+    - [x] **Full `local-mirror` re-audit (closer)** — **67.63 % → 78.69 %** (550 killed + 4 timeout /
+      704 covered). Confirms the three hardened files (index 100 %, server 85.71 %, notion-gateway
+      97.44 %) lifted the package. RESULTS.md refreshed with the per-file table. _(2026-07-15)_
     - **3-local-mirror enumerated worst-files DONE** (`server.ts`, `index.ts`, `notion-gateway.ts` —
-      the three the Step 2 audit flagged weak). A full-`local-mirror` re-audit (refresh RESULTS.md)
-      is the natural closer before moving to 3-scripts.
+      the three the Step 2 audit flagged weak). Remaining weak tier (NOT in the Step-2 worst-first
+      list, optional follow-up): `notion-transformers.ts` 57 % (50 survivors), `local-mirror.ts` 77 %
+      (61 survivors), `notion-url.ts` 74 %.
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
   "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -98,9 +98,11 @@ built-in `node --test`. Two realistic paths, in tension:
     real tree let a `clear-example-notes` mutant delete the real `vault/` demo notes. rag/local-mirror
     run `inPlace` (non-destructive, files restored). Tune `concurrency`/timeout for big suites (the
     513-test scripts suite faked a 99.97 % via mass timeouts at default concurrency 13).
-- [ ] **Step 3 — Triage & kill surviving mutants.** For each survivor, decide: add the missing
-  assertion (the usual outcome), or mark it an accepted equivalent/ignored mutant with a reason. **TDD**
-  the new assertions (`tdd-discipline`); green-only commits.
+- [x] **Step 3 — Triage & kill surviving mutants.** _(2026-07-15)_ For each survivor, decide: add the
+  missing assertion (the usual outcome), or mark it an accepted equivalent/ignored mutant with a reason.
+  **TDD** the new assertions (`tdd-discipline`); green-only commits. **All three packages' enumerated
+  worst-files are now hardened** (3-rag, 3-local-mirror, 3-scripts done); the optional weak-tier
+  follow-ups (local-mirror `notion-transformers`/`local-mirror.ts`/`notion-url`) remain non-blocking.
   - **Attack order (Thomas, 2026-06-25): worst-first → `rag` → `local-mirror` → `scripts`.** Start with
     `rag` (lowest global score 57 %), 0 %-files first: `document-scanner`, `vault-watcher`, then
     `frontmatter-parser` (12 %), `chunker` (27 %). `rag`/`local-mirror` run `inPlace` (non-destructive);
@@ -200,7 +202,7 @@ built-in `node --test`. Two realistic paths, in tension:
       the three the Step 2 audit flagged weak). Remaining weak tier (NOT in the Step-2 worst-first
       list, optional follow-up): `notion-transformers.ts` 57 % (50 survivors), `local-mirror.ts` 77 %
       (61 survivors), `notion-url.ts` 74 %.
-  - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory —
+  - [x] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory —
     a `clear-example-notes` mutant deletes the real `vault/`; never reuse a worktree, its vault
     gets corrupted by run-1 mutants)*. Worst-first: `clear-example-notes` 28.6 %, `auto-push`
     41.4 %, `auto-commit` 47.5 % (the git/vault side-effect scripts).
@@ -222,7 +224,21 @@ built-in `node --test`. Two realistic paths, in tension:
       redundant `.trim()` under `Number()` (Number() already trims) + the 6 mutants inside the
       `import.meta.url` entry-point guard (only run when the file IS the process) → effective
       100 % on non-equivalents. _(2026-07-15)_
-    - [ ] `auto-commit.mjs` **47.5 %** (21 survivors).
+    - [x] `auto-commit.mjs` **47.5 % → 98.21 %** (55/56, 1 documented equivalent) —
+      extracted the top-level side-effect script into an injectable core (`buildGit`,
+      `attemptCommit({git})`, `repoRoot`, `isEntryPoint`, `COMMIT_MESSAGE`); unit-tested the
+      dirty/clean branches, the exact stage+commit commands (message included), the git-runner
+      mapping, and `isEntryPoint`. Fixed a latent macOS symlink bug in the entry guard
+      (`realpathSync` both sides — the tmpdir `/var`→`/private/var` symlink) and dropped the
+      redundant `process.exit(0)` (work is synchronous → Node exits 0 on its own; NOT exiting at
+      import keeps the module unit-testable under mutation, which is what kills the `isEntryPoint`
+      condition mutants). Kept the subprocess integration tests — they kill the entry-body
+      mutants a pure import cannot. The 1 survivor is the `if (isEntryPoint(...))→if(true)` guard
+      (only matters when the file IS the process) → effective 100 % on non-equivalents.
+      _(2026-07-15)_
+    - **3-scripts enumerated worst-files DONE** (`clear-example-notes` 100 %, `auto-push` 92.39 %,
+      `auto-commit` 98.21 %) — the only three files the Step-2 audit flagged weak. All of
+      `scripts/lib/**` was already 100 %, so `scripts/**` is now fully hardened.
 - [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
   "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:
   - [x] **Floor guard (runs every CI test pass, free): a sibling test is mandatory.** `rag/src/lib/lib-coverage-guard.test.ts`

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -111,13 +111,27 @@ built-in `node --test`. Two realistic paths, in tension:
       integration test, dropped the unreachable `.gitkeep` exclusion. _(2026-06-25 · `861fa89`)_
     - [x] `vault-watcher.ts` **0 % → 100 %** (26/26) — extracted pure `isIgnoredPath`, injected the
       watch factory, deterministic real-chokidar adapter test. _(2026-06-25 · `fd290c9`)_
-    - [ ] `frontmatter-parser.ts` (11.9 %) — next.
+    - [x] `frontmatter-parser.ts` **11.9 % → 97.6 %** (82/84) — full prefix→type table, title
+      precedence, tag coercion; 2 documented equivalent mutants (heading-regex anchors masked by
+      greedy `.+` + `.trim()`). _(2026-06-25 · `384e6f7`)_
     - [ ] `chunker.ts` (27.1 %), then `vector-store` / `embedder` / `index-manager` / `config`.
   - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
   - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
-- [ ] **Step 4 — Decide a sustainable cadence.** No per-commit gate today; likely a **periodic local
-  audit** (and/or an opt-in, non-blocking CI job — *not* a merge gate, given command-runner cost).
-  Record the chosen cadence + the baseline score here so it survives `/clear`s.
+- [x] **Step 4 — Sustainable cadence + durable guardrails.** _(2026-06-25)_ Decided after the question
+  "how do we stop badly-written tests from recurring?" — three layers, cheapest/most-deterministic first:
+  - [x] **Floor guard (runs every CI test pass, free): a sibling test is mandatory.** `rag/src/lib/lib-coverage-guard.test.ts`
+    fails loud if any `src/lib/*.ts` lacks its `*.test.ts` (`EXEMPT` empty by design). Catches the
+    "no test at all" gap (the document-scanner/vault-watcher 0 %) instantly, no mutation run needed. _(`9d33204`)_
+  - [x] **Per-change non-regression check (on demand, fast): `npm --prefix maintainers/mutation run mutate:changed [baseRef]`**
+    (`mutate-changed.mjs`) mutates only the changed prod files vs `main`, grouped by package; `scripts/**`
+    reported-but-skipped (needs the disposable worktree). Run it on a branch that touches `rag`/`local-mirror` logic.
+  - [x] **Convention (the root cause): "test the glue too".** "Pure I/O glue, no test" is the exact
+    dismissal that produced the 0 %; extract the logic behind a port and TDD it. Engraved in
+    `maintainers/CONVENTIONS.md`.
+  - **No per-commit blocking gate** (command-runner cost) and **no merge gate**. Periodic full audit =
+    re-run `mutate:all` before a release / when test quality is in doubt, refresh [`RESULTS.md`](../../mutation/RESULTS.md).
+  - **Baseline (2026-06-23, see RESULTS.md):** scripts **97.27 %**, local-mirror **67.63 %**, rag **57.23 %**
+    (rag/src/lib hardening in progress under Step 3-rag).
 - [ ] **Step 5 (conditional) — Escalate to Vitest (path B)** *only if* the command-runner audit is too
   slow to run regularly. Spin it off as its own migration plan; do not scope-creep it here.
 

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -101,6 +101,20 @@ built-in `node --test`. Two realistic paths, in tension:
 - [ ] **Step 3 — Triage & kill surviving mutants.** For each survivor, decide: add the missing
   assertion (the usual outcome), or mark it an accepted equivalent/ignored mutant with a reason. **TDD**
   the new assertions (`tdd-discipline`); green-only commits.
+  - **Attack order (Thomas, 2026-06-25): worst-first → `rag` → `local-mirror` → `scripts`.** Start with
+    `rag` (lowest global score 57 %), 0 %-files first: `document-scanner`, `vault-watcher`, then
+    `frontmatter-parser` (12 %), `chunker` (27 %). `rag`/`local-mirror` run `inPlace` (non-destructive);
+    ⚠️ `scripts` **only** in a disposable git worktree (a `clear-example-notes` mutant deleted the real
+    `vault/` during the audit).
+  - [ ] **3-rag** — harden `rag/src/**` survivors.
+    - [x] `document-scanner.ts` **0 % → 100 %** (24/24) — DI `readDir` port + `rootDir`, real-fs
+      integration test, dropped the unreachable `.gitkeep` exclusion. _(2026-06-25 · `861fa89`)_
+    - [x] `vault-watcher.ts` **0 % → 100 %** (26/26) — extracted pure `isIgnoredPath`, injected the
+      watch factory, deterministic real-chokidar adapter test. _(2026-06-25 · `fd290c9`)_
+    - [ ] `frontmatter-parser.ts` (11.9 %) — next.
+    - [ ] `chunker.ts` (27.1 %), then `vector-store` / `embedder` / `index-manager` / `config`.
+  - [ ] **3-local-mirror** — harden `local-mirror/src/**` survivors (start `server.ts` @ 0 %).
+  - [ ] **3-scripts** — harden `scripts/**` survivors *(disposable worktree mandatory)*.
 - [ ] **Step 4 — Decide a sustainable cadence.** No per-commit gate today; likely a **periodic local
   audit** (and/or an opt-in, non-blocking CI job — *not* a merge gate, given command-runner cost).
   Record the chosen cadence + the baseline score here so it survives `/clear`s.

--- a/rag/src/lib/chunker.test.ts
+++ b/rag/src/lib/chunker.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { chunkMarkdown } from "./chunker.js";
+import { CHUNK_MAX_CHARS } from "./config.js";
 
 test("title-only doc (empty body) still yields at least one chunk carrying the title", () => {
   // A Notion page with a meaningful title but no body (the live F8 case: 0 chunkable lines)
@@ -33,3 +34,123 @@ test("no title given → behaves as before (body-only chunks)", () => {
   assert.ok(chunks.every((c) => c.section !== "(title)"));
   assert.ok(chunks.some((c) => c.content.includes("island history")));
 });
+
+test("each heading becomes its own section chunk, in order, as `heading\\n\\nbody`", () => {
+  const md = "# Alpha\n\nFirst body.\n\n## Beta\n\nSecond body.";
+
+  const chunks = chunkMarkdown(md);
+
+  // The heading text drives the section name (regex capture + trim), the body lines
+  // are joined under it, and the chunk content is exactly `heading\n\nbody`.
+  assert.deepEqual(chunks, [
+    { section: "Alpha", content: "Alpha\n\nFirst body.", index: 0 },
+    { section: "Beta", content: "Beta\n\nSecond body.", index: 1 },
+  ]);
+});
+
+test("body before any heading lands under `(intro)`, and empty-body sections are dropped", () => {
+  // Text precedes the first heading → it must be captured under the synthetic
+  // `(intro)` heading; the trailing heading with no body must NOT yield a chunk.
+  const chunks = chunkMarkdown("Intro text.\n\n# Empty Section");
+
+  assert.deepEqual(chunks, [
+    { section: "(intro)", content: "(intro)\n\nIntro text.", index: 0 },
+  ]);
+});
+
+test("a section longer than CHUNK_MAX_CHARS is split into ordered pieces under the same section", () => {
+  // Three ~4000-char paragraphs → `heading\n\nbody` exceeds the 8000-char ceiling,
+  // so splitAtParagraphs must break it on paragraph boundaries (never mid-paragraph),
+  // keep the pieces in order, and keep them all under the same heading.
+  const p1 = "ALPHA" + "a".repeat(3995);
+  const p2 = "BETA" + "b".repeat(3996);
+  const p3 = "GAMMA" + "g".repeat(3995);
+  const md = `# Big\n\n${p1}\n\n${p2}\n\n${p3}`;
+
+  const chunks = chunkMarkdown(md);
+
+  assert.equal(chunks.length, 3, "must split into 3 pieces, not collapse to one");
+  assert.ok(chunks.every((c) => c.section === "Big"), "every piece keeps its section");
+  assert.deepEqual(chunks.map((c) => c.index), [0, 1, 2], "pieces stay in order");
+  // First piece carries the heading joined to the first paragraph by a blank line.
+  assert.ok(chunks[0].content.startsWith("Big\n\nALPHA"));
+  assert.ok(chunks[1].content.startsWith("BETA"));
+  assert.ok(chunks[2].content.startsWith("GAMMA"));
+  // No piece is padded with stray leading/trailing whitespace (the trims).
+  assert.ok(chunks.every((c) => c.content === c.content.trim()));
+});
+
+test("a multi-line body keeps its line-breaks when flushed by the next heading; mid-line #'s stay in the body", () => {
+  // `# Head` has a two-line body flushed when `## Next` arrives (joins body on \n, not "");
+  // the trailing heading whitespace is trimmed; `Refer to ## later` starts with text, so its
+  // mid-line `##` must NOT be promoted to a heading (the `^` anchor).
+  const md = "# Head  \n\nFirst line\nSecond line\n\n## Next\n\nRefer to ## later";
+
+  const chunks = chunkMarkdown(md);
+
+  assert.deepEqual(chunks, [
+    { section: "Head", content: "Head\n\nFirst line\nSecond line", index: 0 },
+    { section: "Next", content: "Next\n\nRefer to ## later", index: 1 },
+  ]);
+});
+
+test("the title is trimmed and seeded first, then body chunks follow in increasing index order", () => {
+  const chunks = chunkMarkdown("## History\n\nSome history.", "  Naxos  ");
+
+  assert.deepEqual(chunks[0], { section: "(title)", content: "Naxos", index: 0 });
+  assert.equal(chunks[1].index, 1, "the body chunk follows the title (index increments, not decrements)");
+});
+
+test("a heading-only section (empty body) between two headings yields no chunk", () => {
+  // `# A` has no body before `# B` → it must be skipped entirely, not emitted as
+  // an empty `A\n\n` chunk.
+  const chunks = chunkMarkdown("# A\n\n# B\n\nbody");
+
+  assert.deepEqual(chunks, [{ section: "B", content: "B\n\nbody", index: 0 }]);
+});
+
+test("when splitting a long section, blank-line runs collapse and each piece is whitespace-trimmed", () => {
+  // A run of 3+ newlines must collapse to a single paragraph separator (\n\n+),
+  // and each emitted piece must be trimmed of stray edge whitespace.
+  const huge = "x".repeat(CHUNK_MAX_CHARS); // forces the split path
+  const md = `# Big\n\nPARA-A\n\n\nPARA-B   \n\n   ${huge}`;
+
+  const chunks = chunkMarkdown(md);
+
+  // The 3-newline run between A and B is normalized to a single blank line.
+  assert.ok(chunks[0].content.includes("PARA-A\n\nPARA-B"));
+  assert.ok(!chunks[0].content.includes("PARA-A\n\n\nPARA-B"));
+  // No piece carries leading/trailing whitespace (the two trims in splitAtParagraphs).
+  assert.ok(chunks.every((c) => c.content === c.content.trim()));
+});
+
+test("packing fills a piece up to exactly CHUNK_MAX_CHARS before splitting (no off-by-one early split)", () => {
+  // `H\n\n` + p1 reaches exactly CHUNK_MAX_CHARS → it must NOT split yet (boundary is
+  // `> max`, not `>= max`); the small p2 then overflows → 2 pieces, not 3.
+  const p1 = "y".repeat(CHUNK_MAX_CHARS - 3); // 1 ("H") + 2 ("\n\n") + (max-3) === max
+  const p2 = "zzzzz";
+  const md = `# H\n\n${p1}\n\n${p2}`;
+
+  const chunks = chunkMarkdown(md);
+
+  assert.equal(chunks.length, 2, "the heading+p1 piece packs up to the limit; only p2 spills over");
+});
+
+// ── Equivalent mutants (mutation audit, Step 3-rag) ──────────────────────────
+// Stryker reaches ~85.9% here; the 12 remaining survivors are EQUIVALENT mutants —
+// they cannot change observable behaviour, so no test can kill them. Effective score
+// on non-equivalent mutants is 73/73 = 100%. Grouped by reason:
+//   • `currentBody.length > 0` → `>= 0` / `true` (lines 35, 44): the only currentBody
+//     of length 0 is an empty section, which is filtered downstream by the
+//     `if (!bodyTrimmed) continue` guard — so pushing it changes nothing.
+//   • `fullText.length <= MAX` → `<` / `false` (line 66): on content that fits, the
+//     split path is the identity (splitAtParagraphs returns the whole as one piece),
+//     so "always split" and the exact `<` boundary produce the same single chunk.
+//   • `current.length > 0` → `>= 0` / `true` (line 15) and `if (current.trim())` →
+//     `if (current)` / `if (true)` (line 22): `current` is only empty/whitespace-only
+//     before the first paragraph or after a trimmed body, neither of which co-occurs
+//     with the surrounding condition — the guard never actually fires differently.
+//   • heading regex `(.+)$` → `(.+)` (drop `$`) and `\s+` → `\s`: `.+` is greedy (so
+//     `$` is redundant) and `headingMatch[1].trim()` erases the extra-space difference.
+
+

--- a/rag/src/lib/config.test.ts
+++ b/rag/src/lib/config.test.ts
@@ -1,9 +1,129 @@
+// Mutation hardening (Stryker): config.ts 43.33 % → 86.67 %.
+// config.ts is a composition root: pure cores (resolvePath, resolveKey) + a thin
+// import-time .env side-effect. We extracted loadEnvFile(path, override, deps) so the
+// "load only if present, right path/override" glue is unit-testable, and pinned the
+// frozen path/number constants (VAULT_DIR/CACHE_DIR/DB_PATH/ENV_PATH/MAX) to their
+// deterministic defaults.
+// The 4 residual survivors are documented EQUIVALENTS, all env-/fs-bound glue:
+//  - 29 defaultEnvLoadDeps.loadConfig → the real dotenv call, only run at a real
+//    import (tests inject fakes);
+//  - 60 GEMINI_API_KEY's `?? "Stryker"` → unreachable fallback when a real key is in
+//    the env (key ?? anything = key); the empty-vs-`&&` contract IS pinned by the
+//    invariant test;
+//  - 79/80 readGeminiKey's reload closure body + its `override:true` → the .env
+//    re-read path, exercised only on an empty-startup-key onboarding; the decision
+//    core (resolveKey) is fully covered. Effective on non-equivalents: 26/26 = 100 %.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { QUERY_RESERVE, resolveKey } from "./config.js";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import {
+  QUERY_RESERVE,
+  MAX_EMBED_REQUESTS_PER_DAY,
+  GEMINI_API_KEY,
+  VAULT_DIR,
+  CACHE_DIR,
+  DB_PATH,
+  ENV_PATH,
+  resolveKey,
+  resolvePath,
+  readGeminiKey,
+  loadEnvFile,
+  type EnvLoadDeps,
+} from "./config.js";
+
+// config.test.ts lives next to config.ts (rag/src/lib/) → same base dirs, so the
+// module's frozen path constants can be reconstructed deterministically here.
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, "../../..");
+
+// Recording fake for loadEnvFile's injected I/O.
+function envLoadSpy(exists: boolean) {
+  const calls: Array<{ path: string; override: boolean }> = [];
+  const deps: EnvLoadDeps = {
+    existsSync: () => exists,
+    loadConfig: (opts) => calls.push(opts),
+  };
+  return { deps, calls };
+}
+
+test("loadEnvFile: no file at the path → does NOT load anything", () => {
+  const { deps, calls } = envLoadSpy(false);
+  loadEnvFile("/nope/.env", false, deps);
+  assert.equal(calls.length, 0);
+});
+
+test("loadEnvFile: file present → loads it at that exact path, override off by default", () => {
+  const { deps, calls } = envLoadSpy(true);
+  loadEnvFile("/home/me/.env", false, deps);
+  assert.deepEqual(calls, [{ path: "/home/me/.env", override: false }]);
+});
+
+test("loadEnvFile: override=true is forwarded (re-read an empty startup key)", () => {
+  const { deps, calls } = envLoadSpy(true);
+  loadEnvFile("/home/me/.env", true, deps);
+  assert.deepEqual(calls, [{ path: "/home/me/.env", override: true }]);
+});
+
+test("loadEnvFile: override defaults to false when omitted (the import-time load)", () => {
+  const { deps, calls } = envLoadSpy(true);
+  loadEnvFile("/home/me/.env", undefined, deps);
+  assert.equal(calls[0].override, false);
+});
+
+test("GEMINI_API_KEY snapshots the env key, empty-string-safe (never undefined)", () => {
+  // Regression invariant: the ?? "" keeps it a string. A && "" (or a dropped
+  // coalesce) would break the "reflects the env key, else empty" contract.
+  assert.equal(GEMINI_API_KEY, process.env.GOOGLE_GEMINI_API_KEY ?? "");
+  assert.equal(typeof GEMINI_API_KEY, "string");
+});
 
 test("QUERY_RESERVE default = 50 (credits reserved for search)", () => {
   assert.equal(QUERY_RESERVE, 50);
+});
+
+test("MAX_EMBED_REQUESTS_PER_DAY default = 7600 (runaway safety net)", () => {
+  assert.equal(MAX_EMBED_REQUESTS_PER_DAY, 7600);
+});
+
+test("VAULT_DIR defaults to <repoRoot>/vault (relocatable-path fallback)", () => {
+  assert.equal(VAULT_DIR, resolve(repoRoot, "vault"));
+});
+
+test("CACHE_DIR defaults to <repoRoot>/rag/.cache", () => {
+  assert.equal(CACHE_DIR, resolve(repoRoot, "rag/.cache"));
+});
+
+test("DB_PATH is vault.db inside the cache dir", () => {
+  assert.equal(DB_PATH, resolve(CACHE_DIR, "vault.db"));
+});
+
+test("ENV_PATH defaults to <repoRoot>/.env", () => {
+  assert.equal(ENV_PATH, resolve(repoRoot, ".env"));
+});
+
+// resolvePath — the pure relocatable-path core (env value wins as absolute, else fallback).
+test("resolvePath: non-empty env value wins, resolved to absolute", () => {
+  assert.equal(resolvePath("/data/vault", "/fallback"), resolve("/data/vault"));
+});
+
+test("resolvePath: undefined env value → keep the fallback verbatim", () => {
+  assert.equal(resolvePath(undefined, "/fallback"), "/fallback");
+});
+
+test("resolvePath: whitespace-only env value → keep the fallback (not an override)", () => {
+  assert.equal(resolvePath("   ", "/fallback"), "/fallback");
+});
+
+test("readGeminiKey: returns the in-process key when present (no .env reload)", () => {
+  const prev = process.env.GOOGLE_GEMINI_API_KEY;
+  process.env.GOOGLE_GEMINI_API_KEY = "AIza-current-in-memory";
+  try {
+    assert.equal(readGeminiKey(), "AIza-current-in-memory");
+  } finally {
+    if (prev === undefined) delete process.env.GOOGLE_GEMINI_API_KEY;
+    else process.env.GOOGLE_GEMINI_API_KEY = prev;
+  }
 });
 
 // The key is read once at MCP process startup. If the user pastes it into .env

--- a/rag/src/lib/config.ts
+++ b/rag/src/lib/config.ts
@@ -18,10 +18,38 @@ export function resolvePath(
   return envValue && envValue.trim() ? resolve(envValue) : fallback;
 }
 
-const envPath = resolvePath(process.env.SBG_ENV_PATH, resolve(projectRoot, ".env"));
-if (existsSync(envPath)) {
-  config({ path: envPath });
+/** Injected I/O for {@link loadEnvFile} — real fs + dotenv by default, faked in tests. */
+export interface EnvLoadDeps {
+  existsSync: (path: string) => boolean;
+  loadConfig: (opts: { path: string; override: boolean }) => void;
 }
+
+const defaultEnvLoadDeps: EnvLoadDeps = {
+  existsSync,
+  loadConfig: (opts) => {
+    config(opts);
+  },
+};
+
+/**
+ * Loads a `.env` file into `process.env` — but ONLY if it exists (a missing file
+ * is a no-op, never a crash). `override` re-reads a key that was empty at startup
+ * (onboarding: key pasted after the MCP launched). Pure decision + injected I/O so
+ * the "load only if present, with the right path/override" glue is unit-testable.
+ */
+export function loadEnvFile(
+  path: string,
+  override = false,
+  deps: EnvLoadDeps = defaultEnvLoadDeps
+): void {
+  if (deps.existsSync(path)) deps.loadConfig({ path, override });
+}
+
+export const ENV_PATH = resolvePath(
+  process.env.SBG_ENV_PATH,
+  resolve(projectRoot, ".env")
+);
+loadEnvFile(ENV_PATH);
 
 export const VAULT_DIR = resolvePath(process.env.VAULT_DIR, resolve(projectRoot, "vault"));
 export const CACHE_DIR = resolvePath(
@@ -49,7 +77,7 @@ export function resolveKey(
 // (the case of the `.env` shipped with `GOOGLE_GEMINI_API_KEY=` empty → process.env freezes "").
 export function readGeminiKey(): string {
   return resolveKey(process.env.GOOGLE_GEMINI_API_KEY, () => {
-    if (existsSync(envPath)) config({ path: envPath, override: true });
+    loadEnvFile(ENV_PATH, true);
     return process.env.GOOGLE_GEMINI_API_KEY;
   });
 }

--- a/rag/src/lib/document-scanner.test.ts
+++ b/rag/src/lib/document-scanner.test.ts
@@ -38,9 +38,12 @@ test("exposes both absolute and vault-relative paths", async () => {
 });
 
 test("recurses into subdirectories and keeps the subdir in the relative path", async () => {
+  // Production recurses via `resolve(dir, name)`, so the subdir key must be the
+  // resolved path (native on Windows: `D:\vault\topics`) — a hard-coded POSIX key
+  // would never match there. `resolve` makes the fake tree OS-portable.
   const readDir = fakeReadDir({
     "/vault": [dir("topics"), file("root.md")],
-    "/vault/topics": [file("deep.md")],
+    [resolve("/vault", "topics")]: [file("deep.md")],
   });
   const files = await scanVault("/vault", readDir);
   assert.deepEqual(

--- a/rag/src/lib/document-scanner.test.ts
+++ b/rag/src/lib/document-scanner.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, resolve } from "path";
 import { scanVault, type DirEntry } from "./document-scanner.js";
 
 function file(name: string): DirEntry {
@@ -29,8 +29,10 @@ test("returns the .md files found at the root", async () => {
 test("exposes both absolute and vault-relative paths", async () => {
   const readDir = fakeReadDir({ "/vault": [file("note.md")] });
   const [scanned] = await scanVault("/vault", readDir);
+  // absolutePath is the native resolved path (openable by fs) — computed the same way
+  // on any OS; relativePath is the POSIX-normalised vault-relative id.
   assert.deepEqual(scanned, {
-    absolutePath: "/vault/note.md",
+    absolutePath: resolve("/vault", "note.md"),
     relativePath: "note.md",
   });
 });

--- a/rag/src/lib/document-scanner.test.ts
+++ b/rag/src/lib/document-scanner.test.ts
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scanVault, type DirEntry } from "./document-scanner.js";
+
+function file(name: string): DirEntry {
+  return { name, isDirectory: () => false };
+}
+function dir(name: string): DirEntry {
+  return { name, isDirectory: () => true };
+}
+
+// Builds a fake readDir port from a map of absolute dir -> entries.
+function fakeReadDir(tree: Record<string, DirEntry[]>) {
+  return async (d: string): Promise<DirEntry[]> => tree[d] ?? [];
+}
+
+test("returns the .md files found at the root", async () => {
+  const readDir = fakeReadDir({ "/vault": [file("note.md")] });
+  const files = await scanVault("/vault", readDir);
+  assert.deepEqual(
+    files.map((f) => f.relativePath),
+    ["note.md"]
+  );
+});
+
+test("exposes both absolute and vault-relative paths", async () => {
+  const readDir = fakeReadDir({ "/vault": [file("note.md")] });
+  const [scanned] = await scanVault("/vault", readDir);
+  assert.deepEqual(scanned, {
+    absolutePath: "/vault/note.md",
+    relativePath: "note.md",
+  });
+});
+
+test("recurses into subdirectories and keeps the subdir in the relative path", async () => {
+  const readDir = fakeReadDir({
+    "/vault": [dir("topics"), file("root.md")],
+    "/vault/topics": [file("deep.md")],
+  });
+  const files = await scanVault("/vault", readDir);
+  assert.deepEqual(
+    files.map((f) => f.relativePath).sort(),
+    ["root.md", "topics/deep.md"]
+  );
+});
+
+test("excludes the _template.md and .gitkeep scaffolding files", async () => {
+  const readDir = fakeReadDir({
+    "/vault": [file("_template.md"), file(".gitkeep"), file("keep.md")],
+  });
+  const files = await scanVault("/vault", readDir);
+  assert.deepEqual(
+    files.map((f) => f.relativePath),
+    ["keep.md"]
+  );
+});
+
+test("ignores files that are not Markdown", async () => {
+  const readDir = fakeReadDir({
+    "/vault": [file("note.md"), file("photo.png"), file("data.json")],
+  });
+  const files = await scanVault("/vault", readDir);
+  assert.deepEqual(
+    files.map((f) => f.relativePath),
+    ["note.md"]
+  );
+});
+
+test("never descends into the .obsidian directory", async () => {
+  const readDir = fakeReadDir({
+    "/vault": [dir(".obsidian"), file("note.md")],
+    "/vault/.obsidian": [file("workspace.md")],
+  });
+  const files = await scanVault("/vault", readDir);
+  assert.deepEqual(
+    files.map((f) => f.relativePath),
+    ["note.md"]
+  );
+});
+
+// Exercises the REAL default readDir port (fs/promises) against an actual tree,
+// so the I/O adapter — not just the injected fake — is covered end to end.
+test("scans a real directory tree through the default fs port", async () => {
+  const root = await mkdtemp(join(tmpdir(), "sbg-scan-"));
+  try {
+    await mkdir(join(root, "topics"), { recursive: true });
+    await writeFile(join(root, "root.md"), "# root");
+    await writeFile(join(root, "topics", "deep.md"), "# deep");
+    await writeFile(join(root, "ignore.txt"), "nope");
+
+    const files = await scanVault(root);
+
+    assert.deepEqual(
+      files.map((f) => f.relativePath).sort(),
+      ["root.md", "topics/deep.md"]
+    );
+    assert.deepEqual(
+      files.map((f) => f.absolutePath).sort(),
+      [join(root, "root.md"), join(root, "topics", "deep.md")]
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/rag/src/lib/document-scanner.ts
+++ b/rag/src/lib/document-scanner.ts
@@ -1,6 +1,14 @@
 import { readdir } from "fs/promises";
-import { resolve, relative } from "path";
+import { resolve, relative, sep } from "path";
 import { VAULT_DIR } from "./config.js";
+
+// The vault-relative path is a canonical document identifier: downstream consumers
+// (frontmatter-parser's folder→type table via `startsWith("topics/")`, its
+// `split("/")` filename extraction) all assume POSIX `/`. On Windows `path.relative`
+// yields `\`, which would silently break type detection and titles — so normalise to
+// forward slashes here, at the single source. `absolutePath` stays native (it must
+// remain openable by the filesystem).
+const toPosix = (p: string): string => p.split(sep).join("/");
 
 export interface ScannedFile {
   absolutePath: string;
@@ -39,7 +47,7 @@ async function walkDir(
     } else if (entry.name.endsWith(".md") && !EXCLUDE_NAMES.has(entry.name)) {
       files.push({
         absolutePath: fullPath,
-        relativePath: relative(rootDir, fullPath),
+        relativePath: toPosix(relative(rootDir, fullPath)),
       });
     }
   }

--- a/rag/src/lib/document-scanner.ts
+++ b/rag/src/lib/document-scanner.ts
@@ -1,4 +1,4 @@
-import { readdir, stat } from "fs/promises";
+import { readdir } from "fs/promises";
 import { resolve, relative } from "path";
 import { VAULT_DIR } from "./config.js";
 
@@ -7,27 +7,49 @@ export interface ScannedFile {
   relativePath: string;
 }
 
-const EXCLUDE_NAMES = new Set(["_template.md", ".gitkeep"]);
+/** Minimal directory entry shape (a subset of `fs.Dirent`), so the scan is unit-testable. */
+export interface DirEntry {
+  name: string;
+  isDirectory(): boolean;
+}
+
+/** Reads a directory's entries — injectable so the walk can be tested without touching the disk. */
+export type ReadDirPort = (dir: string) => Promise<DirEntry[]>;
+
+const defaultReadDir: ReadDirPort = (dir) =>
+  readdir(dir, { withFileTypes: true });
+
+// Only `.md` files reach this set (non-Markdown names are filtered earlier), so a
+// `.gitkeep` entry here would be unreachable — `_template.md` is the real exclusion.
+const EXCLUDE_NAMES = new Set(["_template.md"]);
 const EXCLUDE_DIRS = new Set([".obsidian"]);
 
-async function walkDir(dir: string, files: ScannedFile[]): Promise<void> {
-  const entries = await readdir(dir, { withFileTypes: true });
+async function walkDir(
+  dir: string,
+  rootDir: string,
+  files: ScannedFile[],
+  readDir: ReadDirPort
+): Promise<void> {
+  const entries = await readDir(dir);
   for (const entry of entries) {
     if (EXCLUDE_DIRS.has(entry.name)) continue;
     const fullPath = resolve(dir, entry.name);
     if (entry.isDirectory()) {
-      await walkDir(fullPath, files);
+      await walkDir(fullPath, rootDir, files, readDir);
     } else if (entry.name.endsWith(".md") && !EXCLUDE_NAMES.has(entry.name)) {
       files.push({
         absolutePath: fullPath,
-        relativePath: relative(VAULT_DIR, fullPath),
+        relativePath: relative(rootDir, fullPath),
       });
     }
   }
 }
 
-export async function scanVault(): Promise<ScannedFile[]> {
+export async function scanVault(
+  rootDir: string = VAULT_DIR,
+  readDir: ReadDirPort = defaultReadDir
+): Promise<ScannedFile[]> {
   const files: ScannedFile[] = [];
-  await walkDir(VAULT_DIR, files);
+  await walkDir(rootDir, rootDir, files, readDir);
   return files;
 }

--- a/rag/src/lib/embedder.test.ts
+++ b/rag/src/lib/embedder.test.ts
@@ -1,13 +1,72 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+
+// Mutation hardening (Stryker, 2026-07-15): 34.6% → 81.98% (89 killed + 2 timeout
+// + 20 survived / 111). To make the network logic testable, the 429-retry/backoff
+// (`embedWithRetry`), the Gemini client guard (`buildGeminiClient`) and the progress
+// predicate (`shouldLogProgress`) were extracted/exported, and `sleep` was made
+// injectable via `EmbedDeps`. The 20 survivors are ALL documented EQUIVALENTS /
+// integration-only glue (killable only over the real network / a private field, or
+// with no observable contract), so the EFFECTIVE score on non-equivalent mutants is
+// 91/91 = 100%. The 2 timeouts are genuine kills (a mutant that turns the retry/
+// embed for-loop into an infinite loop, detected via the instant-resolve fake sleep).
+// ⚠️ This score is only reproducible with the tuned concurrency/timeout the rag config
+// now carries — the default 13 runners over-subscribe the CPU and inflate every kill
+// into a FALSE timeout (a bogus 100%); see maintainers/mutation/RESULTS.md.
+// Grouped by reason:
+//   - Real Gemini/quota wiring (10): getClient()'s lazy singleton (`if(!client)`
+//     flips + emptied body), buildGeminiClient's `new GoogleGenAI({apiKey})`→`({})`,
+//     the module-level `UsageTracker({...})` config, and defaultDeps() — all wire the
+//     REAL client/tracker/deps, observable only over the network or an SDK-private
+//     field. Every unit test injects `EmbedDeps`/`QuotaGuard`/`sleepFn` fakes, so
+//     these bodies never run; the PURE guard behind them (buildGeminiClient's
+//     throw-on-missing-key, the whole retry loop) is fully killed below.
+//   - Real timer sleep() (2): the production `setTimeout` body — tests inject fakes.
+//   - console.error MESSAGE TEXT (3): empty message + `attempt±1` / `delay*1000`
+//     INSIDE the log template — cosmetic; the backoff delays, the retry cadence and
+//     the once-per-50 heartbeat ARE pinned below.
+//   - Unreachable post-loop `return []` (1): the retry loop always returns (success)
+//     or throws (non-429 / exhausted 429) inside its body → the trailing return is dead.
+//   - selectEmbedder's openai-compatible baseURL/apiKey `?? ""` defaults (4): the value
+//     lands in OpenAiCompatibleEmbedder's PRIVATE config, observable only through the
+//     adapter's injected fetch — which selectEmbedder does not wire (real global fetch).
+//     Same class as buildGeminiClient's apiKey; the adapter's own request shaping is
+//     covered directly by openai-compatible-embedder.test.ts, and model/dimension
+//     defaults (exposed via the public `identity`) ARE killed.
 import {
   createEmbedder,
   selectEmbedder,
   embedQuery,
   embedTexts,
+  embedWithRetry,
+  buildGeminiClient,
+  shouldLogProgress,
   GeminiEmbedder,
   type QuotaGuard,
 } from "./embedder.js";
+
+// A fake of the GoogleGenAI surface embedWithRetry touches: a scripted
+// `models.embedContent` that returns/throws per call, recording how often it ran.
+function fakeAi(responder: (call: number) => unknown) {
+  let call = 0;
+  const seen: unknown[] = [];
+  return {
+    ai: {
+      models: {
+        embedContent: async (req: unknown) => {
+          seen.push(req);
+          const out = responder(call++);
+          if (out instanceof Error) throw out;
+          return out;
+        },
+      },
+    } as unknown as Parameters<typeof embedWithRetry>[0],
+    get calls() {
+      return call;
+    },
+    seen,
+  };
+}
 
 // Spies on which quota path is consumed, without touching the network.
 class SpyGuard implements QuotaGuard {
@@ -24,6 +83,7 @@ test("GeminiEmbedder exposes its identity (provider/model/dimension) for the sta
   const embedder = new GeminiEmbedder({
     usage: new SpyGuard(),
     embedOne: async () => [],
+    sleep: async () => {},
   });
 
   assert.deepEqual(embedder.identity, {
@@ -57,6 +117,15 @@ test("selectEmbedder: provider 'openai-compatible' → stamped OpenAI-compatible
   });
 });
 
+test("selectEmbedder: 'openai-compatible' with no env fields falls back to empty model / dimension 0", () => {
+  // Pins the `?? ""` / `?? 0` defaults: a missing model reads back "" (not a
+  // canary), and a missing dimension parses to 0 (not NaN from a canary string).
+  const embedder = selectEmbedder({ EMBEDDING_PROVIDER: "openai-compatible" });
+
+  assert.equal(embedder.identity.model, "");
+  assert.equal(embedder.identity.dimension, 0);
+});
+
 test("selectEmbedder: provider 'in-process' → transformers-js adapter, no URL or key", () => {
   const embedder = selectEmbedder({ EMBEDDING_PROVIDER: "in-process" });
 
@@ -80,7 +149,11 @@ test("selectEmbedder: 'in-process' accepts a custom model/dimension via the env"
 
 test("embedQuery consumes on the priority path (never blocked by indexing)", async () => {
   const guard = new SpyGuard();
-  await embedQuery("q", { usage: guard, embedOne: async () => [1, 2, 3] });
+  await embedQuery("q", {
+    usage: guard,
+    embedOne: async () => [1, 2, 3],
+    sleep: async () => {},
+  });
   assert.deepEqual(guard.calls, ["priority"]);
 });
 
@@ -89,7 +162,158 @@ test("embedTexts consumes on the indexing path, once per text", async () => {
   const out = await embedTexts(["a", "b"], {
     usage: guard,
     embedOne: async (t) => [t.length],
+    sleep: async () => {},
   });
   assert.deepEqual(guard.calls, ["index", "index"]);
   assert.deepEqual(out, [[1], [1]]);
+});
+
+test("embedTexts paces between docs but NOT after the last (≈750ms = 80/min)", async () => {
+  const guard = new SpyGuard();
+  const delays: number[] = [];
+  await embedTexts(["a", "b", "c"], {
+    usage: guard,
+    embedOne: async (t) => [t.length],
+    sleep: async (ms) => {
+      delays.push(ms);
+    },
+  });
+  // Three docs → two inter-doc pauses (the guard `i < texts.length - 1`); each is
+  // Math.ceil(60_000 / 80) = 750ms (the 80-calls-per-minute throttle).
+  assert.deepEqual(delays, [750, 750]);
+});
+
+test("embedTexts emits a progress heartbeat exactly once per 50 chunks", async () => {
+  const errors: string[] = [];
+  const realError = console.error;
+  console.error = (msg: string) => errors.push(String(msg));
+  try {
+    await embedTexts(Array.from({ length: 50 }, (_, i) => `t${i}`), {
+      usage: new SpyGuard(),
+      embedOne: async () => [0],
+      sleep: async () => {},
+    });
+  } finally {
+    console.error = realError;
+  }
+  // The 50th chunk (i=49) trips the heartbeat; nothing before it does → exactly one.
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /50\/50 chunks embedded/);
+});
+
+// --- shouldLogProgress: a heartbeat every 50 embedded chunks ------------------
+
+test("shouldLogProgress fires on every 50th chunk (1-based), nowhere else", () => {
+  // i is 0-based → the 50th chunk is i=49, the 100th is i=99.
+  assert.equal(shouldLogProgress(49), true);
+  assert.equal(shouldLogProgress(99), true);
+  assert.equal(shouldLogProgress(0), false);
+  assert.equal(shouldLogProgress(48), false);
+  assert.equal(shouldLogProgress(50), false);
+});
+
+// --- buildGeminiClient: the key-missing guard (user-facing error) -------------
+
+test("buildGeminiClient throws a named, .env-pointing error when the key is missing", () => {
+  assert.throws(
+    () => buildGeminiClient(undefined),
+    /GOOGLE_GEMINI_API_KEY is not set in \.env/
+  );
+  assert.throws(() => buildGeminiClient(""), /GOOGLE_GEMINI_API_KEY/);
+});
+
+test("buildGeminiClient returns a client when a key is present", () => {
+  // Construction is offline (no request fired until embed time), so a dummy key
+  // is enough to prove the guard lets a present key through.
+  assert.ok(buildGeminiClient("dummy-key"));
+});
+
+// --- embedWithRetry: success, empty response, 429 backoff, fatal errors -------
+const noSleep = async () => {};
+
+test("embedWithRetry returns the embedding values on the first success", async () => {
+  const fake = fakeAi(() => ({ embeddings: [{ values: [0.1, 0.2] }] }));
+
+  const out = await embedWithRetry(fake.ai, "hello", 3, noSleep);
+
+  assert.deepEqual(out, [0.1, 0.2]);
+  assert.equal(fake.calls, 1, "should not retry a successful call");
+});
+
+test("embedWithRetry sends the Gemini model and the text in the expected request shape", async () => {
+  const fake = fakeAi(() => ({ embeddings: [{ values: [1] }] }));
+
+  await embedWithRetry(fake.ai, "hello world", 3, noSleep);
+
+  // Pins the request payload Gemini expects: the model name and the nested
+  // contents: [{ parts: [{ text }] }] envelope (an emptied/flattened shape would
+  // reach the API malformed).
+  assert.deepEqual(fake.seen[0], {
+    model: "gemini-embedding-001",
+    contents: [{ parts: [{ text: "hello world" }] }],
+  });
+});
+
+test("embedWithRetry returns [] when the response carries no embeddings field", async () => {
+  // Pins the FIRST optional-chain link: `response.embeddings?.[0]` — without it,
+  // `undefined[0]` throws instead of degrading to [].
+  const fake = fakeAi(() => ({}));
+
+  assert.deepEqual(await embedWithRetry(fake.ai, "x", 3, noSleep), []);
+});
+
+test("embedWithRetry returns [] when embeddings is an empty array", async () => {
+  // Pins the SECOND optional-chain link: `[0]?.values` — and the `?? []` default
+  // (a mutated `&& []` would yield undefined, a canary default would leak).
+  const fake = fakeAi(() => ({ embeddings: [] }));
+
+  assert.deepEqual(await embedWithRetry(fake.ai, "x", 3, noSleep), []);
+});
+
+test("embedWithRetry retries a 429 and backs off 20s then 40s before succeeding", async () => {
+  const rateLimited = (call: number) =>
+    call < 2
+      ? new Error("429 Too Many Requests")
+      : { embeddings: [{ values: [9] }] };
+  const fake = fakeAi(rateLimited);
+  const delays: number[] = [];
+
+  const out = await embedWithRetry(fake.ai, "q", 3, async (ms) => {
+    delays.push(ms);
+  });
+
+  assert.deepEqual(out, [9]);
+  assert.equal(fake.calls, 3, "two 429s then one success");
+  // Math.min(60_000, (attempt + 1) * 20_000): attempt 0 → 20s, attempt 1 → 40s.
+  assert.deepEqual(delays, [20_000, 40_000]);
+});
+
+test("embedWithRetry rethrows a non-429 error at once, without retry or backoff", async () => {
+  const fake = fakeAi(() => new Error("500 Internal Server Error"));
+  let slept = false;
+
+  await assert.rejects(
+    embedWithRetry(fake.ai, "q", 3, async () => {
+      slept = true;
+    }),
+    /500 Internal Server Error/
+  );
+  assert.equal(fake.calls, 1, "a non-rate-limit error is fatal — no second try");
+  assert.equal(slept, false, "no backoff on a fatal error");
+});
+
+test("embedWithRetry gives up and rethrows once the 429s outlast the retries", async () => {
+  // Always 429: with maxRetries=2, attempts 0 and 1 back off, attempt 2 is the
+  // last pass (attempt < maxRetries is false) → the 429 propagates.
+  const fake = fakeAi(() => new Error("429 rate limited"));
+  const delays: number[] = [];
+
+  await assert.rejects(
+    embedWithRetry(fake.ai, "q", 2, async (ms) => {
+      delays.push(ms);
+    }),
+    /429/
+  );
+  assert.equal(fake.calls, 3, "maxRetries=2 → 3 attempts total");
+  assert.deepEqual(delays, [20_000, 40_000], "backed off on the first two only");
 });

--- a/rag/src/lib/embedder.ts
+++ b/rag/src/lib/embedder.ts
@@ -49,15 +49,23 @@ const usage = new UsageTracker({
   reserveForPriority: QUERY_RESERVE,
 });
 
+/**
+ * Builds the Gemini client from a key, or throws the named, .env-pointing error
+ * the install flow relies on when the key is missing. Pure (no memoization, no
+ * env read) → testable; the construction is offline (no request until embed time).
+ */
+export function buildGeminiClient(key: string | undefined): GoogleGenAI {
+  if (!key) {
+    throw new Error("GOOGLE_GEMINI_API_KEY is not set in .env");
+  }
+  return new GoogleGenAI({ apiKey: key });
+}
+
 function getClient(): GoogleGenAI {
   if (!client) {
     // Re-reads .env on the fly: if the key was pasted after Claude Code's first
     // launch, the next request picks it up without reconnecting the MCP.
-    const key = readGeminiKey();
-    if (!key) {
-      throw new Error("GOOGLE_GEMINI_API_KEY is not set in .env");
-    }
-    client = new GoogleGenAI({ apiKey: key });
+    client = buildGeminiClient(readGeminiKey());
   }
   return client;
 }
@@ -66,10 +74,21 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function embedWithRetry(
+/** A progress heartbeat fires once every 50 embedded chunks (i is 0-based). */
+export function shouldLogProgress(i: number): boolean {
+  return (i + 1) % 50 === 0;
+}
+
+/**
+ * Embeds one text with a bounded 429-retry/backoff loop. `sleepFn` is injectable
+ * so the backoff is testable without real wall-clock delays. Non-rate-limit errors
+ * (and a rate-limit that outlasts the retries) propagate; an empty response → [].
+ */
+export async function embedWithRetry(
   ai: GoogleGenAI,
   text: string,
-  maxRetries = 3
+  maxRetries = 3,
+  sleepFn: (ms: number) => Promise<void> = sleep
 ): Promise<number[]> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -86,7 +105,7 @@ async function embedWithRetry(
         console.error(
           `[embedder] Rate limit hit, waiting ${delay / 1000}s (attempt ${attempt + 1}/${maxRetries})...`
         );
-        await sleep(delay);
+        await sleepFn(delay);
         continue;
       }
       throw err;
@@ -103,14 +122,20 @@ export interface QuotaGuard {
   consumePriority(n?: number): void;
 }
 
-/** Injectable embedder dependencies (network + quota), stubbable in tests. */
+/** Injectable embedder dependencies (network + quota + pacing), stubbable in tests. */
 export interface EmbedDeps {
   usage: QuotaGuard;
   embedOne: (text: string) => Promise<number[]>;
+  /** Inter-document pause (the 80-calls/min throttle); injectable to avoid real waits. */
+  sleep: (ms: number) => Promise<void>;
 }
 
 function defaultDeps(): EmbedDeps {
-  return { usage, embedOne: (text) => embedWithRetry(getClient(), text) };
+  return {
+    usage,
+    embedOne: (text) => embedWithRetry(getClient(), text),
+    sleep,
+  };
 }
 
 /**
@@ -141,10 +166,10 @@ export class GeminiEmbedder implements Embedder {
       allEmbeddings.push(embedding);
 
       if (i < texts.length - 1) {
-        await sleep(DELAY_MS);
+        await this.deps.sleep(DELAY_MS);
       }
 
-      if ((i + 1) % 50 === 0) {
+      if (shouldLogProgress(i)) {
         console.error(`[embedder] ${i + 1}/${texts.length} chunks embedded...`);
       }
     }

--- a/rag/src/lib/frontmatter-parser.test.ts
+++ b/rag/src/lib/frontmatter-parser.test.ts
@@ -28,3 +28,103 @@ test("sourceUrl is null when the note has no source_url (non-mirror note)", () =
 
   assert.equal(parsed.sourceUrl, null);
 });
+
+// --- type detection ---------------------------------------------------------
+
+const PREFIX_TYPES: [string, string][] = [
+  ["daily/", "daily"],
+  ["people/", "person"],
+  ["topics/", "topic"],
+  ["decisions/", "decision"],
+  ["meetings/", "meeting"],
+  ["prep-1-1/", "prep-1-1"],
+  ["prep-day/", "prep-day"],
+  ["backlog/", "backlog"],
+  ["coaching/", "coaching"],
+  ["initiatives/", "initiative"],
+  ["raw-sources/", "raw-source"],
+  ["briefings/", "briefing"],
+  ["domains/", "domain"],
+  ["drafts/", "draft"],
+  ["articles/", "article"],
+];
+
+for (const [prefix, expectedType] of PREFIX_TYPES) {
+  test(`maps the "${prefix}" folder to type "${expectedType}"`, () => {
+    const parsed = parseDocument("body", `${prefix}note.md`);
+    assert.equal(parsed.type, expectedType);
+  });
+}
+
+test("an explicit frontmatter type overrides the folder prefix", () => {
+  const parsed = parseDocument("---\ntype: custom\n---\n", "topics/x.md");
+  assert.equal(parsed.type, "custom");
+});
+
+test("falls back to type \"other\" for an unknown folder", () => {
+  const parsed = parseDocument("body", "unknown-folder/x.md");
+  assert.equal(parsed.type, "other");
+});
+
+// --- title extraction -------------------------------------------------------
+
+test("trims surrounding whitespace from the frontmatter title", () => {
+  const parsed = parseDocument("---\ntitle: '  Naxos  '\n---\n", "topics/x.md");
+  assert.equal(parsed.title, "Naxos");
+});
+
+test("a blank frontmatter title does not win (falls through to the heading)", () => {
+  const parsed = parseDocument("---\ntitle: '   '\n---\n# Real Heading\n", "topics/x.md");
+  assert.equal(parsed.title, "Real Heading");
+});
+
+test("uses the first Markdown H1 heading when there is no frontmatter title", () => {
+  const parsed = parseDocument("intro\n\n# The Heading\n\nbody", "topics/x.md");
+  assert.equal(parsed.title, "The Heading");
+});
+
+test("falls back to the filename (without .md) when there is no title nor heading", () => {
+  const parsed = parseDocument("just a body, no heading", "topics/sub/my-note.md");
+  assert.equal(parsed.title, "my-note");
+});
+
+test("only treats a '#' at the start of a line as a heading", () => {
+  // "C# is great" has a mid-line '# ' that must NOT be read as an H1 heading,
+  // otherwise the title would become "is great" instead of the filename.
+  const parsed = parseDocument("C# is great here\n", "topics/csharp.md");
+  assert.equal(parsed.title, "csharp");
+});
+
+test("trims the extracted heading title", () => {
+  const parsed = parseDocument("# Heading with trailing spaces   \nbody", "topics/x.md");
+  assert.equal(parsed.title, "Heading with trailing spaces");
+});
+
+test("strips only the trailing .md extension from the filename", () => {
+  // The '$' anchor matters: a literal '.md' earlier in the name must survive.
+  const parsed = parseDocument("body", "topics/v2.md-notes.md");
+  assert.equal(parsed.title, "v2.md-notes");
+});
+
+// --- tags -------------------------------------------------------------------
+
+test("coerces every frontmatter tag to a string", () => {
+  const parsed = parseDocument("---\ntags: [alpha, 42]\n---\n", "topics/x.md");
+  assert.deepEqual(parsed.tags, ["alpha", "42"]);
+});
+
+test("yields an empty tag list when tags is absent or not an array", () => {
+  assert.deepEqual(parseDocument("body", "topics/x.md").tags, []);
+  assert.deepEqual(
+    parseDocument("---\ntags: not-a-list\n---\n", "topics/x.md").tags,
+    []
+  );
+});
+
+// --- passthrough ------------------------------------------------------------
+
+test("returns the body content with the frontmatter stripped", () => {
+  const parsed = parseDocument("---\ntitle: T\n---\nhello world\n", "topics/x.md");
+  assert.equal(parsed.content.trim(), "hello world");
+  assert.equal(parsed.frontmatter.title, "T");
+});

--- a/rag/src/lib/index-manager.test.ts
+++ b/rag/src/lib/index-manager.test.ts
@@ -1,6 +1,25 @@
+// Mutation hardening (Stryker): index-manager.ts 39.44 % → 94.87 %.
+// The `reindex`/`runReindex` orchestration is unit-tested through injected
+// `ReindexStorePorts` (scan/read/hash/prune/stamp/persist) + an injected embedder
+// and reporter — the "test the glue too" discipline that produced the jump.
+// The 4 residual survivors are all documented EQUIVALENTS: the `defaultStorePorts`
+// object literal + its `scan`/`readFile` arrows + the `"utf-8"` encoding are the
+// DEFAULT wiring to the real fs/DB modules, exercised only in a real reindex (not
+// unit-observable here, where every port is faked) — same class as embedder's
+// `selectEmbedder` defaults and vector-store's `getDb` singleton. Effective score
+// on non-equivalents: 74/74 = 100 %.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { reindex, runIndexingPhase } from "./index-manager.js";
+import {
+  reindex,
+  runIndexingPhase,
+  shouldSkip,
+  classifyWall,
+  sha256,
+  type ReindexStorePorts,
+} from "./index-manager.js";
+import { INDEX_SCHEMA_VERSION } from "./vector-store.js";
+import type { EmbedderIdentity } from "./embedder.js";
 import { ReindexLock, type LockState, type LockStorage } from "./reindex-lock.js";
 import { ReindexReporter, type ProgressStorage } from "./reindex-reporter.js";
 import type { PreparedDoc, IndexPorts } from "./indexer.js";
@@ -54,6 +73,299 @@ class MemStorage implements LockStorage {
   }
 }
 
+test("shouldSkip: incremental run, unchanged doc (same hash) → skip", () => {
+  assert.equal(shouldSkip(false, "abc", "abc"), true);
+});
+
+test("shouldSkip: incremental run, changed doc (different hash) → do not skip", () => {
+  assert.equal(shouldSkip(false, "old", "new"), false);
+});
+
+test("shouldSkip: forced run always re-indexes, even on an identical hash", () => {
+  assert.equal(shouldSkip(true, "abc", "abc"), false);
+});
+
+test("shouldSkip: never-indexed doc (no stored hash) → do not skip", () => {
+  assert.equal(shouldSkip(false, null, "abc"), false);
+});
+
+test("sha256: hashes content with a known SHA-256 vector", () => {
+  // Canonical NIST test vector for "abc".
+  assert.equal(
+    sha256("abc"),
+    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+  );
+});
+
+test("classifyWall: both walls present → local-cap wins (it throws before the network)", () => {
+  assert.equal(
+    classifyWall(["got status: 429 RESOURCE_EXHAUSTED", "DailyCapExceededError: over"]),
+    "local-cap"
+  );
+});
+
+test("classifyWall: only a 429 → google-rate-limit", () => {
+  assert.equal(classifyWall(["boom: 429 RESOURCE_EXHAUSTED"]), "google-rate-limit");
+});
+
+test("classifyWall: no wall marker → null", () => {
+  assert.equal(classifyWall(["Read error: foo.md: ENOENT"]), null);
+});
+
+test("classifyWall: empty error list → null", () => {
+  assert.equal(classifyWall([]), null);
+});
+
+// A lock nobody else holds → reindex acquires it and runs the full path.
+function unlockedLock() {
+  const storage = new MemStorage(null);
+  const lock = new ReindexLock({
+    storage,
+    pid: 4321,
+    isAlive: () => false,
+    now: () => new Date("2026-05-31T18:00:00Z"),
+  });
+  return { lock, storage };
+}
+
+// Embedder spy — records how many document batches it embedded.
+function spyEmbedder(): { embedder: Embedder; calls: () => number } {
+  let n = 0;
+  const embedder: Embedder = {
+    identity: { providerId: "fake", model: "spy", dimension: 2 },
+    embedDocuments: async (texts) => {
+      n++;
+      return texts.map(() => [0.1, 0.2]);
+    },
+    embedQuery: async () => [0.1, 0.2],
+  };
+  return { embedder, calls: () => n };
+}
+
+// In-memory store ports + recorder, all effects overridable.
+type IndexedDoc = {
+  relativePath: string;
+  title: string;
+  type: string;
+  tags: string[];
+  hash: string;
+  chunks: Array<{ section: string; content: string; chunkIndex: number; embedding: number[] }>;
+  sourceUrl: string | null;
+};
+
+function fakePorts(overrides: Partial<ReindexStorePorts> = {}) {
+  const calls = {
+    stamped: [] as EmbedderIdentity[],
+    indexed: [] as string[],
+    docs: [] as IndexedDoc[],
+    removedWith: [] as Set<string>[],
+  };
+  const base: ReindexStorePorts = {
+    scan: async () => [],
+    readFile: async () => "",
+    getDocumentHash: () => null,
+    removeDeletedDocs: (paths) => {
+      calls.removedWith.push(paths);
+      return 0;
+    },
+    currentIndexSchemaVersion: () => INDEX_SCHEMA_VERSION,
+    currentIndexIdentity: () => null,
+    stampIndexIdentity: (id) => {
+      calls.stamped.push(id);
+    },
+    indexDocument: (relativePath, title, type, tags, hash, chunks, sourceUrl) => {
+      calls.indexed.push(relativePath);
+      calls.docs.push({ relativePath, title, type, tags, hash, chunks, sourceUrl });
+    },
+  };
+  return { ports: { ...base, ...overrides }, calls };
+}
+
+test("reindex unlocked, pristine index: scans, indexes, stamps identity, releases lock", async () => {
+  const { lock, storage } = unlockedLock();
+  const { embedder, calls: embedCalls } = spyEmbedder();
+  const progress = memProgressStorage();
+  const reporter = new ReindexReporter({
+    storage: progress,
+    now: () => new Date("2026-05-31T18:00:00Z"),
+  });
+  const { ports, calls } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/a.md", relativePath: "a.md" }],
+    readFile: async () => "# A\n\nsome body text for a.",
+    getDocumentHash: () => null, // never indexed → must index
+    removeDeletedDocs: (paths) => {
+      calls.removedWith.push(paths);
+      return 2; // two docs pruned this run
+    },
+  });
+
+  const result = await reindex(false, { lock, embedder, reporter, ports });
+
+  assert.equal(result.scanned, 1);
+  assert.equal(result.indexed, 1);
+  assert.equal(result.skipped, 0);
+  assert.equal(result.removed, 2);
+  assert.deepEqual(result.errors, []);
+  assert.equal(embedCalls(), 1); // the INJECTED embedder was used
+  assert.deepEqual(calls.indexed, ["a.md"]);
+  assert.equal(calls.stamped.length, 1); // pristine → stamped once…
+  assert.deepEqual(calls.stamped[0], embedder.identity); // …with the current embedder
+  assert.equal(storage.load(), null); // lock released in the finally
+
+  // The doc reaches indexDocument fully materialised (chunk fields + embeddings).
+  const indexed = calls.docs[0];
+  assert.equal(indexed.relativePath, "a.md");
+  assert.equal(indexed.hash, sha256("# A\n\nsome body text for a."));
+  assert.ok(indexed.chunks.length >= 1);
+  for (const c of indexed.chunks) {
+    assert.equal(typeof c.section, "string");
+    assert.equal(typeof c.content, "string");
+    assert.equal(typeof c.chunkIndex, "number");
+    assert.deepEqual(c.embedding, [0.1, 0.2]); // the injected embedder's vectors
+  }
+
+  // The scan/skip/prune counts are threaded to the reporter (meta object).
+  const final = progress.load();
+  assert.equal(final?.scanned, 1);
+  assert.equal(final?.skipped, 0);
+  assert.equal(final?.removed, 2);
+});
+
+test("reindex materialises a mirror doc's source_url onto the indexed document", async () => {
+  const { lock } = unlockedLock();
+  const { embedder } = spyEmbedder();
+  const { ports, calls } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/m.md", relativePath: "m.md" }],
+    readFile: async () =>
+      "---\nsource_url: https://notion.so/page\n---\n# M\n\nmirror body.",
+  });
+
+  await reindex(false, { lock, embedder, ports });
+
+  assert.equal(calls.docs[0].sourceUrl, "https://notion.so/page");
+});
+
+test("reindex without a source_url passes null (never undefined) to indexDocument", async () => {
+  const { lock } = unlockedLock();
+  const { embedder } = spyEmbedder();
+  const { ports, calls } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/a.md", relativePath: "a.md" }],
+    readFile: async () => "# A\n\nplain body, no frontmatter source.",
+  });
+
+  await reindex(false, { lock, embedder, ports });
+
+  assert.strictEqual(calls.docs[0].sourceUrl, null);
+});
+
+test("reindex called without a force argument defaults to an incremental (non-forced) run", async () => {
+  const { lock } = unlockedLock();
+  const { embedder } = spyEmbedder();
+  const content = "# A\n\nunchanged body.";
+  const { ports } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/a.md", relativePath: "a.md" }],
+    readFile: async () => content,
+    getDocumentHash: () => sha256(content), // matches → skipped ONLY if not forced
+  });
+
+  const result = await reindex(undefined, { lock, embedder, ports });
+
+  assert.equal(result.skipped, 1); // default force=false honoured the incremental skip
+  assert.equal(result.indexed, 0);
+});
+
+test("reindex incremental: unchanged doc (stored hash matches) is skipped, not re-embedded", async () => {
+  const { lock } = unlockedLock();
+  const { embedder, calls: embedCalls } = spyEmbedder();
+  const content = "# A\n\nunchanged body.";
+  const { ports, calls } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/a.md", relativePath: "a.md" }],
+    readFile: async () => content,
+    getDocumentHash: () => sha256(content), // stored hash == fresh hash → skip
+  });
+
+  const result = await reindex(false, { lock, embedder, ports });
+
+  assert.equal(result.scanned, 1);
+  assert.equal(result.skipped, 1);
+  assert.equal(result.indexed, 0);
+  assert.equal(embedCalls(), 0); // nothing re-embedded
+  assert.deepEqual(calls.indexed, []);
+});
+
+test("reindex: a doc that fails to read is recorded as an error, others proceed", async () => {
+  const { lock } = unlockedLock();
+  const { embedder } = spyEmbedder();
+  const { ports, calls } = fakePorts({
+    scan: async () => [
+      { absolutePath: "/v/bad.md", relativePath: "bad.md" },
+      { absolutePath: "/v/ok.md", relativePath: "ok.md" },
+    ],
+    readFile: async (p) => {
+      if (p === "/v/bad.md") throw new Error("ENOENT");
+      return "# OK\n\nbody.";
+    },
+  });
+
+  const result = await reindex(false, { lock, embedder, ports });
+
+  assert.equal(result.scanned, 2);
+  assert.equal(result.indexed, 1);
+  assert.deepEqual(calls.indexed, ["ok.md"]); // the readable one got indexed
+  assert.equal(result.errors.length, 1);
+  assert.match(result.errors[0], /Read error: bad\.md/);
+});
+
+test("reindex on an already-stamped index (incremental): does NOT re-stamp identity", async () => {
+  const { lock } = unlockedLock();
+  const { embedder } = spyEmbedder();
+  const alreadyStamped: EmbedderIdentity = { providerId: "prev", model: "old", dimension: 2 };
+  const { ports, calls } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/a.md", relativePath: "a.md" }],
+    readFile: async () => "# A\n\nbody.",
+    currentIndexIdentity: () => alreadyStamped, // stamped + not forced → keep it
+  });
+
+  await reindex(false, { lock, embedder, ports });
+
+  assert.equal(calls.stamped.length, 0);
+});
+
+test("reindex forced on a stamped index: re-stamps with the current embedder", async () => {
+  const { lock } = unlockedLock();
+  const { embedder } = spyEmbedder();
+  const alreadyStamped: EmbedderIdentity = { providerId: "prev", model: "old", dimension: 2 };
+  const { ports, calls } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/a.md", relativePath: "a.md" }],
+    readFile: async () => "# A\n\nbody.",
+    currentIndexIdentity: () => alreadyStamped,
+  });
+
+  await reindex(true, { lock, embedder, ports }); // force → re-encode → re-stamp
+
+  assert.equal(calls.stamped.length, 1);
+  assert.deepEqual(calls.stamped[0], embedder.identity);
+});
+
+test("reindex prunes deleted docs using the set of currently-scanned paths", async () => {
+  const { lock } = unlockedLock();
+  const { embedder } = spyEmbedder();
+  const { ports, calls } = fakePorts({
+    scan: async () => [{ absolutePath: "/v/a.md", relativePath: "a.md" }],
+    readFile: async () => "# A\n\nbody.",
+    removeDeletedDocs: (paths) => {
+      calls.removedWith.push(paths);
+      return 3;
+    },
+  });
+
+  const result = await reindex(false, { lock, embedder, ports });
+
+  assert.equal(result.removed, 3);
+  assert.equal(calls.removedWith.length, 1);
+  assert.ok(calls.removedWith[0].has("a.md")); // pruning is scoped to what's still on disk
+});
+
 test("reindex locked by another live process: no-op, zero embedding", async () => {
   const storage = new MemStorage({
     pid: 999,
@@ -79,6 +391,8 @@ test("reindex locked by another live process: no-op, zero embedding", async () =
   const result = await reindex(false, { lock, embedder: embedderSpy });
 
   assert.equal(result.skippedLocked, true);
+  assert.deepEqual(result.errors, []); // the no-op reports no error
+  assert.equal(result.scanned, 0);
   assert.equal(embedCalls, 0); // embedding was never triggered
   assert.equal(storage.load()?.pid, 999); // the other process keeps the lock
 });

--- a/rag/src/lib/index-manager.test.ts
+++ b/rag/src/lib/index-manager.test.ts
@@ -128,6 +128,15 @@ function unlockedLock() {
   return { lock, storage };
 }
 
+// A reporter backed by in-memory storage → reindex tests never touch the real
+// CACHE_DIR (no leaked last-run.json on disk).
+function memReporter(): ReindexReporter {
+  return new ReindexReporter({
+    storage: memProgressStorage(),
+    now: () => new Date("2026-05-31T18:00:00Z"),
+  });
+}
+
 // Embedder spy — records how many document batches it embedded.
 function spyEmbedder(): { embedder: Embedder; calls: () => number } {
   let n = 0;
@@ -240,7 +249,7 @@ test("reindex materialises a mirror doc's source_url onto the indexed document",
       "---\nsource_url: https://notion.so/page\n---\n# M\n\nmirror body.",
   });
 
-  await reindex(false, { lock, embedder, ports });
+  await reindex(false, { lock, embedder, reporter: memReporter(), ports });
 
   assert.equal(calls.docs[0].sourceUrl, "https://notion.so/page");
 });
@@ -253,7 +262,7 @@ test("reindex without a source_url passes null (never undefined) to indexDocumen
     readFile: async () => "# A\n\nplain body, no frontmatter source.",
   });
 
-  await reindex(false, { lock, embedder, ports });
+  await reindex(false, { lock, embedder, reporter: memReporter(), ports });
 
   assert.strictEqual(calls.docs[0].sourceUrl, null);
 });
@@ -268,7 +277,7 @@ test("reindex called without a force argument defaults to an incremental (non-fo
     getDocumentHash: () => sha256(content), // matches → skipped ONLY if not forced
   });
 
-  const result = await reindex(undefined, { lock, embedder, ports });
+  const result = await reindex(undefined, { lock, embedder, reporter: memReporter(), ports });
 
   assert.equal(result.skipped, 1); // default force=false honoured the incremental skip
   assert.equal(result.indexed, 0);
@@ -284,7 +293,7 @@ test("reindex incremental: unchanged doc (stored hash matches) is skipped, not r
     getDocumentHash: () => sha256(content), // stored hash == fresh hash → skip
   });
 
-  const result = await reindex(false, { lock, embedder, ports });
+  const result = await reindex(false, { lock, embedder, reporter: memReporter(), ports });
 
   assert.equal(result.scanned, 1);
   assert.equal(result.skipped, 1);
@@ -307,7 +316,7 @@ test("reindex: a doc that fails to read is recorded as an error, others proceed"
     },
   });
 
-  const result = await reindex(false, { lock, embedder, ports });
+  const result = await reindex(false, { lock, embedder, reporter: memReporter(), ports });
 
   assert.equal(result.scanned, 2);
   assert.equal(result.indexed, 1);
@@ -326,7 +335,7 @@ test("reindex on an already-stamped index (incremental): does NOT re-stamp ident
     currentIndexIdentity: () => alreadyStamped, // stamped + not forced → keep it
   });
 
-  await reindex(false, { lock, embedder, ports });
+  await reindex(false, { lock, embedder, reporter: memReporter(), ports });
 
   assert.equal(calls.stamped.length, 0);
 });
@@ -341,7 +350,7 @@ test("reindex forced on a stamped index: re-stamps with the current embedder", a
     currentIndexIdentity: () => alreadyStamped,
   });
 
-  await reindex(true, { lock, embedder, ports }); // force → re-encode → re-stamp
+  await reindex(true, { lock, embedder, reporter: memReporter(), ports }); // force → re-encode → re-stamp
 
   assert.equal(calls.stamped.length, 1);
   assert.deepEqual(calls.stamped[0], embedder.identity);
@@ -359,7 +368,7 @@ test("reindex prunes deleted docs using the set of currently-scanned paths", asy
     },
   });
 
-  const result = await reindex(false, { lock, embedder, ports });
+  const result = await reindex(false, { lock, embedder, reporter: memReporter(), ports });
 
   assert.equal(result.removed, 3);
   assert.equal(calls.removedWith.length, 1);

--- a/rag/src/lib/index-manager.ts
+++ b/rag/src/lib/index-manager.ts
@@ -1,9 +1,9 @@
 import { readFile } from "fs/promises";
 import { createHash } from "crypto";
-import { scanVault } from "./document-scanner.js";
+import { scanVault, type ScannedFile } from "./document-scanner.js";
 import { parseDocument } from "./frontmatter-parser.js";
 import { chunkMarkdown } from "./chunker.js";
-import { createEmbedder, type Embedder } from "./embedder.js";
+import { createEmbedder, type Embedder, type EmbedderIdentity } from "./embedder.js";
 import {
   getDocumentHash,
   indexDocument,
@@ -20,8 +20,20 @@ import { ReindexLock } from "./reindex-lock.js";
 import { ReindexReporter } from "./reindex-reporter.js";
 import type { WallReason } from "./progress-report.js";
 
-function sha256(content: string): string {
+export function sha256(content: string): string {
   return createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Incremental-diff decision: skip a doc only on a non-forced run whose stored hash
+ * matches the freshly-computed one (content unchanged). Pure → unit-testable.
+ */
+export function shouldSkip(
+  force: boolean,
+  existingHash: string | null,
+  hash: string
+): boolean {
+  return !force && existingHash === hash;
 }
 
 /**
@@ -29,7 +41,7 @@ function sha256(content: string): string {
  * The LOCAL guardrail takes priority: it throws BEFORE the network call, so if it fired,
  * it is the one that cut off first (even if a 429 lingers in an earlier error).
  */
-function classifyWall(errors: string[]): WallReason {
+export function classifyWall(errors: string[]): WallReason {
   if (errors.some((e) => e.includes("DailyCapExceededError"))) return "local-cap";
   if (errors.some((e) => e.includes("429"))) return "google-rate-limit";
   return null;
@@ -45,6 +57,47 @@ export interface IndexResult {
   skippedLocked?: boolean;
 }
 
+/**
+ * Store-side effectful seams of a reindex run (scan, per-doc read/hash, deleted-doc
+ * pruning, index-identity stamp, persistence). Injectable so the whole `runReindex`
+ * orchestration is unit-testable with in-memory fakes — cf. "test the glue too".
+ * Defaults wire the real modules (see {@link defaultStorePorts}).
+ */
+export interface ReindexStorePorts {
+  scan: () => Promise<ScannedFile[]>;
+  readFile: (absolutePath: string) => Promise<string>;
+  getDocumentHash: (relativePath: string) => string | null;
+  removeDeletedDocs: (existingPaths: Set<string>) => number;
+  currentIndexSchemaVersion: () => number | null;
+  currentIndexIdentity: () => EmbedderIdentity | null;
+  stampIndexIdentity: (identity: EmbedderIdentity) => void;
+  indexDocument: (
+    relativePath: string,
+    title: string,
+    type: string,
+    tags: string[],
+    hash: string,
+    chunks: Array<{
+      section: string;
+      content: string;
+      chunkIndex: number;
+      embedding: number[];
+    }>,
+    sourceUrl: string | null
+  ) => void;
+}
+
+const defaultStorePorts: ReindexStorePorts = {
+  scan: () => scanVault(),
+  readFile: (absolutePath) => readFile(absolutePath, "utf-8"),
+  getDocumentHash,
+  removeDeletedDocs,
+  currentIndexSchemaVersion,
+  currentIndexIdentity,
+  stampIndexIdentity,
+  indexDocument,
+};
+
 export interface ReindexOptions {
   /** Single-writer lock (default: file lock in CACHE_DIR). */
   lock?: ReindexLock;
@@ -52,6 +105,8 @@ export interface ReindexOptions {
   embedder?: Embedder;
   /** Progress reporter (default: file persistence in CACHE_DIR). */
   reporter?: ReindexReporter;
+  /** Store-side effect ports — injectable for tests; default the real modules. */
+  ports?: ReindexStorePorts;
 }
 
 export async function reindex(
@@ -61,6 +116,7 @@ export async function reindex(
   const lock = opts.lock ?? new ReindexLock();
   const embedder = opts.embedder ?? createEmbedder();
   const reporter = opts.reporter ?? new ReindexReporter();
+  const ports = opts.ports ?? defaultStorePorts;
 
   // Single-writer: if another process is already indexing, we step aside (no-op) so as
   // not to double the quota consumption. Acquired up front → no pointless scan or DB.
@@ -76,7 +132,7 @@ export async function reindex(
   }
 
   try {
-    return await runReindex(force, embedder, reporter);
+    return await runReindex(force, embedder, reporter, ports);
   } finally {
     lock.release();
   }
@@ -85,7 +141,8 @@ export async function reindex(
 async function runReindex(
   requestedForce: boolean,
   embedder: Embedder,
-  reporter: ReindexReporter
+  reporter: ReindexReporter,
+  ports: ReindexStorePorts
 ): Promise<IndexResult> {
   // A stale index SCHEMA can only be repaired by a full re-encode: an incremental
   // run skips unchanged docs (old format left in place) AND never re-stamps the
@@ -94,10 +151,10 @@ async function runReindex(
   // forces a full reindex — which also restamps the schema via stampIndexIdentity.
   const force = reindexForce(
     requestedForce,
-    currentIndexSchemaVersion(),
+    ports.currentIndexSchemaVersion(),
     INDEX_SCHEMA_VERSION
   );
-  const files = await scanVault();
+  const files = await ports.scan();
   const result: IndexResult = {
     scanned: files.length,
     indexed: 0,
@@ -107,18 +164,18 @@ async function runReindex(
   };
 
   const existingPaths = new Set(files.map((f) => f.relativePath));
-  result.removed = removeDeletedDocs(existingPaths);
+  result.removed = ports.removeDeletedDocs(existingPaths);
 
   // Phase 1 — scan + incremental diff + chunking (no network). We prepare the
   // docs to (re)index; unchanged ones (identical hash) are skipped.
   const toIndex: PreparedDoc[] = [];
   for (const file of files) {
     try {
-      const raw = await readFile(file.absolutePath, "utf-8");
+      const raw = await ports.readFile(file.absolutePath);
       const hash = sha256(raw);
-      const existingHash = getDocumentHash(file.relativePath);
+      const existingHash = ports.getDocumentHash(file.relativePath);
 
-      if (!force && existingHash === hash) {
+      if (shouldSkip(force, existingHash, hash)) {
         result.skipped++;
         continue;
       }
@@ -152,8 +209,8 @@ async function runReindex(
   // Incrementally on an already-stamped index, we don't touch it (we never
   // dress up a mixed index as "fresh"). Stamped BEFORE the phase: even a run cut off
   // by the quota wall leaves an index consistent in identity (everything = current embedder).
-  if (shouldStamp(force, currentIndexIdentity())) {
-    stampIndexIdentity(embedder.identity);
+  if (shouldStamp(force, ports.currentIndexIdentity())) {
+    ports.stampIndexIdentity(embedder.identity);
   }
 
   const runResult = await runIndexingPhase(
@@ -161,7 +218,7 @@ async function runReindex(
     {
       embed: (texts) => embedder.embedDocuments(texts),
       persist: (doc, embeddings) =>
-        indexDocument(
+        ports.indexDocument(
           doc.relativePath,
           doc.title,
           doc.type,

--- a/rag/src/lib/lib-coverage-guard.test.ts
+++ b/rag/src/lib/lib-coverage-guard.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync } from "fs";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// Modules under src/lib that intentionally ship WITHOUT a sibling unit test.
+// Adding a name here must be a CONSCIOUS, reviewed decision with a reason in the
+// comment — never a silent skip. Empty by design: the document-scanner /
+// vault-watcher 0%-mutation gap came precisely from "it's just I/O glue, no test
+// needed" dismissals. Pure I/O glue still hides logic; extract it behind a port
+// and test it (see maintainers/CONVENTIONS.md, "Test the glue too").
+const EXEMPT = new Set<string>([]);
+
+// Deterministic guardrail (ADR 0009 spirit): every logic module in src/lib must
+// carry a sibling *.test.ts. Catches the "no test at all" gap instantly — without
+// waiting for a mutation run — and fails LOUD with the offending file names.
+test("every src/lib module has a sibling *.test.ts (no silently-untested logic)", () => {
+  const entries = readdirSync(here);
+  const tests = new Set(entries.filter((f) => f.endsWith(".test.ts")));
+  const prod = entries.filter(
+    (f) => f.endsWith(".ts") && !f.endsWith(".test.ts") && !f.endsWith(".d.ts")
+  );
+
+  const missing = prod.filter(
+    (f) => !EXEMPT.has(f) && !tests.has(f.replace(/\.ts$/, ".test.ts"))
+  );
+
+  assert.deepEqual(
+    missing,
+    [],
+    `These src/lib modules have no sibling test (add one, or justify in EXEMPT): ${missing.join(", ")}`
+  );
+});

--- a/rag/src/lib/vault-watcher.test.ts
+++ b/rag/src/lib/vault-watcher.test.ts
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { FSWatcher, ChokidarOptions } from "chokidar";
+import { VAULT_DIR } from "./config.js";
+import {
+  isIgnoredPath,
+  startVaultWatcher,
+  type WatchFactory,
+} from "./vault-watcher.js";
+
+test("ignores paths nested under a .git / .cache / node_modules segment", () => {
+  assert.equal(isIgnoredPath("/vault/.git/config"), true);
+  assert.equal(isIgnoredPath("/vault/notes/node_modules/x.md"), true);
+  assert.equal(isIgnoredPath("/vault/a/.cache/b.md"), true);
+});
+
+test("ignores a path that ends on an ignored segment", () => {
+  assert.equal(isIgnoredPath("/vault/.git"), true);
+  assert.equal(isIgnoredPath("/vault/sub/node_modules"), true);
+});
+
+test("watches a regular vault note", () => {
+  assert.equal(isIgnoredPath("/vault/topics/note.md"), false);
+});
+
+test("does not ignore a segment merely containing an ignored name", () => {
+  // `.gitignore` contains ".git" but is a real note path, not the .git dir.
+  assert.equal(isIgnoredPath("/vault/.gitignore"), false);
+  assert.equal(isIgnoredPath("/vault/my-node_modules-notes.md"), false);
+});
+
+type Handler = (p: string) => void;
+
+// Records every `.on(event, handler)` registration and can replay events,
+// standing in for chokidar's FSWatcher without touching the filesystem.
+class FakeWatcher {
+  readonly handlers: Record<string, Handler> = {};
+  on(event: string, handler: Handler): this {
+    this.handlers[event] = handler;
+    return this;
+  }
+  emit(event: string, path: string): void {
+    this.handlers[event]?.(path);
+  }
+}
+
+function recordingFactory() {
+  const watcher = new FakeWatcher();
+  const calls: { dir: string; options: ChokidarOptions }[] = [];
+  const factory: WatchFactory = (dir, options) => {
+    calls.push({ dir, options });
+    return watcher as unknown as FSWatcher;
+  };
+  return { factory, watcher, calls };
+}
+
+test("forwards add, change and unlink events to onChange", () => {
+  const seen: string[] = [];
+  const { factory, watcher } = recordingFactory();
+  startVaultWatcher({ onChange: (p) => seen.push(p) }, factory);
+
+  watcher.emit("add", "/vault/added.md");
+  watcher.emit("change", "/vault/edited.md");
+  watcher.emit("unlink", "/vault/removed.md");
+
+  assert.deepEqual(seen, [
+    "/vault/added.md",
+    "/vault/edited.md",
+    "/vault/removed.md",
+  ]);
+});
+
+test("watches the explicitly provided vault directory", () => {
+  const { factory, calls } = recordingFactory();
+  startVaultWatcher({ onChange: () => {}, vaultDir: "/custom/vault" }, factory);
+  assert.equal(calls[0].dir, "/custom/vault");
+});
+
+test("falls back to VAULT_DIR when no directory is provided", () => {
+  const { factory, calls } = recordingFactory();
+  startVaultWatcher({ onChange: () => {} }, factory);
+  assert.equal(calls[0].dir, VAULT_DIR);
+});
+
+test("skips the initial scan and stays persistent", () => {
+  const { factory, calls } = recordingFactory();
+  startVaultWatcher({ onChange: () => {} }, factory);
+  assert.equal(calls[0].options.ignoreInitial, true);
+  assert.equal(calls[0].options.persistent, true);
+});
+
+test("wires the ignore predicate into chokidar", () => {
+  const { factory, calls } = recordingFactory();
+  startVaultWatcher({ onChange: () => {} }, factory);
+  const ignored = calls[0].options.ignored as (p: string) => boolean;
+  assert.equal(ignored("/vault/.git/config"), true);
+  assert.equal(ignored("/vault/note.md"), false);
+});
+
+test("returns the created watcher", () => {
+  const { factory, watcher } = recordingFactory();
+  const result = startVaultWatcher({ onChange: () => {} }, factory);
+  assert.equal(result, watcher as unknown as FSWatcher);
+});
+
+// Exercises the REAL default factory (chokidar) — without it the I/O adapter
+// `(dir, options) => watch(dir, options)` is never run. Deterministic: it asserts
+// a live, closeable watcher is built (no fs-event timing), then closes it.
+test("the default factory builds a real, closeable chokidar watcher", async () => {
+  const root = await mkdtemp(join(tmpdir(), "sbg-watch-"));
+  try {
+    const watcher = startVaultWatcher({ onChange: () => {}, vaultDir: root });
+    assert.equal(typeof watcher.close, "function");
+    await watcher.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/rag/src/lib/vault-watcher.ts
+++ b/rag/src/lib/vault-watcher.ts
@@ -1,4 +1,4 @@
-import { watch, type FSWatcher } from "chokidar";
+import { watch, type FSWatcher, type ChokidarOptions } from "chokidar";
 import { VAULT_DIR } from "./config.js";
 
 export interface VaultWatcherOptions {
@@ -16,20 +16,35 @@ export interface VaultWatcherOptions {
 const IGNORED_SEGMENTS = [".cache", ".git", "node_modules"];
 
 /**
+ * True when `p` sits inside (or terminates on) an ignored segment — matched on
+ * full `/segment/` boundaries so a note like `.gitignore` is NOT mistaken for `.git`.
+ * Pure + unit-tested.
+ */
+export function isIgnoredPath(p: string): boolean {
+  return IGNORED_SEGMENTS.some(
+    (seg) => p.includes(`/${seg}/`) || p.endsWith(`/${seg}`)
+  );
+}
+
+/** Creates the underlying filesystem watcher — injectable so wiring is unit-testable. */
+export type WatchFactory = (dir: string, options: ChokidarOptions) => FSWatcher;
+
+const defaultWatch: WatchFactory = (dir, options) => watch(dir, options);
+
+/**
  * Thin I/O layer: a filesystem watcher (chokidar) on the vault that notifies on
  * every write. All the debounce/coalescing logic lives in `ReindexScheduler`
- * (tested separately) — here we just relay the event. Not unit-tested: pure I/O
- * glue on top of chokidar.
+ * (tested separately) — here we just relay the event.
  */
-export function startVaultWatcher(opts: VaultWatcherOptions): FSWatcher {
+export function startVaultWatcher(
+  opts: VaultWatcherOptions,
+  watchFactory: WatchFactory = defaultWatch
+): FSWatcher {
   const dir = opts.vaultDir ?? VAULT_DIR;
-  const watcher = watch(dir, {
+  const watcher = watchFactory(dir, {
     // The startup reindex already covers existing files → we only react to writes.
     ignoreInitial: true,
-    ignored: (p: string) =>
-      IGNORED_SEGMENTS.some(
-        (seg) => p.includes(`/${seg}/`) || p.endsWith(`/${seg}`)
-      ),
+    ignored: (p: string) => isIgnoredPath(p),
     persistent: true,
   });
   watcher.on("add", (p) => opts.onChange(p));

--- a/rag/src/lib/vector-store.singleton.test.ts
+++ b/rag/src/lib/vector-store.singleton.test.ts
@@ -1,0 +1,57 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Exercises the getDb() SINGLETON path end-to-end (real better-sqlite3, real
+// on-disk file) — the only way to kill the thin `return fooIn(getDb(), …)`
+// wrappers that the in-memory *In tests cannot reach. The DB location is rooted
+// at a throwaway temp dir via CACHE_DIR, which config.ts freezes into DB_PATH at
+// import time; hence the env MUST be set BEFORE importing the module, and the
+// import MUST be dynamic (a static import is hoisted ahead of this line).
+const cacheDir = mkdtempSync(join(tmpdir(), "vs-singleton-"));
+process.env.CACHE_DIR = cacheDir;
+
+const vs = await import("./vector-store.js");
+
+after(() => {
+  vs.closeDb();
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test("singleton: stamp then read identity round-trips through getDb()", () => {
+  vs.stampIndexIdentity({ providerId: "gemini", model: "m", dimension: 7 });
+
+  assert.deepEqual(vs.currentIndexIdentity(), {
+    providerId: "gemini",
+    model: "m",
+    dimension: 7,
+  });
+  assert.equal(vs.currentIndexSchemaVersion(), vs.INDEX_SCHEMA_VERSION);
+});
+
+test("singleton: index → hash, search, list, stats, remove via getDb()", () => {
+  vs.indexDocument(
+    "doc.md",
+    "Doc",
+    "note",
+    ["t"],
+    "hh",
+    [{ section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] }],
+    "https://x"
+  );
+
+  assert.equal(vs.getDocumentHash("doc.md"), "hh");
+
+  const hits = vs.searchSimilar([1, 0], 5);
+  assert.equal(hits[0].path, "doc.md");
+  assert.equal(hits[0].sourceUrl, "https://x");
+
+  assert.equal(vs.listDocuments().length, 1);
+  assert.equal(vs.getStats().docCount, 1);
+
+  // Absent from the existing set → removed, and the store is empty afterwards.
+  assert.equal(vs.removeDeletedDocs(new Set<string>()), 1);
+  assert.equal(vs.listDocuments().length, 0);
+});

--- a/rag/src/lib/vector-store.test.ts
+++ b/rag/src/lib/vector-store.test.ts
@@ -8,7 +8,24 @@ import {
   readIndexSchemaVersion,
   indexDocumentIn,
   searchSimilarIn,
+  getDocumentHashIn,
+  listDocumentsIn,
+  getStatsIn,
+  removeDeletedDocsIn,
 } from "./vector-store.js";
+
+// Mutation hardening (Stryker, 2026-06-26): 33.8% → ~92%. The residual survivors
+// are documented EQUIVALENT mutants, not test gaps:
+//   - ragRoot() / rebuildBetterSqlite() (native-ABI rebuild path) — only runs on a
+//     better-sqlite3 ABI mismatch, an environment we cannot provoke from a unit
+//     test; the rebuild invocation itself is covered by native-deps.test.ts.
+//   - getDb()'s `if (!db)` flipped to `if (true)` — harmless against a FILE-backed
+//     DB: a fresh connection re-reads the same on-disk data, so behaviour is
+//     preserved (only connection churn differs, not correctness).
+//   - closeDb() — pure shutdown cleanup (db.close + null); the singleton handle is
+//     module-private, so "is it closed?" has no unit-observable contract.
+// Everything with an observable contract is killed below, incl. the getDb()
+// singleton wrappers (vector-store.singleton.test.ts) and applySchema idempotency.
 
 test("index_meta: identity round-trip (written at indexing time, read back afterwards)", () => {
   const db = new Database(":memory:");
@@ -42,6 +59,13 @@ test("index_meta: an index stamped before schema versioning reads back null", ()
   applySchema(db);
 
   assert.equal(readIndexSchemaVersion(db), null);
+});
+
+test("index_meta: an unstamped index reads back a null identity", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+
+  assert.equal(readIndexIdentity(db), null);
 });
 
 function columnNames(db: Database.Database, table: string): string[] {
@@ -88,6 +112,283 @@ test("a note without a source_url reads back null (grandfathered / non-mirror)",
   assert.equal(results[0].sourceUrl, null);
 });
 
+// --- cosineSimilarity (exercised through searchSimilarIn) ---------------------
+// Two cases pin every arithmetic/assignment term: identical vectors must score
+// exactly 1, and an asymmetric pair must score the hand-computed cosine.
+
+test("cosineSimilarity: identical query and embedding score exactly 1", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "n.md", "N", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [3, 4] },
+  ]);
+
+  const [hit] = searchSimilarIn(db, [3, 4], 5);
+
+  assert.ok(Math.abs(hit.score - 1) < 1e-6, `expected ~1, got ${hit.score}`);
+});
+
+test("cosineSimilarity: asymmetric vectors score the exact cosine (4/5)", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  // query [1,2] · stored [2,1] = 4 ; |q|=|s|=√5 → 4/(√5·√5) = 0.8.
+  // Asymmetric on purpose: distinguishes `+=` from `=` (which keeps the last
+  // term only) and `*` from `/` in dot/norm accumulation.
+  indexDocumentIn(db, "n.md", "N", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [2, 1] },
+  ]);
+
+  const [hit] = searchSimilarIn(db, [1, 2], 5);
+
+  assert.ok(Math.abs(hit.score - 0.8) < 1e-6, `expected 0.8, got ${hit.score}`);
+});
+
+// --- getDocumentHashIn --------------------------------------------------------
+
+test("getDocumentHashIn: returns the stored hash for a known doc", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "n.md", "N", "note", [], "deadbeef", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  assert.equal(getDocumentHashIn(db, "n.md"), "deadbeef");
+});
+
+test("getDocumentHashIn: returns null for an unknown doc", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+
+  assert.equal(getDocumentHashIn(db, "missing.md"), null);
+});
+
+// --- listDocumentsIn ----------------------------------------------------------
+
+function seedDocs(db: Database.Database): void {
+  indexDocumentIn(db, "b.md", "B", "note", ["x"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "a.md", "A", "person", ["y"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+}
+
+test("listDocumentsIn: returns every doc ordered by path", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  seedDocs(db);
+
+  assert.deepEqual(
+    listDocumentsIn(db).map((d) => d.path),
+    ["a.md", "b.md"]
+  );
+});
+
+test("listDocumentsIn: typeFilter narrows to a single type", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  seedDocs(db);
+
+  assert.deepEqual(
+    listDocumentsIn(db, "person").map((d) => d.path),
+    ["a.md"]
+  );
+});
+
+test("listDocumentsIn: tagFilter narrows to docs carrying the tag", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  seedDocs(db);
+
+  assert.deepEqual(
+    listDocumentsIn(db, undefined, "x").map((d) => d.path),
+    ["b.md"]
+  );
+});
+
+test("listDocumentsIn: type AND tag filters combine (both clauses required)", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "match.md", "M", "person", ["teamA"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "type-only.md", "T", "person", ["teamB"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "tag-only.md", "G", "note", ["teamA"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  assert.deepEqual(
+    listDocumentsIn(db, "person", "teamA").map((d) => d.path),
+    ["match.md"]
+  );
+});
+
+// --- getStatsIn ---------------------------------------------------------------
+
+test("getStatsIn: counts docs and chunks and ranks types by frequency", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  // two notes, one person → types ranked note(2) before person(1).
+  indexDocumentIn(db, "n1.md", "N1", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+    { section: "S", content: "c", chunkIndex: 1, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "n2.md", "N2", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "p.md", "P", "person", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  const stats = getStatsIn(db);
+
+  assert.equal(stats.docCount, 3);
+  assert.equal(stats.chunkCount, 4);
+  assert.deepEqual(stats.types, [
+    { type: "note", n: 2 },
+    { type: "person", n: 1 },
+  ]);
+});
+
+// --- removeDeletedDocsIn ------------------------------------------------------
+
+test("removeDeletedDocsIn: deletes docs absent from the existing set, with their chunks", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "keep.md", "K", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "gone.md", "G", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  const removed = removeDeletedDocsIn(db, new Set(["keep.md"]));
+
+  assert.equal(removed, 1);
+  assert.deepEqual(
+    listDocumentsIn(db).map((d) => d.path),
+    ["keep.md"]
+  );
+  // the orphaned chunk is gone too (no result for the deleted doc).
+  assert.equal(searchSimilarIn(db, [1, 0], 5).length, 1);
+});
+
+test("removeDeletedDocsIn: removes nothing when every doc still exists", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "a.md", "A", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  assert.equal(removeDeletedDocsIn(db, new Set(["a.md"])), 0);
+  assert.equal(listDocumentsIn(db).length, 1);
+});
+
+// --- searchSimilarIn: ranking, limit and filters ------------------------------
+
+function seedRanked(db: Database.Database): void {
+  // Against query [1,0]: a→1, b→1/√2≈0.707, c→0 (strictly decreasing).
+  // Inserted in a DELIBERATELY un-sorted order (c, a, b) so that dropping the
+  // sort (or neutering its comparator) leaves the rows in insertion order and the
+  // assertion fails — otherwise a no-op sort would pass on already-ordered rows.
+  indexDocumentIn(db, "c.md", "C", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [0, 1] },
+  ]);
+  indexDocumentIn(db, "a.md", "A", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "b.md", "B", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 1] },
+  ]);
+}
+
+test("searchSimilarIn: results are ordered by descending score", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  seedRanked(db);
+
+  const results = searchSimilarIn(db, [1, 0], 5);
+
+  assert.deepEqual(
+    results.map((r) => r.path),
+    ["a.md", "b.md", "c.md"]
+  );
+});
+
+test("searchSimilarIn: limit keeps only the top-N hits", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  seedRanked(db);
+
+  const results = searchSimilarIn(db, [1, 0], 2);
+
+  assert.deepEqual(
+    results.map((r) => r.path),
+    ["a.md", "b.md"]
+  );
+});
+
+test("searchSimilarIn: typeFilter keeps only matching-type docs", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "note.md", "N", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "person.md", "P", "person", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  const results = searchSimilarIn(db, [1, 0], 5, "person");
+
+  assert.deepEqual(
+    results.map((r) => r.path),
+    ["person.md"]
+  );
+});
+
+test("searchSimilarIn: tagFilter keeps only docs carrying the tag", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "tagged.md", "T", "note", ["projectX"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  indexDocumentIn(db, "plain.md", "P", "note", [], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  const results = searchSimilarIn(db, [1, 0], 5, undefined, "projectX");
+
+  assert.deepEqual(
+    results.map((r) => r.path),
+    ["tagged.md"]
+  );
+});
+
+test("searchSimilarIn: type AND tag filters combine (both clauses required)", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+  indexDocumentIn(db, "match.md", "M", "person", ["teamA"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  // Right type, wrong tag — excluded only if the two clauses are AND-combined.
+  indexDocumentIn(db, "type-only.md", "T", "person", ["teamB"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+  // Right tag, wrong type — same.
+  indexDocumentIn(db, "tag-only.md", "G", "note", ["teamA"], "h", [
+    { section: "S", content: "c", chunkIndex: 0, embedding: [1, 0] },
+  ]);
+
+  const results = searchSimilarIn(db, [1, 0], 5, "person", "teamA");
+
+  assert.deepEqual(
+    results.map((r) => r.path),
+    ["match.md"]
+  );
+});
+
 test("documents: applySchema migrates a pre-source_url table out of band", () => {
   const db = new Database(":memory:");
   // A brain indexed before this column existed: CREATE IF NOT EXISTS is a no-op,
@@ -106,4 +407,38 @@ test("documents: applySchema migrates a pre-source_url table out of band", () =>
   applySchema(db);
 
   assert.ok(columnNames(db, "documents").includes("source_url"));
+});
+
+test("applySchema is idempotent: a second run adds no duplicate column", () => {
+  const db = new Database(":memory:");
+  applySchema(db);
+
+  // The out-of-band ALTERs are guarded by hasColumn; without the guard a second
+  // run would throw "duplicate column". This pins the guard (kills if→true and
+  // the column-name literal) AND documents the real idempotency contract: getDb
+  // and a reindex can both call applySchema on the same DB.
+  assert.doesNotThrow(() => applySchema(db));
+  assert.equal(
+    columnNames(db, "index_meta").filter((c) => c === "index_schema_version")
+      .length,
+    1
+  );
+});
+
+test("index_meta: applySchema migrates a pre-version table out of band", () => {
+  const db = new Database(":memory:");
+  // A brain whose index_meta predates schema versioning: CREATE IF NOT EXISTS is
+  // a no-op, so the index_schema_version column must be added out of band.
+  db.exec(`
+    CREATE TABLE index_meta (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      provider_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      dimension INTEGER NOT NULL
+    );
+  `);
+
+  applySchema(db);
+
+  assert.ok(columnNames(db, "index_meta").includes("index_schema_version"));
 });

--- a/rag/src/lib/vector-store.ts
+++ b/rag/src/lib/vector-store.ts
@@ -185,7 +185,15 @@ export function currentIndexSchemaVersion(): number | null {
 }
 
 export function getDocumentHash(path: string): string | null {
-  const row = getDb()
+  return getDocumentHashIn(getDb(), path);
+}
+
+/** DB-injectable core of {@link getDocumentHash} — testable in-memory. */
+export function getDocumentHashIn(
+  d: Database.Database,
+  path: string
+): string | null {
+  const row = d
     .prepare("SELECT hash FROM documents WHERE path = ?")
     .get(path) as { hash: string } | undefined;
   return row?.hash ?? null;
@@ -353,7 +361,15 @@ export function searchSimilarIn(
 }
 
 export function listDocuments(typeFilter?: string, tagFilter?: string) {
-  const d = getDb();
+  return listDocumentsIn(getDb(), typeFilter, tagFilter);
+}
+
+/** DB-injectable core of {@link listDocuments} — testable in-memory. */
+export function listDocumentsIn(
+  d: Database.Database,
+  typeFilter?: string,
+  tagFilter?: string
+) {
   let sql = "SELECT path, title, type, tags, updated_at FROM documents";
   const conditions: string[] = [];
   const params: unknown[] = [];
@@ -381,7 +397,11 @@ export function listDocuments(typeFilter?: string, tagFilter?: string) {
 }
 
 export function getStats() {
-  const d = getDb();
+  return getStatsIn(getDb());
+}
+
+/** DB-injectable core of {@link getStats} — testable in-memory. */
+export function getStatsIn(d: Database.Database) {
   const docCount = (
     d.prepare("SELECT COUNT(*) as n FROM documents").get() as { n: number }
   ).n;
@@ -395,7 +415,14 @@ export function getStats() {
 }
 
 export function removeDeletedDocs(existingPaths: Set<string>): number {
-  const d = getDb();
+  return removeDeletedDocsIn(getDb(), existingPaths);
+}
+
+/** DB-injectable core of {@link removeDeletedDocs} — testable in-memory. */
+export function removeDeletedDocsIn(
+  d: Database.Database,
+  existingPaths: Set<string>
+): number {
   const allDocs = d.prepare("SELECT path FROM documents").all() as Array<{ path: string }>;
   let removed = 0;
   for (const doc of allDocs) {

--- a/scripts/auto-commit.mjs
+++ b/scripts/auto-commit.mjs
@@ -10,29 +10,64 @@
 // script location (not the hook's cwd).
 // ─────────────────────────────────────────────────────────────────────────────
 import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+// Builds the real git runner bound to `repo`. `execFile` is injected (default:
+// execFileSync) so the ok/failure mapping is unit-testable without a real git.
+export function buildGit(repo, execFile = execFileSync) {
+  return (args) => {
+    try {
+      const out = execFile("git", args, {
+        cwd: repo,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      return { out: out ?? "", ok: true };
+    } catch (e) {
+      return { out: `${e.stdout ?? ""}${e.stderr ?? ""}`, ok: false };
+    }
+  };
+}
 
-function git(args) {
+export const COMMIT_MESSAGE = "auto: vault/claude sync";
+
+// Commit-only vault persistence: if the tree is dirty, stage everything and
+// commit (never pushes — the Stop hook does that once per turn). Returns
+// "committed" | "clean". `git` is the injected runner. NEVER throws for a clean
+// tree; a failing git runner is best-effort (the local commit is the safety net).
+export function attemptCommit({ git }) {
+  const dirty = git(["status", "--porcelain"]).out.trim().length > 0;
+  if (!dirty) return "clean";
+  git(["add", "."]);
+  git(["commit", "-m", COMMIT_MESSAGE]);
+  return "committed";
+}
+
+// Repo root derived from THIS module's location (one level up from scripts/),
+// not the hook's cwd. `metaUrl` is injected so it is testable.
+export function repoRoot(metaUrl) {
+  return resolve(dirname(fileURLToPath(metaUrl)), "..");
+}
+
+// Is THIS module the process entry point (invoked as the hook), vs merely
+// imported by a test? Compare REAL paths — import.meta.url is already symlink-
+// resolved by Node, so we realpath argv[1] too (macOS /var → /private/var).
+export function isEntryPoint(argv1, metaUrl) {
   try {
-    const out = execFileSync("git", args, {
-      cwd: REPO,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return { out: out ?? "", ok: true };
-  } catch (e) {
-    return { out: `${e.stdout ?? ""}${e.stderr ?? ""}`, ok: false };
+    // A falsy/absent argv1 makes realpathSync throw → caught → false (imported case).
+    return realpathSync(argv1) === fileURLToPath(metaUrl);
+  } catch {
+    return false;
   }
 }
 
-const dirty = git(["status", "--porcelain"]).out.trim().length > 0;
-if (!dirty) process.exit(0);
-
-git(["add", "."]);
-git(["commit", "-m", "auto: vault/claude sync"]);
-// No push here — the Stop hook (auto-push.mjs) pushes pending commits once per
-// turn. The opt-in gate (secondbrain.autopush) + inherited-remote safety now
-// live there.
+// ── CLI entry (the actual PostToolUse hook) ──────────────────────────────────
+// Guarded so importing this module in tests does NOT run it. Commit-only; the
+// push moved to the Stop hook (auto-push.mjs). No explicit process.exit: the
+// work is fully synchronous (execFileSync), so Node exits 0 on its own — and
+// NOT exiting at import time keeps the module unit-testable under mutation.
+if (isEntryPoint(process.argv[1], import.meta.url)) {
+  attemptCommit({ git: buildGit(repoRoot(import.meta.url)) });
+}

--- a/scripts/auto-commit.test.mjs
+++ b/scripts/auto-commit.test.mjs
@@ -2,14 +2,28 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, copyFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
+import {
+  buildGit,
+  attemptCommit,
+  repoRoot,
+  isEntryPoint,
+  COMMIT_MESSAGE,
+} from "./auto-commit.mjs";
 
 // NON-REGRESSION test: locks in the "no remote" behavior of auto-commit.mjs
 // (local commit, NO push attempted, NO error). This is the foundation of the
 // "no remote repository = safe" decision (cf. PLAN §3.4 / §5.E).
 // Green right away: we characterize an already-correct behavior, not an addition.
+//
+// Mutation score 98.21 % — the single residual survivor is a documented equivalent:
+// the `if (isEntryPoint(...))` guard forced to `if (true)`. It only matters when the
+// module IS the process; under the command runner, forcing it true merely self-runs
+// attemptCommit at import (harmless, no assertion observes it). Effective 100 % on
+// non-equivalents. (The integration tests below drive the REAL script as a subprocess,
+// which is what kills the entry-body/BlockStatement mutants a pure import cannot.)
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REAL_SCRIPT = join(HERE, "auto-commit.mjs");
@@ -60,6 +74,103 @@ function addBareRemote(root, git) {
   };
   return { bare, headCount };
 }
+
+// ── Unit tests for the extracted, injectable core ────────────────────────────
+// Fake git keyed on the full command; records calls so we assert the exact
+// staging/commit commands (message included).
+function fakeGit({ status = "" } = {}) {
+  const calls = [];
+  const git = (args) => {
+    calls.push(args.join(" "));
+    if (args[0] === "status") return { out: status, ok: true };
+    return { out: "", ok: true };
+  };
+  return { git, calls };
+}
+
+test("attemptCommit — dirty tree: stages all + commits with the auto message → committed", () => {
+  const { git, calls } = fakeGit({ status: " M note.md\n" });
+  assert.equal(attemptCommit({ git }), "committed");
+  assert.deepEqual(calls, [
+    "status --porcelain",
+    "add .",
+    `commit -m ${COMMIT_MESSAGE}`,
+  ]);
+});
+
+test("attemptCommit — clean tree: no add, no commit → clean (idempotent)", () => {
+  const { git, calls } = fakeGit({ status: "" });
+  assert.equal(attemptCommit({ git }), "clean");
+  assert.deepEqual(calls, ["status --porcelain"]);
+});
+
+test("attemptCommit — whitespace-only status counts as clean (trim)", () => {
+  const { git, calls } = fakeGit({ status: "\n  \n" });
+  assert.equal(attemptCommit({ git }), "clean");
+  assert.ok(!calls.some((c) => c.startsWith("add")), "no staging on a whitespace-only status");
+});
+
+test("COMMIT_MESSAGE — is the stable auto: sync message", () => {
+  assert.equal(COMMIT_MESSAGE, "auto: vault/claude sync");
+});
+
+test("buildGit — maps a successful execFile to {out, ok:true} with the right git call", () => {
+  const seen = [];
+  const git = buildGit("/repo", (bin, args, opts) => {
+    seen.push({ bin, args, opts });
+    return "output";
+  });
+  assert.deepEqual(git(["status", "--porcelain"]), { out: "output", ok: true });
+  assert.equal(seen[0].bin, "git");
+  assert.deepEqual(seen[0].args, ["status", "--porcelain"]);
+  assert.equal(seen[0].opts.cwd, "/repo");
+  assert.equal(seen[0].opts.encoding, "utf8");
+  assert.deepEqual(seen[0].opts.stdio, ["ignore", "pipe", "pipe"]);
+});
+
+test("buildGit — null execFile output becomes '' (ok:true)", () => {
+  const git = buildGit("/repo", () => null);
+  assert.deepEqual(git(["status"]), { out: "", ok: true });
+});
+
+test("buildGit — a throwing execFile → {ok:false}, out = stdout+stderr concatenated", () => {
+  const git = buildGit("/repo", () => {
+    const e = new Error("boom");
+    e.stdout = "OUT";
+    e.stderr = "ERR";
+    throw e;
+  });
+  assert.deepEqual(git(["commit"]), { out: "OUTERR", ok: false });
+});
+
+test("buildGit — throwing execFile with no stdout/stderr → out = '' (ok:false)", () => {
+  const git = buildGit("/repo", () => { throw new Error("boom"); });
+  assert.deepEqual(git(["commit"]), { out: "", ok: false });
+});
+
+test("repoRoot — resolves ONE level up from the module (scripts/ → repo root)", () => {
+  const here = fileURLToPath(import.meta.url);
+  assert.equal(repoRoot(import.meta.url), resolve(dirname(here), ".."));
+  assert.notEqual(repoRoot(import.meta.url), dirname(here));
+});
+
+test("isEntryPoint — true when argv1 realpath matches the module URL", () => {
+  const me = fileURLToPath(import.meta.url);
+  assert.equal(isEntryPoint(me, import.meta.url), true);
+});
+
+test("isEntryPoint — false when argv1 points at a different file", () => {
+  assert.equal(isEntryPoint(REAL_SCRIPT, import.meta.url), false);
+});
+
+test("isEntryPoint — false for a missing argv1 (imported, not invoked)", () => {
+  assert.equal(isEntryPoint(undefined, import.meta.url), false);
+  assert.equal(isEntryPoint("", import.meta.url), false);
+});
+
+test("isEntryPoint — false (not throwing) when argv1 does not exist on disk", () => {
+  assert.equal(isEntryPoint("/no/such/path/x.mjs", import.meta.url), false);
+});
 
 test("auto-commit — no remote: local commit, no push, no error", () => {
   const { root, git } = makeRepo();

--- a/scripts/auto-push.mjs
+++ b/scripts/auto-push.mjs
@@ -46,16 +46,14 @@ export function attemptPush({ git, sleep }) {
   }
 }
 
-// ── CLI entry (the actual Stop hook) ─────────────────────────────────────────
-// Guarded so importing this module in tests does NOT run it. Wires the real git
-// runner + a real blocking pause, then ALWAYS exits 0 (best-effort, ignores the
-// hook stdin). A failed push only prints a non-blocking warning.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const git = (args) => {
+// ── CLI wiring (the real Stop hook seams, extracted so they are testable) ────
+// Builds the real git runner bound to `repo`. `execFile` is injected (default:
+// execFileSync) so the ok/failure mapping is unit-testable without a real git.
+export function buildGit(repo, execFile = execFileSync) {
+  return (args) => {
     try {
-      const out = execFileSync("git", args, {
-        cwd: REPO,
+      const out = execFile("git", args, {
+        cwd: repo,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -64,15 +62,41 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
       return { out: `${e.stdout ?? ""}${e.stderr ?? ""}`, ok: false };
     }
   };
-  // Blocking pause (the hook runs synchronously, under a Claude Code timeout).
-  const sleep = (ms) =>
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
-  if (attemptPush({ git, sleep }) === "failed") {
-    process.stdout.write(
-      "\n⚠️  PUSH FAILED — local commits OK but not pushed. Check your network; " +
-        "the next turn will retry automatically (or run: git push).\n",
-    );
-  }
-  process.exit(0);
+// Blocking pause (the hook runs synchronously, under a Claude Code timeout).
+export const realSleep = (ms) =>
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+export const PUSH_FAILED_WARNING =
+  "\n⚠️  PUSH FAILED — local commits OK but not pushed. Check your network; " +
+  "the next turn will retry automatically (or run: git push).\n";
+
+// Runs the hook: attempt the push, print a non-blocking warning on failure.
+// ALWAYS returns 0 (best-effort). `write` is injected for testing.
+export function runHook({ git, sleep, write }) {
+  if (attemptPush({ git, sleep }) === "failed") write(PUSH_FAILED_WARNING);
+  return 0;
+}
+
+// Repo root derived from THIS module's location (one level up from scripts/),
+// not the hook's cwd. `metaUrl` is injected so it is testable.
+export function repoRoot(metaUrl) {
+  return resolve(dirname(fileURLToPath(metaUrl)), "..");
+}
+
+// Real stdout writer (forwards to process.stdout).
+export const realWrite = (s) => process.stdout.write(s);
+
+// The real hook wiring: a git runner bound to the repo root, the blocking sleep
+// and the real writer. Injected as one object into runHook at the entry point.
+export function realHookDeps(metaUrl) {
+  return { git: buildGit(repoRoot(metaUrl)), sleep: realSleep, write: realWrite };
+}
+
+// ── CLI entry (the actual Stop hook) ─────────────────────────────────────────
+// Guarded so importing this module in tests does NOT run it. Wires the real
+// git/sleep/write, then ALWAYS exits 0 (ignores the hook stdin).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(runHook(realHookDeps(import.meta.url)));
 }

--- a/scripts/auto-push.test.mjs
+++ b/scripts/auto-push.test.mjs
@@ -1,32 +1,52 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { attemptPush } from "./auto-push.mjs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  attemptPush,
+  buildGit,
+  realSleep,
+  runHook,
+  repoRoot,
+  realWrite,
+  realHookDeps,
+  PUSH_FAILED_WARNING,
+} from "./auto-push.mjs";
 
 // auto-push.mjs is the Stop hook: it pushes the pending commits ONCE per turn,
 // best-effort. attemptPush() is the testable core — the git runner is injected,
 // so no real network/process is involved. It returns a status describing the
 // outcome: "pushed" | "skipped" | "failed". It must NEVER throw.
+//
+// Mutation score 92.39 % — the 7 residual survivors are all documented equivalents:
+//   • `Number(...out.trim())` losing its `.trim()` (Number() already trims surrounding
+//     whitespace, so the mutant is behaviour-identical);
+//   • the 6 mutants inside the `import.meta.url` entry-point guard (its condition +
+//     body only run when THIS file IS the process — unreachable from a unit test).
+// Effective 100 % on non-equivalent mutants.
 
-// Fake git runner: interprets the args the hook uses and records every call so
-// tests can assert that no network push happened when it shouldn't.
+// Fake git runner keyed on the FULL command (args.join(" ")), not just args[0],
+// so mutating ANY arg string (e.g. "--get", "@{u}..HEAD") yields an unknown
+// command → a broken/neutral {ok:false} answer that fails the happy path → the
+// mutant is caught. Records every call so tests can assert push discipline.
 function makeGit({ remote = "", autopush = false, upstream = false, unpushed = 0, pushOk = true } = {}) {
   const calls = [];
+  // Real git output carries trailing newlines → the code must .trim(); we mirror
+  // that so trim-removing mutants change the outcome.
+  const responses = {
+    "remote": { out: remote, ok: true },
+    "config --get secondbrain.autopush": { out: autopush ? "true\n" : "", ok: true },
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": {
+      out: upstream ? "origin/main\n" : "",
+      ok: upstream,
+    },
+    "rev-list --count @{u}..HEAD": { out: `${unpushed}\n`, ok: true },
+    "push": { out: pushOk ? "" : "fatal: unable to access", ok: pushOk },
+  };
   const git = (args) => {
-    calls.push(args.join(" "));
-    switch (args[0]) {
-      case "remote":
-        return { out: remote, ok: true };
-      case "config":
-        return { out: autopush ? "true" : "", ok: true };
-      case "rev-parse": // @{u} resolves only when an upstream is set
-        return { out: upstream ? "origin/main" : "", ok: upstream };
-      case "rev-list": // --count @{u}..HEAD
-        return { out: String(unpushed), ok: true };
-      case "push":
-        return { out: pushOk ? "" : "fatal: unable to access", ok: pushOk };
-      default:
-        return { out: "", ok: true };
-    }
+    const key = args.join(" ");
+    calls.push(key);
+    return responses[key] ?? { out: "", ok: false };
   };
   return { git, calls };
 }
@@ -40,11 +60,23 @@ test("auto-push — no remote → skipped, push never called", () => {
   assert.ok(!calls.some((c) => c.startsWith("push")), "no network push attempted");
 });
 
+test("auto-push — whitespace-only `git remote` output counts as no remote (trim) → skipped", () => {
+  const { git, calls } = makeGit({ remote: "\n  ", autopush: true, upstream: true, unpushed: 3 });
+  assert.equal(attemptPush({ git, sleep: noSleep }), "skipped");
+  assert.ok(!calls.some((c) => c.startsWith("push")), "trimmed-empty remote → no push");
+});
+
 test("auto-push — remote+autopush+upstream+pending → pushed once", () => {
   const { git, calls } = makeGit({ remote: "origin", autopush: true, upstream: true, unpushed: 3 });
   const status = attemptPush({ git, sleep: noSleep });
   assert.equal(status, "pushed");
   assert.equal(calls.filter((c) => c.startsWith("push")).length, 1, "exactly one push");
+});
+
+test("auto-push — autopush disabled gates the push even when everything else is ready → skipped", () => {
+  const { git, calls } = makeGit({ remote: "origin", autopush: false, upstream: true, unpushed: 3 });
+  assert.equal(attemptPush({ git, sleep: noSleep }), "skipped");
+  assert.ok(!calls.some((c) => c.startsWith("push")), "no push without secondbrain.autopush=true");
 });
 
 test("auto-push — upstream set but nothing pending → skipped, no network push", () => {
@@ -70,4 +102,123 @@ test("auto-push — push fails → 1 retry after a pause → still KO → failed
   assert.equal(status, "failed");
   assert.equal(calls.filter((c) => c.startsWith("push")).length, 2, "initial push + 1 retry");
   assert.equal(sleeps, 1, "one pause between the two attempts");
+});
+
+test("auto-push — first push KO, retry OK → pushed, pause is exactly 3000ms", () => {
+  let pushAttempts = 0;
+  const git = (args) => {
+    switch (args[0]) {
+      case "remote": return { out: "origin", ok: true };
+      case "config": return { out: "true", ok: true };
+      case "rev-parse": return { out: "origin/main", ok: true };
+      case "rev-list": return { out: "3", ok: true };
+      case "push":
+        pushAttempts += 1;
+        return { out: "", ok: pushAttempts >= 2 }; // 1st KO, 2nd OK
+      default: return { out: "", ok: true };
+    }
+  };
+  const sleepArgs = [];
+  const status = attemptPush({ git, sleep: (ms) => sleepArgs.push(ms) });
+  assert.equal(status, "pushed");
+  assert.equal(pushAttempts, 2, "initial push + 1 retry");
+  assert.deepEqual(sleepArgs, [3000], "one 3000ms pause before the retry");
+});
+
+// ── CLI seams (buildGit, runHook, realSleep) — the untested Stop-hook wiring ──
+test("buildGit — maps a successful execFile to {out, ok:true} with the right git call", () => {
+  const seen = [];
+  const execFile = (bin, args, opts) => {
+    seen.push({ bin, args, opts });
+    return "some output";
+  };
+  const git = buildGit("/repo", execFile);
+  const res = git(["remote"]);
+  assert.deepEqual(res, { out: "some output", ok: true });
+  assert.equal(seen[0].bin, "git");
+  assert.deepEqual(seen[0].args, ["remote"]);
+  assert.equal(seen[0].opts.cwd, "/repo");
+  assert.equal(seen[0].opts.encoding, "utf8");
+  assert.deepEqual(seen[0].opts.stdio, ["ignore", "pipe", "pipe"]);
+});
+
+test("buildGit — null execFile output becomes '' (ok:true)", () => {
+  const git = buildGit("/repo", () => null);
+  assert.deepEqual(git(["remote"]), { out: "", ok: true });
+});
+
+test("buildGit — a throwing execFile → {ok:false}, out = stdout+stderr concatenated", () => {
+  const git = buildGit("/repo", () => {
+    const e = new Error("boom");
+    e.stdout = "OUT";
+    e.stderr = "ERR";
+    throw e;
+  });
+  assert.deepEqual(git(["push"]), { out: "OUTERR", ok: false });
+});
+
+test("buildGit — throwing execFile with no stdout/stderr → out = '' (ok:false)", () => {
+  const git = buildGit("/repo", () => { throw new Error("boom"); });
+  assert.deepEqual(git(["push"]), { out: "", ok: false });
+});
+
+test("runHook — push failed → writes the warning, returns 0", () => {
+  const git = () => { throw new Error("git missing"); }; // → attemptPush returns "failed"
+  const writes = [];
+  const code = runHook({ git, sleep: () => {}, write: (s) => writes.push(s) });
+  assert.equal(code, 0);
+  assert.deepEqual(writes, [PUSH_FAILED_WARNING]);
+});
+
+test("runHook — nothing to push (skipped) → no warning, returns 0", () => {
+  const { git } = makeGit({ remote: "", autopush: true, upstream: true, unpushed: 3 });
+  const writes = [];
+  const code = runHook({ git, sleep: () => {}, write: (s) => writes.push(s) });
+  assert.equal(code, 0);
+  assert.equal(writes.length, 0);
+});
+
+test("runHook — successful push → no warning, returns 0", () => {
+  const { git } = makeGit({ remote: "origin", autopush: true, upstream: true, unpushed: 3 });
+  const writes = [];
+  const code = runHook({ git, sleep: () => {}, write: (s) => writes.push(s) });
+  assert.equal(code, 0);
+  assert.equal(writes.length, 0);
+});
+
+test("PUSH_FAILED_WARNING — mentions the push failure and the retry", () => {
+  assert.match(PUSH_FAILED_WARNING, /PUSH FAILED/);
+  assert.match(PUSH_FAILED_WARNING, /git push/);
+});
+
+test("realSleep — a 0ms pause returns immediately without throwing", () => {
+  // Atomics.wait on an unchanged value with a 0ms timeout returns 'timed-out'.
+  assert.equal(realSleep(0), "timed-out");
+});
+
+test("repoRoot — resolves ONE level up from the module (scripts/ → repo root)", () => {
+  const here = fileURLToPath(import.meta.url);
+  const expected = resolve(dirname(here), "..");
+  assert.equal(repoRoot(import.meta.url), expected);
+  // sanity: it is strictly a parent, not the scripts dir itself
+  assert.notEqual(repoRoot(import.meta.url), dirname(here));
+});
+
+test("realWrite — forwards its argument to process.stdout.write", () => {
+  const orig = process.stdout.write;
+  const seen = [];
+  process.stdout.write = (s) => { seen.push(s); return true; };
+  try {
+    realWrite("payload");
+  } finally {
+    process.stdout.write = orig;
+  }
+  assert.deepEqual(seen, ["payload"]);
+});
+
+test("realHookDeps — wires a git runner + the real sleep + the real writer", () => {
+  const deps = realHookDeps(import.meta.url);
+  assert.equal(typeof deps.git, "function");
+  assert.equal(deps.sleep, realSleep);
+  assert.equal(deps.write, realWrite);
 });

--- a/scripts/clear-example-notes.mjs
+++ b/scripts/clear-example-notes.mjs
@@ -26,35 +26,48 @@ export function clearExamples(rootDir) {
   return clearExampleNotes(vaultDir);
 }
 
-function main(argv) {
-  const root = process.cwd();
+// Real wiring for runClear — the actual side effects, injected so the glue is
+// unit-testable (spawnSync/console/cwd/platform behind a port).
+export const realClearDeps = {
+  cwd: () => process.cwd(),
+  clear: clearExamples,
+  spawnSync,
+  platform: process.platform,
+  log: (...a) => console.log(...a),
+  error: (...a) => console.error(...a),
+};
+
+// Deletes the example notes and re-indexes the RAG (unless --no-reindex).
+// Returns the process exit code. All side effects come through `deps`.
+export function runClear(argv, deps = realClearDeps) {
+  const root = deps.cwd();
   const noReindex = argv.includes("--no-reindex");
 
-  const deleted = clearExamples(root);
+  const deleted = deps.clear(root);
   if (deleted.length === 0) {
-    console.log("Nothing to do: no example notes found (already removed).");
+    deps.log("Nothing to do: no example notes found (already removed).");
     return 0;
   }
-  for (const f of deleted) console.log(`  🗑️  removed ${f}`);
-  console.log(`✓ ${deleted.length} example note(s) removed.`);
+  for (const f of deleted) deps.log(`  🗑️  removed ${f}`);
+  deps.log(`✓ ${deleted.length} example note(s) removed.`);
 
   if (noReindex) return 0;
 
-  const NPM = process.platform === "win32" ? "npm.cmd" : "npm";
-  const r = spawnSync(NPM, ["run", "--silent", "reindex"], {
+  const NPM = deps.platform === "win32" ? "npm.cmd" : "npm";
+  const r = deps.spawnSync(NPM, ["run", "--silent", "reindex"], {
     cwd: join(root, "rag"),
     stdio: "inherit",
     // npm.cmd needs a shell since Node ≥ 18.20 (CVE-2024-27980) or EINVAL; no-op POSIX (ADR 0031).
-    shell: needsShell(NPM, process.platform),
+    shell: needsShell(NPM, deps.platform),
   });
   if (r.status !== 0) {
-    console.error("✗ re-index failed — run it by hand:  cd rag && npm run reindex");
+    deps.error("✗ re-index failed — run it by hand:  cd rag && npm run reindex");
     return 1;
   }
-  console.log("✓ RAG re-indexed — your brain has forgotten the example notes.");
+  deps.log("✓ RAG re-indexed — your brain has forgotten the example notes.");
   return 0;
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  process.exit(main(process.argv.slice(2)));
+  process.exit(runClear(process.argv.slice(2)));
 }

--- a/scripts/clear-example-notes.test.mjs
+++ b/scripts/clear-example-notes.test.mjs
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { clearExamples } from "./clear-example-notes.mjs";
+import { spawnSync } from "node:child_process";
+import { clearExamples, runClear, realClearDeps } from "./clear-example-notes.mjs";
 
 const fmExemple = "---\ntype: topic\ntags: [exemple, architecture]\n---\n\n# Demo\n";
 const fmHarness = "---\ntype: backlog\ntags: [harness, backlog]\n---\n\n# Frictions\n";
@@ -29,6 +30,20 @@ test("clearExamples — removes the exemple-tagged notes under <root>/vault, kee
   }
 });
 
+test("clearExamples — only clears <root>/vault, never example notes elsewhere in the brain", () => {
+  const root = makeBrain();
+  // an exemple-tagged note OUTSIDE vault/ must be left untouched (scope is vault/ only)
+  mkdirSync(join(root, "notes"), { recursive: true });
+  writeFileSync(join(root, "notes", "outside.md"), fmExemple);
+  try {
+    const deleted = clearExamples(root);
+    assert.deepEqual(deleted, [join(root, "vault", "topics", "flemmr.md")]);
+    assert.equal(existsSync(join(root, "notes", "outside.md")), true);
+  } finally {
+    rmSync(root, { recursive: true });
+  }
+});
+
 test("clearExamples — returns [] when there is no vault/ (nothing to do)", () => {
   const root = mkdtempSync(join(tmpdir(), "brain-novault-"));
   try {
@@ -36,4 +51,109 @@ test("clearExamples — returns [] when there is no vault/ (nothing to do)", () 
   } finally {
     rmSync(root, { recursive: true });
   }
+});
+
+// ── runClear (the glue: argv parsing, deletion report, reindex spawn) ─────────
+// Fake deps recording every side effect so branches/args are asserted without fs.
+function fakeDeps(overrides = {}) {
+  const calls = { log: [], error: [], spawn: [] };
+  const deps = {
+    cwd: () => "/brain",
+    clear: () => ["/brain/vault/topics/flemmr.md"],
+    spawnSync: (cmd, args, opts) => {
+      calls.spawn.push({ cmd, args, opts });
+      return { status: 0 };
+    },
+    platform: "darwin",
+    log: (...a) => calls.log.push(a.join(" ")),
+    error: (...a) => calls.error.push(a.join(" ")),
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+test("runClear — nothing to do: logs, returns 0, never reindexes", () => {
+  const { deps, calls } = fakeDeps({ clear: () => [] });
+  assert.equal(runClear([], deps), 0);
+  assert.deepEqual(calls.log, ["Nothing to do: no example notes found (already removed)."]);
+  assert.equal(calls.spawn.length, 0);
+});
+
+test("runClear — deletes, reports each file + count, reindexes on success → 0", () => {
+  const { deps, calls } = fakeDeps({
+    clear: () => ["/brain/vault/a.md", "/brain/vault/b.md"],
+  });
+  assert.equal(runClear([], deps), 0);
+  assert.deepEqual(calls.log, [
+    "  🗑️  removed /brain/vault/a.md",
+    "  🗑️  removed /brain/vault/b.md",
+    "✓ 2 example note(s) removed.",
+    "✓ RAG re-indexed — your brain has forgotten the example notes.",
+  ]);
+  assert.equal(calls.spawn.length, 1);
+});
+
+test("runClear — reindex spawn uses `npm`, run --silent reindex, cwd <root>/rag, inherit", () => {
+  const { deps, calls } = fakeDeps({ cwd: () => "/xyz" });
+  runClear([], deps);
+  const { cmd, args, opts } = calls.spawn[0];
+  assert.equal(cmd, "npm");
+  assert.deepEqual(args, ["run", "--silent", "reindex"]);
+  assert.equal(opts.cwd, join("/xyz", "rag"));
+  assert.equal(opts.stdio, "inherit");
+});
+
+test("runClear — win32 uses npm.cmd and asks for a shell", () => {
+  const { deps, calls } = fakeDeps({ platform: "win32" });
+  runClear([], deps);
+  assert.equal(calls.spawn[0].cmd, "npm.cmd");
+  assert.equal(calls.spawn[0].opts.shell, true);
+});
+
+test("runClear — POSIX uses npm and no shell", () => {
+  const { deps, calls } = fakeDeps({ platform: "linux" });
+  runClear([], deps);
+  assert.equal(calls.spawn[0].cmd, "npm");
+  assert.equal(calls.spawn[0].opts.shell, false);
+});
+
+test("runClear — reindex failure (status != 0): logs error, returns 1", () => {
+  const { deps, calls } = fakeDeps({ spawnSync: () => ({ status: 1 }) });
+  assert.equal(runClear([], deps), 1);
+  assert.equal(calls.error.length, 1);
+  assert.match(calls.error[0], /re-index failed/);
+  assert.equal(calls.log.at(-1), "✓ 1 example note(s) removed.");
+});
+
+test("runClear — --no-reindex: deletes but skips reindex, returns 0", () => {
+  const { deps, calls } = fakeDeps();
+  assert.equal(runClear(["--no-reindex"], deps), 0);
+  assert.equal(calls.spawn.length, 0);
+  assert.equal(calls.log.at(-1), "✓ 1 example note(s) removed.");
+});
+
+// ── realClearDeps (the default real wiring, used when runClear is called w/o deps)
+test("realClearDeps — wires the real side effects (clear/spawnSync/platform/cwd)", () => {
+  assert.equal(realClearDeps.clear, clearExamples);
+  assert.equal(realClearDeps.spawnSync, spawnSync);
+  assert.equal(realClearDeps.platform, process.platform);
+  assert.equal(realClearDeps.cwd(), process.cwd());
+});
+
+test("realClearDeps.log/error forward to console.log/console.error", () => {
+  const origLog = console.log;
+  const origErr = console.error;
+  const logged = [];
+  const errored = [];
+  console.log = (...a) => logged.push(a.join(" "));
+  console.error = (...a) => errored.push(a.join(" "));
+  try {
+    realClearDeps.log("hello", "world");
+    realClearDeps.error("oops");
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+  assert.deepEqual(logged, ["hello world"]);
+  assert.deepEqual(errored, ["oops"]);
 });

--- a/scripts/lib/assert-matcher-lint.mjs
+++ b/scripts/lib/assert-matcher-lint.mjs
@@ -1,0 +1,68 @@
+// Deterministic test-quality guard (ADR 0009 spirit): flag `assert.throws(…)` /
+// `assert.rejects(…)` calls with NO second argument — a bare "it threw" assertion
+// that survives StringLiteral / `throw ''` mutants (the C1 cluster the 2026-07 mutation
+// retrospective found recurring). See maintainers/CONVENTIONS.md §5ter and the global
+// tdd-discipline skill: assert the message/matcher, not just the fact that it threw.
+//
+// Cheap + conservative BY DESIGN: we only flag the zero-second-argument shape (the one we
+// can detect mechanically without a full JS parser). A string-only 2nd arg is still loose
+// but is left to the written rule — no false positives here.
+
+const METHODS = ["throws", "rejects"];
+
+// Scans one source string, returns [{ line, method }] for every loose call.
+export function findLooseAssertions(source) {
+  const findings = [];
+  for (const method of METHODS) {
+    const needle = `assert.${method}(`;
+    let from = 0;
+    for (;;) {
+      const at = source.indexOf(needle, from);
+      if (at === -1) break;
+      from = at + needle.length;
+      if (!hasSecondArgument(source, from)) {
+        findings.push({ line: lineOf(source, at), method });
+      }
+    }
+  }
+  return findings.sort((a, b) => a.line - b.line);
+}
+
+// From just after the opening `(`, walk the argument list tracking nesting and skipping
+// string literals. A top-level comma (nesting back at 1) ⇒ there is a 2nd argument.
+// Reaching the matching close paren first ⇒ no 2nd argument (loose).
+function hasSecondArgument(source, start) {
+  let nesting = 1; // we are already inside the initial `(`
+  let quote = null;
+  let afterComma = false; // seen a top-level comma; awaiting a real token vs `)`
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (quote) {
+      if (ch === "\\") i++; // skip the escaped char
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    // A top-level comma only counts if a REAL token follows it — a comma directly
+    // before the closing paren is a trailing comma, not a 2nd argument.
+    if (afterComma && !/\s/.test(ch)) {
+      return !(ch === ")" && nesting === 1);
+    }
+    if (ch === "'" || ch === '"' || ch === "`") {
+      quote = ch;
+    } else if (ch === "(" || ch === "[" || ch === "{") {
+      nesting++;
+    } else if (ch === ")" || ch === "]" || ch === "}") {
+      nesting--;
+      if (nesting === 0) return false; // closed the call with no top-level comma
+    } else if (ch === "," && nesting === 1) {
+      afterComma = true; // decide on the next non-whitespace char
+    }
+  }
+  return false; // unbalanced source — treat as loose rather than crash
+}
+
+function lineOf(source, index) {
+  let line = 1;
+  for (let i = 0; i < index; i++) if (source[i] === "\n") line++;
+  return line;
+}

--- a/scripts/lib/assert-matcher-lint.test.mjs
+++ b/scripts/lib/assert-matcher-lint.test.mjs
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findLooseAssertions } from "./assert-matcher-lint.mjs";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests — the pure scanner
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("flags a bare assert.throws with no matcher", () => {
+  const found = findLooseAssertions("assert.throws(() => f());");
+  assert.deepEqual(found, [{ line: 1, method: "throws" }]);
+});
+
+test("a matcher as 2nd argument is accepted (not flagged)", () => {
+  assert.deepEqual(findLooseAssertions("assert.throws(() => f(), /boom/);"), []);
+  assert.deepEqual(findLooseAssertions("assert.throws(() => f(), MyError);"), []);
+});
+
+test("flags a loose call spanning multiple lines, reporting the opening line", () => {
+  const src = "const x = 1;\nassert.throws(\n  () => f(),\n);\n";
+  assert.deepEqual(findLooseAssertions(src), [{ line: 2, method: "throws" }]);
+});
+
+test("commas nested inside the callback body are NOT a 2nd argument", () => {
+  assert.deepEqual(findLooseAssertions("assert.throws(() => f(a, b));"), [
+    { line: 1, method: "throws" },
+  ]);
+});
+
+test("commas inside an object/array argument are NOT a 2nd argument", () => {
+  assert.deepEqual(findLooseAssertions("assert.rejects(run({ a: 1, b: 2 }));"), [
+    { line: 1, method: "rejects" },
+  ]);
+});
+
+test("commas inside a string literal are NOT a 2nd argument", () => {
+  assert.deepEqual(findLooseAssertions('assert.throws(() => f(","));'), [
+    { line: 1, method: "throws" },
+  ]);
+});
+
+test("detects assert.rejects too, and awaited calls", () => {
+  assert.deepEqual(findLooseAssertions("await assert.rejects(p());"), [
+    { line: 1, method: "rejects" },
+  ]);
+  assert.deepEqual(findLooseAssertions("await assert.rejects(p(), /x/);"), []);
+});
+
+test("reports every loose call in a file, sorted by line", () => {
+  const src = "assert.throws(() => a());\nassert.rejects(b(), /ok/);\nassert.throws(() => c());\n";
+  assert.deepEqual(findLooseAssertions(src), [
+    { line: 1, method: "throws" },
+    { line: 3, method: "throws" },
+  ]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repo-wide guard — no loose throws/rejects may enter the tree (fail-loud).
+// This is the deterministic net for the C1 cluster. EXEMPT is empty by design;
+// the guard's own test file is skipped because it carries loose examples as fixtures.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..");
+const SCAN_ROOTS = ["scripts", "rag/src", "local-mirror/src"];
+const SELF = relative(REPO_ROOT, fileURLToPath(import.meta.url));
+const EXEMPT = new Set([SELF]);
+
+function collectTestFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    if (name === "node_modules") continue;
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...collectTestFiles(full));
+    else if (/\.test\.(mjs|ts)$/.test(name)) out.push(full);
+  }
+  return out;
+}
+
+test("no loose assert.throws/rejects anywhere in the engine test suites", () => {
+  const offenders = [];
+  for (const root of SCAN_ROOTS) {
+    for (const file of collectTestFiles(join(REPO_ROOT, root))) {
+      const rel = relative(REPO_ROOT, file);
+      if (EXEMPT.has(rel)) continue;
+      for (const { line, method } of findLooseAssertions(readFileSync(file, "utf8"))) {
+        offenders.push(`${rel}:${line} — assert.${method}(…) has no matcher/message`);
+      }
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `Loose throw/reject assertions found (assert the message/matcher, not just that it threw — CONVENTIONS.md §5ter):\n${offenders.join("\n")}`,
+  );
+});

--- a/scripts/lib/tracked-files.mjs
+++ b/scripts/lib/tracked-files.mjs
@@ -42,6 +42,10 @@ const DEV_ONLY_PREFIXES = [
   // (checkNode). Pure launcher-side, like installer.mjs — useless in a brain.
   // Covers the .mjs AND its .test.mjs via the prefix.
   "scripts/lib/node-compat",
+  // assert-matcher-lint: a maintainer-side test-quality guard (flags loose
+  // assert.throws/rejects). Pure dev tooling, useless in a brain. Covers the .mjs
+  // AND its .test.mjs via the prefix.
+  "scripts/lib/assert-matcher-lint",
   "rag/scripts/",
   // Localized artefact sources (constitution, skills, demo vault) live under
   // templates/<locale>/. They are NOT bulk-copied: the installer overlays only


### PR DESCRIPTION
## Why

One root cause of the "everything we ship feels degraded" episode was that **test quality was never
objectified** — we asserted the tests were good instead of measuring it. This branch runs a full
**mutation-testing audit** (StrykerJS, command runner) across the engine's three packages and hardens
the weak spots, then turns the recurring survivor patterns into **durable rules** so the gaps stop
recurring.

Plan: `maintainers/plans/prospective/mutation-testing-stryker.md`. Scores:
`maintainers/mutation/RESULTS.md`. Retrospective: `maintainers/mutation/RETROSPECTIVE.md`.

## What's in it

**Step 3 — hardening (worst-first), TDD baby-steps, green-only commits:**
- **rag** (8 files): `document-scanner` 0→100%, `vault-watcher` 0→100%, `frontmatter-parser` 11.9→97.6%,
  `chunker` 27→85.9%, `vector-store` 33.8→92.5%, `embedder` 34.6→81.98%, `index-manager` 39.4→94.87%,
  `config` 43.3→86.67%.
- **local-mirror**: `server` 0→85.71%, `index` 2.2→100%, `notion-gateway` 21→97.44%, plus the optional
  weak tier (`notion-transformers` 57→94.87%, `notion-url` 74→97.87%, `local-mirror` domain 77→98.52%);
  full re-audit **67.63 → 78.69%**.
- **scripts**: `clear-example-notes` 28.6→100%, `auto-push` 41.4→92.39%, `auto-commit` 47.5→98.21%
  (`scripts/lib/**` was already 100%).

**Step 4 — sustainable guardrails:** deterministic sibling-test guard (`lib-coverage-guard`), on-demand
`mutate:changed` non-regression, and the "test the glue too" convention.

**Step 6 — retrospective → durable rules:** the 6 recurring survivor clusters (all confirmed) + 3 new
infra-shaped ones, engraved belt-and-suspenders — the 5 language-agnostic habits in the `tdd-discipline`
skill (separate repo), the infra clusters + equivalent-mutant literacy + the Stryker false-timeout trap
in `CONVENTIONS.md` §5ter (§5bis broadened). A deterministic C1 lint
(`scripts/lib/assert-matcher-lint.mjs`) fails CI on any `assert.throws/rejects` with no matcher.

## Verification

All engine suites green: `scripts/**` 560/560 (incl. the new lint + `tracked-files`), `rag` and
`local-mirror` suites green. All mutation tooling is dev-only (`maintainers/` + `DEV_ONLY_PREFIXES`) and
never ships into a generated brain.

> History note: this branch was rebased onto `main` to split off two unrelated marketing commits
> (`MARKETING.md` one-pager + boards) onto their own branch `docs/marketing-page`. This PR is now
> mutation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)