### PR TITLE
docs(readme): add a mutation-tested (Stryker) capability badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 &nbsp;[![Engine: self-upgradable since v3.0.0](https://img.shields.io/badge/engine-self--upgradable%20since%20v3.0.0-651fff?style=flat-square&logo=rocket&logoColor=white)](#keeping-your-brain-up-to-date-its-engine)
 &nbsp;[![Privacy: local by default](https://img.shields.io/badge/privacy-local%20by%20default-3d5afe?style=flat-square&logo=lock&logoColor=white)](#and-the-privacy-of-my-data)
 &nbsp;[![Runs on macOS and Windows](https://img.shields.io/badge/runs%20on-macOS%20%C2%B7%20Windows-2979ff?style=flat-square)](#ready-to-try-it)
-&nbsp;[![Mutation tested with Stryker](https://img.shields.io/badge/mutation%20tested-Stryker-536dfe?style=flat-square&logo=stryker&logoColor=white)](https://github.com/tpierrain/second-brain-generator/tree/main/maintainers/mutation)
+&nbsp;[![Mutation tested with Stryker](https://img.shields.io/badge/mutation%20tested-Stryker-e74c24?style=flat-square&logo=stryker&logoColor=white)](https://github.com/tpierrain/second-brain-generator/tree/main/maintainers/mutation)
 
 **Ask it like you'd ask a personal assistant — no dev skills required — and pull up any decision or piece of info from your work in seconds, always with the sources.**
 *In Claude Desktop or on the command line, your call.*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 &nbsp;[![Engine: self-upgradable since v3.0.0](https://img.shields.io/badge/engine-self--upgradable%20since%20v3.0.0-651fff?style=flat-square&logo=rocket&logoColor=white)](#keeping-your-brain-up-to-date-its-engine)
 &nbsp;[![Privacy: local by default](https://img.shields.io/badge/privacy-local%20by%20default-3d5afe?style=flat-square&logo=lock&logoColor=white)](#and-the-privacy-of-my-data)
 &nbsp;[![Runs on macOS and Windows](https://img.shields.io/badge/runs%20on-macOS%20%C2%B7%20Windows-2979ff?style=flat-square)](#ready-to-try-it)
+&nbsp;[![Mutation tested with Stryker](https://img.shields.io/badge/mutation%20tested-Stryker-536dfe?style=flat-square&logo=stryker&logoColor=white)](https://github.com/tpierrain/second-brain-generator/tree/main/maintainers/mutation)
 
 **Ask it like you'd ask a personal assistant — no dev skills required — and pull up any decision or piece of info from your work in seconds, always with the sources.**
 *In Claude Desktop or on the command line, your call.*


### PR DESCRIPTION
Adds a **capability** badge to the README badge row, next to "Runs on macOS · Windows":

`mutation tested · Stryker` → links to `maintainers/mutation/` (the dev-only Stryker workspace shipped in v3.4.1).

### Why a capability badge, not a score

There is no Stryker dashboard reporter and mutation testing is not run in CI, so a hardcoded numeric score would go stale and become a misleading "green" — exactly what the repo's own "local green ≠ green" convention warns against. A capability badge stays honest and durable, and the link makes the claim verifiable.

The same badge was added to the v3.4.1 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)