### PR TITLE
docs(mutation): rag re-audit refresh (57%→82.6%) + next-steps backlog

### DIFF
--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -9,6 +9,11 @@
 
 ## Baseline run — 2026-06-23 (engine at v3.4.0, commit `49e46a9`)
 
+> ⚠️ **SUPERSEDED for `rag` and `local-mirror`.** This is the *pre-hardening* photo. For the current
+> package scores after Step 3, read **[Full `rag` re-audit — 2026-07-16](#full-rag-re-audit-closer--2026-07-16)**
+> (**57.23 % → 82.59 %**) and the local-mirror re-audit below (67.63 % → 78.69 %). Do not quote the
+> baseline numbers as the current state.
+
 Faithful scope: every mutant re-runs the **whole package suite** (command runner, no
 StrykerJS `node:test` runner). Scores are the durable test-quality signal the project lacked.
 
@@ -73,6 +78,49 @@ from 67.63 % → 78.69 %** (550 killed + 4 timeout / 704 covered, 150 survived).
 Enumerated Step-2 worst-files (`server.ts`, `index.ts`, `notion-gateway.ts`) are **done**.
 The remaining weak tier (`notion-transformers.ts` 57 %, `local-mirror.ts` 77 %, `notion-url.ts`
 74 %) was not flagged in the Step-2 worst-first list; hardening it is optional follow-up.
+
+## Full `rag` re-audit (closer) — 2026-07-16
+
+After hardening all enumerated Step-2 worst-files, a full-package re-audit lifts **`rag` from
+57.23 % → 82.59 %** (1177 killed + 9 timeout / 1436 covered, 250 survived, 0 no-coverage). Run at
+`concurrency: 4` (honest timeouts). Per-file, worst-first on the **remaining** survivors:
+
+| File | Score | Survived | Tier |
+|---|---|---|---|
+| `citation-renderer.ts` | 45.45 % | 18 | never hardened — real gaps |
+| `usage-tracker.ts` | 55.88 % | 30 | never hardened — real gaps |
+| `fake-embedder.ts` | 62.50 % | 6 | test helper (arguably should be excluded from mutation) |
+| `health-check.ts` | 63.25 % | 43 | never hardened — **most survivors in the package** |
+| `search-degradation.ts` | 71.43 % | 2 | small |
+| `reindex-scheduler.ts` | 74.19 % | 8 | never hardened |
+| `reindex-lock.ts` | 75.34 % | 18 | never hardened |
+| `status-report.ts` | 78.87 % | 15 | never hardened |
+| `index-freshness.ts` | 81.13 % | 10 | never hardened |
+| `embedder.ts` | 81.98 % | 20 | **hardened — residual are documented equivalents** |
+| `in-process-embedder.ts` | 82.61 % | 8 | never hardened |
+| `reindex-reporter.ts` | 83.64 % | 9 | never hardened |
+| `openai-compatible-embedder.ts` | 84.00 % | 4 | never hardened |
+| `engine-version.ts` | 84.44 % | 7 | never hardened |
+| `progress-report.ts` | 85.25 % | 9 | never hardened |
+| `chunker.ts` | 85.88 % | 12 | **hardened — documented equivalents** |
+| `config.ts` | 86.67 % | 4 | **hardened — documented equivalents** |
+| `notify.ts` | 90.91 % | 9 | already decent |
+| `vector-store.ts` | 92.47 % | 11 | **hardened — documented equivalents** |
+| `indexer.ts` | 94.44 % | 1 | already decent |
+| `index-manager.ts` | 94.87 % | 4 | **hardened — documented equivalents** |
+| `frontmatter-parser.ts` | 97.62 % | 2 | **hardened — documented equivalents** |
+| `document-scanner.ts` | 100.00 % | 0 | hardened |
+| `native-deps.ts` | 100.00 % | 0 | already 100 % |
+| `vault-watcher.ts` | 100.00 % | 0 | hardened |
+
+**Reading it.** Of the 250 survivors, ~53 are the **documented equivalent mutants** in the already-hardened
+files (chunker 12, embedder 20, vector-store 11, index-manager 4, config 4, frontmatter-parser 2) — those
+are unkillable by definition. The remaining ~197 sit in files the Step-2 worst-first list never flagged
+(they were dwarfed by the near-0 % files at baseline). Highest-leverage next targets, worst-first:
+**`health-check.ts` (43), `usage-tracker.ts` (30), `citation-renderer.ts` (18), `reindex-lock.ts` (18),
+`status-report.ts` (15)** — ~124 survivors across 5 files. Hardening those alone would move the package
+toward ~90-93 %; the practical ceiling is ~96 % (the equivalents can't be killed, so chasing 100 % is
+chasing equivalents).
 
 ## How each package is run (and why)
 

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -6,6 +6,37 @@
 
 # Mutation testing (Stryker) — global audit of the engine's three packages
 
+## ▶ Resume after /clear — Backlog: what to fix next (2026-07-16)
+
+State: the three-package audit + hardening is done; the **rag full re-audit closed at 57.23 % → 82.59 %**
+(RESULTS.md refreshed, baseline marked superseded). Agreed next build = **the anti-rot nightly**.
+Resume at the first unchecked box below.
+
+- [ ] **B1 — Anti-rot NIGHTLY workflow** *(agreed next build; latency analysis done — nightly wins over a PR gate)*
+  - [ ] New `.github/workflows/mutation-nightly.yml` on **`ubuntu-latest`** (NOT macOS/Windows: mutation
+    is OS-agnostic, and macOS billing is ×10). `schedule:` cron + `workflow_dispatch` for manual test.
+  - [ ] Run `mutate:all` — but `scripts/**` must run in a **disposable git worktree** (destructive inPlace,
+    see RESULTS.md § How each package is run). rag + local-mirror run inPlace.
+  - [ ] **Re-tune `concurrency`** for a 4-core runner (start at 2-3; verify no FALSE timeouts before
+    trusting the score — the documented bogus-100 % trap).
+  - [ ] Upload the HTML reports (`maintainers/mutation/reports/`) as a build artifact; non-blocking (informational).
+  - [ ] Ship it via `workflow_dispatch` FIRST (run once, confirm honest scores), THEN enable the cron.
+  - [ ] (stretch) Add the Stryker **dashboard reporter** → unlocks the LIVE badge we deferred (replace the
+    static capability badge in README + release notes).
+- [ ] **B2 — Config hygiene: stop mutating test doubles.** `rag/src/lib/fake-embedder.ts` (62.5 %) is a
+  **test helper**, not production code — mutating it measures the wrong thing. Exclude it from the rag
+  mutate glob (and sweep for other `fake-*`/stub files across the three configs). Improves signal, not just score.
+- [ ] **B3 — Harden the newly-surfaced rag weak tier** (optional; lifts ~82.6 % → ~90-93 %). Worst-first,
+  TDD baby-steps, 6 engraved reflexes (+ reflex #6 = extract a pure seam when I/O glue resists):
+  - [ ] `health-check.ts` 63.25 % (43 survivors — most in the package)
+  - [ ] `usage-tracker.ts` 55.88 % (30)
+  - [ ] `citation-renderer.ts` 45.45 % (18 — lowest score)
+  - [ ] `reindex-lock.ts` 75.34 % (18)
+  - [ ] `status-report.ts` 78.87 % (15)
+  - Ceiling ~96 % (documented equivalents can't be killed — do NOT chase 100 %).
+- [ ] **B4 — (optional) local-mirror weak tier** (from the local-mirror re-audit, never worst-listed):
+  `local-mirror.ts` 77.41 %, `notion-url.ts` 74.47 %, `config.ts`/`fresh-env.ts` 62.5 %/71.4 %.
+
 ## Why (the WHAT)
 
 One root cause of the "everything you ship feels degraded" episode was that **test quality was never
@@ -166,9 +197,17 @@ built-in `node --test`. Two realistic paths, in tension:
       present, the `.env` re-read closure exercised only on empty-startup onboarding) → effective
       26/26 = 100 % on non-equivalents. _(2026-07-15 · `42bda19`)_
     - **3-rag enumerated worst-files DONE** (document-scanner, vault-watcher, frontmatter-parser,
-      chunker, vector-store, embedder, index-manager, config). The other `rag/src/lib/*.ts` were
-      not flagged weak by the Step 2 audit; a full-`rag` re-audit (refresh RESULTS.md) is the
-      natural closer before moving on.
+      chunker, vector-store, embedder, index-manager, config).
+    - [x] **Full `rag` re-audit (closer)** — **57.23 % → 82.59 %** (1177 killed + 9 timeout / 1436
+      covered, 250 survived). RESULTS.md refreshed with the per-file table. _(2026-07-16)_
+    - [ ] **Optional follow-up — newly-surfaced weak tier** (not in the Step-2 worst-first list; they
+      were dwarfed by the near-0 % files at baseline). Worst-first, ~124 survivors across 5 files:
+      - [ ] `health-check.ts` 63.25 % (43 survivors — most in the package)
+      - [ ] `usage-tracker.ts` 55.88 % (30)
+      - [ ] `citation-renderer.ts` 45.45 % (18 — lowest score)
+      - [ ] `reindex-lock.ts` 75.34 % (18)
+      - [ ] `status-report.ts` 78.87 % (15)
+      - Target ~90-93 %; ceiling ~96 % (documented equivalents can't be killed — do not chase 100 %).
   - [x] **3-local-mirror** — harden `local-mirror/src/**` survivors. Enumerated worst-files done +
     re-audit closer (67.63 % → 78.69 %). _(2026-07-15)_
     - [x] `server.ts` **0 % → 85.71 %** (10 killed + 2 timeout / 14) — composition root: extracted

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -9,8 +9,29 @@
 ## ▶ Resume after /clear — Backlog: what to fix next (2026-07-16)
 
 State: the three-package audit + hardening is done; the **rag full re-audit closed at 57.23 % → 82.59 %**
-(RESULTS.md refreshed, baseline marked superseded). Agreed next build = **the anti-rot nightly**.
-Resume at the first unchecked box below.
+(RESULTS.md refreshed, baseline marked superseded). Goal added 2026-07-16: **make the numbers sellable on
+the GitHub release page** (today the badge link still surfaces the stale 57 %). Resume at the first
+unchecked box below.
+
+> **Insight — where a static score is honest.** A published GitHub release is **frozen**, so a pinned
+> number ("rag 82.59 % at v3.4.1") stays true forever → put real scores in **release notes**. The
+> **README** tracks moving `main`, so a static number there would rot → keep the README on a **capability**
+> badge (or a **live** dashboard badge via the nightly). Cadence going forward: harden → re-measure → cut a
+> release → pin that release's score snapshot in its notes.
+
+### Do-first (the "sellable numbers" ask)
+
+- [ ] **A0 — Merge PR #22** → `main`'s RESULTS.md shows **82.59 %** (baseline superseded), so the repo page
+  linked from the badge stops surfacing the stale 57 %.
+- [ ] **A1 — Pin the aggregate scores into the GitHub release notes.**
+  - [ ] Edit the **v3.4.1** note's "Hardened (test quality)" section to state the package aggregates:
+    **rag 82.59 %, scripts 97.27 %, local-mirror 78.69 %** (honest — the release is frozen).
+  - [ ] Adopt the convention: every future release note carries a mutation-score snapshot pinned to its tag.
+- [ ] **A2 — After B2+B3 raise the score, cut the improved numbers as the NEXT release** so the *latest*
+  release shows the *improved* scores (e.g. rag ~90-93 %). This is what actually satisfies "associate the
+  better numbers with the latest release".
+
+### Improve + keep-fresh
 
 - [ ] **B1 — Anti-rot NIGHTLY workflow** *(agreed next build; latency analysis done — nightly wins over a PR gate)*
   - [ ] New `.github/workflows/mutation-nightly.yml` on **`ubuntu-latest`** (NOT macOS/Windows: mutation


### PR DESCRIPTION
## Why

The RESULTS.md `rag` scores were the **pre-hardening baseline (57.23 %)**. Every enumerated worst-file had since been hardened in separate commits, but the package was never re-measured — so the headline number read as stale and disappointing.

## What

- Ran the full `rag` re-audit (1436 mutants, `concurrency: 4`, ~14 min): **57.23 % → 82.59 %** (1177 killed + 9 timeout / 1436 covered, 250 survived).
- RESULTS.md: added the per-file table, marked the baseline **SUPERSEDED** for `rag`/`local-mirror` so its numbers aren't quoted as current, and recorded the reading (~53 of the 250 survivors are documented equivalent mutants in already-hardened files — unkillable; the rest sit in files the Step-2 worst-first list never flagged).
- Plan: added a top **"Resume / Backlog"** block capturing the agreed next build (anti-rot **nightly** on `ubuntu-latest`), a config-hygiene item (stop mutating the `fake-embedder` test double), and the optional `rag`/`local-mirror` weak tiers to harden.

Docs only — no engine or test code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)