### PR TITLE
The One Where Windows Finally Forgets the Demo Notes (v3.4.1)

### DIFF
--- a/maintainers/plans/archived/windows-clear-example-notes-and-cwd-fixes-action.md
+++ b/maintainers/plans/archived/windows-clear-example-notes-and-cwd-fixes-action.md
@@ -1,0 +1,90 @@
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- This is the ONE canonical plan for this chantier.                             -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+
+> **STATUS: ✅ SHIPPED (2026-07-16, in TDD) — branch `fix/windows-clear-example-notes`, release v3.4.1.**
+> All three pure-Windows findings fixed in baby-steps: **B3** (CRLF-tolerant frontmatter regex in
+> `scripts/lib/example-notes.mjs`), **B2** (entrypoint guard extracted to a pure `isEntrypoint`
+> predicate in `scripts/lib/entrypoint.mjs` using `pathToFileURL`), **B1** (`.\` path-qualified
+> install invocation in `scripts/lib/rag-launcher.mjs`). PROVEN end-to-end: on a CRLF temp vault the
+> purge deletes the `exemple`-tagged note and keeps the machinery (was a silent no-op before). Sweep
+> confirmed no other separator-less `cmd /c <name>` invocation. Green: engine 329/329, scripts 564/564.
+> **Scope: Second brain (runtime) — brain-side scripts + install invocation. No engine (`rag/`) touched.**
+
+# Plan — Windows follow-ups on top of v3.4.0: silent `clear-example-notes` + hardened-cwd install
+
+## Context
+
+A colleague installed v3.4.0 ("The One Where Windows Installs Clean", PR #17) on a hardened
+corporate Windows machine (Visma) and filed a high-quality follow-up report. The original three
+v3.3.x bugs are confirmed fixed; **three new pure-Windows findings remain**, all invisible on
+macOS/Linux (strings coincide by chance, LF line endings). The report ships exact root causes,
+minimal fixes and a regression test — verified against the current tree, all three still present.
+
+Source report (local, not versioned — private machine context, do not commit it):
+`~/Downloads/second-brain-generator-windows-node20-report (1).md`.
+
+**Severity (assessed):**
+- 🔴 **Serious — bugs B2+B3 combine into a silent no-op of `clear-example-notes` on ALL Windows.**
+  After install + import, the documented purge command does nothing (no output, no error), so the
+  RAG keeps answering from the fictional demo notes (Flemmr, Pélagie) as if real. This breaks the
+  product's core promise (*"answers from YOUR vault, cites its sources"*) and violates the
+  fail-loud preference (ADR 0009). It is silent, which is the worst failure mode.
+- 🟠 **Install blocker but loud — bug B1 (`NoDefaultCurrentDirectoryInExePath`).** Fails the install
+  at step 8/10 with a clear message, only on hardened/corporate Windows where that env var is set.
+- 🟢 No security issue, no data corruption.
+
+## Provenance — since when? (git archaeology, 2026-06-25)
+
+**NOT a regression from v3.4.0.** B2+B3 are latent debt present since the demo-purge feature was
+born; v3.4.0 (PR #17) only hardened Windows *install* and surfaced the path by getting a colleague
+to finally exercise the purge on a real Windows machine. B1 is the only finding that touches the
+v3.4.0 perimeter.
+
+- **B3** (frontmatter regex LF-only, `scripts/lib/example-notes.mjs:14`) — introduced **`2b09cfc`**,
+  2026-06-03 (*"bootstrap — étape 6/9 « vider les notes d'exemple »"*) → present since the **very
+  first** version of the purge mechanism.
+- **B2** (hand-rolled `file://` entrypoint guard, `scripts/clear-example-notes.mjs:58`) — introduced
+  **`e993af4`**, 2026-06-10 (*"offer yes/no deletion of example notes after the demo answer"*) →
+  present since the interactive-deletion flow was added.
+- **Why never caught:** on macOS/Linux the `file://` strings coincide by chance and LF is the
+  default, so both are invisible there; the reporter is likely the first to run the purge on a real
+  Windows checkout (CRLF + direct invocation), the only setup that triggers both at once.
+
+## Tracking
+
+- [ ] **Step 0 — Branch + decision recap**
+  - [ ] Create branch `fix/windows-clear-example-notes` off `main`
+  - [x] Confirm scope with Thomas _(2026-07-16 · re-scoped: fix all 3; B2 → **extract a pure `isEntrypoint(metaUrl, argv1)` predicate** for fail-first testing; B3 → **minimal CRLF-tolerant regex**, NOT a gray-matter dependency in the lean launcher scripts; release = **standalone patch v3.4.1**)_
+- [ ] **Step 1 — 🔴 Make `clear-example-notes` actually work on Windows (the serious one)**
+  - [x] B3 — `isExampleNote()` tolerates CRLF frontmatter (`scripts/lib/example-notes.mjs:14`) — **minimal regex fix, no gray-matter dep** (keep the launcher scripts lean / bare-node) _(2026-07-16)_
+    - [x] RED: add failing test in `scripts/lib/example-notes.test.mjs` — `isExampleNote(fmExemple.replace(/\n/g, "\r\n"))` must be `true` (current fixtures are all LF, so they never caught it) _(saw `false !== true`)_
+    - [x] GREEN: regex `/^---\n.../` → `/^---\r?\n([\s\S]*?)\r?\n---/` (inner `tags:` capture already stops at `]`, unaffected)
+    - [x] Refactor + suite green (`node --test scripts/lib/example-notes.test.mjs` → 8/8) — refactor: RAS
+  - [x] B2 — entrypoint guard via `pathToFileURL` (`scripts/clear-example-notes.mjs:72`) _(2026-07-16)_
+    - [x] Extract a pure predicate `isEntrypoint(metaUrl, argv1)` → new `scripts/lib/entrypoint.mjs`; call site becomes `if (isEntrypoint(import.meta.url, process.argv[1]))` _(behavior-preserving extraction: 561/561 still green)_
+    - [x] RED: cross-platform demonstrator — `isEntrypoint` is `false` for a path with a **space** (`/Users/John Doe/…`), because `file://${argv1}` keeps the literal space while `import.meta.url` is `%20`-encoded (same failure class as Windows backslashes/drive letter, no Windows needed) _(saw `false !== true`)_
+    - [x] GREEN: `import { pathToFileURL } from "node:url"` → `metaUrl === pathToFileURL(argv1).href` _(entrypoint 3/3, full scripts suite 564/564)_
+    - [x] Refactor + green — refactor: RAS (one-line predicate)
+  - [x] Verify the combo end-to-end intent (B2 masked B3): with both fixed, running the script on a **CRLF** temp vault deletes the `exemple`-tagged note and keeps the `harness` note _(2026-07-16 · proven by hand: `🗑️ removed demo.md`, harness preserved, exit 0)_
+- [x] **Step 2 — 🟠 Hardened-Windows install: explicit relative `.\` invocation** _(2026-07-16)_
+  - [x] B1 — `buildRagInstallInvocation()` (`scripts/lib/rag-launcher.mjs:177`)
+    - [x] RED: corrected the existing win32 test's expectation from the bare name to the path-qualified `.\\sbg-rag-install.cmd` (the old assertion encoded the bug) → saw deep-equal mismatch
+    - [x] GREEN: `args: ["/c", name]` → `args: ["/c", `.\\${name}`]`
+    - [x] Refactor + green (rag-launcher 21/21; full scripts suite 564/564); aligned the function doc-comment. Siblings (lines 130/228 `local-mirror\\launch.cmd`, `rag\\launch.cmd`) carry a separator → NOT affected, left untouched
+- [ ] **Step 3 — Sibling-pattern sweep (the report explicitly asks for it)**
+  - [x] Grep the repo for other `file://${process.argv[1]}` entrypoint guards _(2026-06-25 · NONE found outside `clear-example-notes.mjs` — B2 is contained)_
+  - [x] Check whether the RAG engine's frontmatter parser shares the LF assumption _(2026-06-25 · NO — `rag/src/lib/frontmatter-parser.ts` uses the `gray-matter` lib, which handles CRLF; the LF bug is confined to the hand-rolled regex in `scripts/lib/example-notes.mjs`. Engine retrieval on CRLF vaults is NOT degraded.)_
+  - [x] Grep for other bare-relative `cmd /c <name>` invocations that rely on implicit cwd search → qualify with `.\` (or absolute) _(2026-07-16 · swept `"/c"` across `scripts/` + `installer.mjs`: siblings 130/228 carry a separator = safe; `installer.mjs:553` uses `join(TARGET, …)` = absolute + separator = safe. The ONLY separator-less bare name was B1's, now fixed.)_
+  - [x] For any remaining hit: add/extend a regression test before fixing (baby-steps) _(none remaining → no extra test needed)_
+- [x] **Step 4 — Wrap up** _(2026-07-16)_
+  - [x] Full engine + scripts test suites green (engine 329/329, scripts 564/564); `rag/` NOT touched → no `tsc` run needed
+  - [x] Release **v3.4.1** (standalone patch) — version is tag-driven (no root `package.json`/CHANGELOG in this repo); tag + GitHub release with a "The One With…" codename at merge
+  - [x] PR off `main`, English title + body; pre-flight English-artifact ritual
+  - [x] On ship: `git mv` this plan to `archived/` with a ✅ STATUS + proof _(no plans README exists → nothing to update)_
+
+## Notes / open questions
+
+- [x] Decide whether this is a patch release (v3.4.1) on its own or bundled — _(2026-07-16 · Thomas: standalone **v3.4.1**)_
+- [ ] The report's "staging/move dance" (§ at the bottom) is **environmental, NOT a generator bug** — do not act on it.
+- [ ] Keep the colleague's regression-test names/intent; they pinpoint exactly why LF fixtures missed B3.

--- a/scripts/clear-example-notes.mjs
+++ b/scripts/clear-example-notes.mjs
@@ -17,6 +17,7 @@ import { spawnSync } from "node:child_process";
 
 import { clearExampleNotes } from "./lib/example-notes.mjs";
 import { needsShell } from "./lib/spawn-shell.mjs";
+import { isEntrypoint } from "./lib/entrypoint.mjs";
 
 // Deletes the exemple-tagged notes under <rootDir>/vault. Returns deleted paths
 // (empty if there is no vault/ — nothing to do).
@@ -68,6 +69,6 @@ export function runClear(argv, deps = realClearDeps) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isEntrypoint(import.meta.url, process.argv[1])) {
   process.exit(runClear(process.argv.slice(2)));
 }

--- a/scripts/lib/entrypoint.mjs
+++ b/scripts/lib/entrypoint.mjs
@@ -1,0 +1,20 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// entrypoint.mjs — "is this module the process entry point?" predicate.
+//
+// The idiom `import.meta.url === file://${process.argv[1]}` is a hand-rolled URL
+// that breaks whenever argv[1] is not already a well-formed, percent-encoded file
+// URL path: Windows paths (backslashes, `C:` drive letter) and any path with a
+// space or other char that must be percent-encoded. `import.meta.url` is always a
+// canonical file URL, so the two never match there → the guarded top-level block
+// silently never runs (bug B2). Compare through the SAME canonicalisation the
+// runtime uses instead.
+// ─────────────────────────────────────────────────────────────────────────────
+import { pathToFileURL } from "node:url";
+
+// True when `metaUrl` (an import.meta.url) denotes the same file as `argv1`
+// (a process.argv[1] filesystem path) — i.e. this module is the entry point.
+// Canonicalise argv1 through pathToFileURL (the same transform the runtime applies
+// to build import.meta.url) so backslashes, drive letters and spaces all match.
+export function isEntrypoint(metaUrl, argv1) {
+  return metaUrl === pathToFileURL(argv1).href;
+}

--- a/scripts/lib/entrypoint.test.mjs
+++ b/scripts/lib/entrypoint.test.mjs
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+import { isEntrypoint } from "./entrypoint.mjs";
+
+test("isEntrypoint — true when the meta-url is the canonical URL of argv1", () => {
+  const argv1 = "/Users/dev/brain/scripts/clear-example-notes.mjs";
+  assert.equal(isEntrypoint(pathToFileURL(argv1).href, argv1), true);
+});
+
+test("isEntrypoint — false for a different file", () => {
+  const argv1 = "/Users/dev/brain/scripts/clear-example-notes.mjs";
+  const otherUrl = pathToFileURL("/Users/dev/brain/scripts/reindex.mjs").href;
+  assert.equal(isEntrypoint(otherUrl, argv1), false);
+});
+
+test("isEntrypoint — true when argv1 contains a space (percent-encoded path)", () => {
+  // import.meta.url is ALWAYS a canonical, percent-encoded file URL. A path with a
+  // space (`C:\Users\John Doe\…`, `/Users/John Doe/…`) encodes to `%20`, whereas the
+  // hand-rolled `file://${argv1}` keeps the literal space → the guard never matched
+  // → silent no-op (bug B2). This reproduces it cross-platform, no Windows needed.
+  const argv1 = "/Users/John Doe/brain/scripts/clear-example-notes.mjs";
+  assert.equal(isEntrypoint(pathToFileURL(argv1).href, argv1), true);
+});

--- a/scripts/lib/example-notes.mjs
+++ b/scripts/lib/example-notes.mjs
@@ -11,7 +11,7 @@ import { join } from "node:path";
 
 // True if the Markdown frontmatter contains an `exemple` tag.
 export function isExampleNote(content) {
-  const fm = content.match(/^---\n([\s\S]*?)\n---/);
+  const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!fm) return false;
   const tags = fm[1].match(/^tags:\s*\[([^\]]*)\]/m);
   if (!tags) return false;

--- a/scripts/lib/example-notes.test.mjs
+++ b/scripts/lib/example-notes.test.mjs
@@ -24,6 +24,13 @@ test("isExampleNote — false without frontmatter", () => {
   assert.equal(isExampleNote(noFm), false);
 });
 
+test("isExampleNote — true with CRLF frontmatter (Windows line endings)", () => {
+  // A real Windows checkout carries CRLF, so the frontmatter delimiters are
+  // `---\r\n` — the LF-only `^---\n` regex missed them → the purge was a silent
+  // no-op on Windows (bug B3). Fixtures above are LF, so they never caught it.
+  assert.equal(isExampleNote(fmExemple.replace(/\n/g, "\r\n")), true);
+});
+
 function makeVault() {
   const dir = mkdtempSync(join(tmpdir(), "vault-ex-"));
   mkdirSync(join(dir, "topics"), { recursive: true });

--- a/scripts/lib/rag-launcher.mjs
+++ b/scripts/lib/rag-launcher.mjs
@@ -159,8 +159,10 @@ const realInstallIo = {
 // killing the install-node ≠ runtime-node ABI skew (ADR 0021-A). Returns
 // {command, args, cleanup} for child_process; run it with cwd = ragDir, then call
 // cleanup() (a no-op on POSIX). On win32 the self-heal block + `npm install` are
-// written to a real .cmd inside rag/ and invoked by a space-free RELATIVE name
-// (NOT passed as a multi-line `cmd /c` argument, which cmd silently truncates
+// written to a real .cmd inside rag/ and invoked by a space-free, cwd-qualified
+// relative name (`.\sbg-rag-install.cmd`, NOT a bare name — a hardened box with
+// NoDefaultCurrentDirectoryInExePath set won't search cwd for a bare name; NOT
+// passed as a multi-line `cmd /c` argument either, which cmd silently truncates
 // after the first newline — the install was skipped yet exited 0; and an absolute
 // temp path could carry spaces). `io` is injected for testability; reuses
 // pathPrependCmd() so the self-heal block stays the single source of truth.
@@ -168,7 +170,11 @@ export function buildRagInstallInvocation(platform, ragDir, io = realInstallIo) 
   if (platform === "win32") {
     const script = `@echo off\r\n${pathPrependCmd()}\r\nnpm install --silent\r\n`;
     const name = io.writeScript(ragDir, script);
-    return { command: "cmd", args: ["/c", name], cleanup: () => io.removeScript(ragDir, name) };
+    // Qualify with `.\` (not a bare name): on a hardened box where
+    // NoDefaultCurrentDirectoryInExePath is set, cmd does NOT search cwd for a bare
+    // name → the install would fail. An explicit relative path is always resolved
+    // against cwd (=rag/). Still space-free, so `John Doe` paths stay safe (B1).
+    return { command: "cmd", args: ["/c", `.\\${name}`], cleanup: () => io.removeScript(ragDir, name) };
   }
   return {
     command: "/bin/sh",

--- a/scripts/lib/rag-launcher.test.mjs
+++ b/scripts/lib/rag-launcher.test.mjs
@@ -135,9 +135,11 @@ test("buildRagInstallInvocation win32: writes the self-heal block into rag/ and 
   // first newline (the install was silently skipped, yet exit 0) — and a long PATH
   // trips the line-length limit. So we materialise the self-heal block + npm install
   // into a real .cmd file and execute that. Crucially the file goes INTO rag/ and is
-  // invoked by a SPACE-FREE relative name (`cmd /c sbg-rag-install.cmd`), with the
-  // caller setting cwd=rag/ — so a brain path containing spaces (C:\Users\John Doe\…)
-  // can't break cmd's argument splitting. The fs is injected so the seam stays pure.
+  // invoked by a SPACE-FREE, PATH-QUALIFIED relative name (`cmd /c .\sbg-rag-install.cmd`),
+  // with the caller setting cwd=rag/ — so a brain path containing spaces (C:\Users\John
+  // Doe\…) can't break cmd's argument splitting, AND a hardened box with
+  // NoDefaultCurrentDirectoryInExePath set still resolves it (a BARE name is not searched
+  // in cwd there → bug B1). The fs is injected so the seam stays pure.
   let writtenDir, written;
   const io = {
     writeScript: (dir, content) => {
@@ -149,7 +151,7 @@ test("buildRagInstallInvocation win32: writes the self-heal block into rag/ and 
   };
   const { command, args } = buildRagInstallInvocation("win32", "C:\\Users\\John Doe\\brain\\rag", io);
   assert.equal(command, "cmd");
-  assert.deepEqual(args, ["/c", "sbg-rag-install.cmd"]); // relative, space-free
+  assert.deepEqual(args, ["/c", ".\\sbg-rag-install.cmd"]); // relative, space-free, cwd-qualified
   assert.equal(writtenDir, "C:\\Users\\John Doe\\brain\\rag"); // file lands inside rag/
   // The materialised script still carries the SAME self-heal block as launch.cmd
   // (ADR 0021-A single source of truth) followed by the install.


### PR DESCRIPTION
## Why

A colleague installed v3.4.0 on a hardened corporate Windows machine and filed a high-quality follow-up report. The v3.4.0 install-hardening was confirmed, but **three pure-Windows findings** remained — all invisible on macOS/Linux, where the `file://` strings coincide by chance and LF is the default. Fixed here in TDD baby-steps.

## The bugs

### 🔴 B2 + B3 combine into a **silent no-op** of `clear-example-notes` on all Windows
After install + import, the documented purge command did nothing (no output, no error), so the RAG kept answering from the fictional demo notes (Flemmr, Pélagie) **as if real** — breaking the product's core promise and violating the fail-loud preference (ADR 0009). Silent = the worst failure mode.

- **B2** — the entrypoint guard `import.meta.url === \`file://\${process.argv[1]}\`` never matched on Windows (backslashes, `C:` drive letter) nor for any path with a space, so the whole script never ran. Extracted a pure `isEntrypoint(metaUrl, argv1)` predicate (`scripts/lib/entrypoint.mjs`) that canonicalises through `pathToFileURL` — the same transform the runtime uses to build `import.meta.url`. RED reproduced cross-platform via a space-containing path (percent-encoding mismatch), no Windows needed.
- **B3** — `isExampleNote` matched frontmatter with an LF-only regex (`^---\n`), so on a CRLF checkout no note was ever detected. Minimal fix: `^---\r?\n([\s\S]*?)\r?\n---`. Kept the launcher scripts lean (no gray-matter dependency).

Proven end-to-end: on a CRLF temp vault the purge now deletes the `exemple`-tagged note and keeps the machinery.

### 🟠 B1 — hardened-Windows install blocker (loud)
`buildRagInstallInvocation` invoked the win32 install script by a bare, separator-less name (`cmd /c sbg-rag-install.cmd`); a hardened box with `NoDefaultCurrentDirectoryInExePath` set won't search cwd for a bare name. Qualified it with `.\` (still space-free). Sibling launch invocations already carry a separator and are unaffected — a sweep confirmed no other bare-name case.

## Provenance
Not a v3.4.0 regression: B2/B3 are latent debt present since the demo-purge feature was born; v3.4.0 only surfaced them by getting a colleague to finally exercise the purge on a real Windows machine.

## Tests
- Baby-steps RED→GREEN for each of B1/B2/B3.
- Green: engine **329/329**, scripts **564/564**.
- Scope: second-brain (runtime) brain-side scripts + install invocation. **No engine (`rag/`) touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)