### PR TITLE
v3.4.2: The One Where the Survivors Run Out of Places to Hide

### DIFF
--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -1,0 +1,90 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# Mutation testing (nightly): the anti-rot net for TEST QUALITY (plan B1).
+#
+# Mutation score is the durable test-quality signal the project lacked (see
+# maintainers/plans/prospective/mutation-testing-stryker.md). The per-change
+# on-demand check (`mutate:changed`) covers a branch; this nightly re-measures
+# the WHOLE engine so a slow drift in test quality surfaces on its own instead
+# of only when someone remembers to run a full audit before a release.
+#
+# INFORMATIONAL ONLY, never a gate:
+#   - it runs on a schedule + manual dispatch, never as a required PR check;
+#   - every stryker config has `thresholds.break: null`, so a low score still
+#     exits 0 (a red job here means a crash, not a weak score).
+#
+# Cost: mutation is OS-agnostic, so this runs ONLY on ubuntu-latest (macOS
+# Actions minutes bill x10 for zero extra signal). The three packages fan out
+# as parallel matrix jobs so the slow one (scripts, 513 tests re-run per mutant)
+# does not serialize behind the others.
+#
+# Rollout (per the plan): validated first via `workflow_dispatch` to confirm the
+# scores are HONEST (no false-timeout inflation) BEFORE trusting the cron.
+# ═══════════════════════════════════════════════════════════════════════════
+name: Mutation (nightly)
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC, nightly
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  mutate:
+    name: mutate · ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [rag, local-mirror, scripts]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # The harness suite asserts against a real git tree (engine-manifest
+      # integrity, auto-commit/auto-push seams), so give the runner an identity.
+      - name: Configure a git identity
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@example.com"
+
+      # rag mutates the TS engine: its suite needs the native binding built.
+      - name: Install engine deps (rag) builds better-sqlite3
+        if: matrix.package == 'rag'
+        working-directory: rag
+        run: npm ci
+
+      - name: Install local-mirror deps
+        if: matrix.package == 'local-mirror'
+        working-directory: local-mirror
+        run: npm ci
+
+      # scripts needs no package deps (pure .mjs seams, like the CI harness job);
+      # only the Stryker workspace is required.
+      - name: Install the Stryker workspace
+        working-directory: maintainers/mutation
+        run: npm ci
+
+      # --concurrency 2: GitHub's 4-vCPU runner over-subscribes at the local
+      # configs' 4-5 concurrent runners (each re-runs the WHOLE package suite per
+      # mutant), which inflates genuine kills into FALSE timeouts and a bogus high
+      # score (the documented trap, see RESULTS.md § Gotchas). Start low so a
+      # timeout means a REAL infinite loop, not a starved runner. scripts runs its
+      # committed `inPlace: false` sandbox config, so no worktree is needed here
+      # (the ephemeral runner is itself disposable).
+      - name: Mutate ${{ matrix.package }}
+        run: npm --prefix maintainers/mutation run mutate:${{ matrix.package }} -- --concurrency 2
+
+      - name: Upload the HTML report (informational)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report-${{ matrix.package }}
+          path: maintainers/mutation/reports/mutation-${{ matrix.package }}.html
+          if-no-files-found: warn

--- a/maintainers/CONVENTIONS.md
+++ b/maintainers/CONVENTIONS.md
@@ -183,6 +183,14 @@ with no matcher/2nd argument (dev-only, excluded from the brain copy via `DEV_ON
 other clusters stay **written rules** (no cheap reliable check) — the on-demand net is
 `npm --prefix maintainers/mutation run mutate:changed`.
 
+**Publishing the score — pin it to a frozen release, not to moving `main`.** A published GitHub release
+is **frozen**, so a pinned number ("rag 82.59 % at v3.4.1") stays true for that tag forever. Convention:
+**every release note carries a mutation-score snapshot pinned to its tag** (the per-package aggregates
+from [`maintainers/mutation/RESULTS.md`](mutation/RESULTS.md), measured against that tag's production
+code). The **README** tracks moving `main`, so a static number there would rot: keep the README on a
+**capability** badge (or a live dashboard badge). Cadence going forward: harden, re-measure, cut a
+release, pin that release's snapshot in its notes.
+
 ## 6. ADRs carry a `Scope:` field
 
 Every ADR carries a `- **Scope:**` line right under `STATUS`, with an **explicit** value (never the

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -10,9 +10,11 @@
 ## Baseline run — 2026-06-23 (engine at v3.4.0, commit `49e46a9`)
 
 > ⚠️ **SUPERSEDED for `rag` and `local-mirror`.** This is the *pre-hardening* photo. For the current
-> package scores after Step 3, read **[Full `rag` re-audit — 2026-07-16](#full-rag-re-audit-closer--2026-07-16)**
-> (**57.23 % → 82.59 %**) and the local-mirror re-audit below (67.63 % → 78.69 %). Do not quote the
-> baseline numbers as the current state.
+> `rag` score after the weak-tier hardening (B3), read **[Full `rag` re-audit #2 — 2026-07-16
+> (post-B2/B3)](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening)** (**82.59 % → 90.42 %**,
+> production-only). The earlier 57.23 % → 82.59 % closer is itself superseded (it still mutated the
+> `fake-embedder` test double). For local-mirror see the re-audit below (67.63 % → 78.69 %). Do not
+> quote the baseline numbers as the current state.
 
 Faithful scope: every mutant re-runs the **whole package suite** (command runner, no
 StrykerJS `node:test` runner). Scores are the durable test-quality signal the project lacked.
@@ -79,7 +81,60 @@ Enumerated Step-2 worst-files (`server.ts`, `index.ts`, `notion-gateway.ts`) are
 The remaining weak tier (`notion-transformers.ts` 57 %, `local-mirror.ts` 77 %, `notion-url.ts`
 74 %) was not flagged in the Step-2 worst-first list; hardening it is optional follow-up.
 
-## Full `rag` re-audit (closer) — 2026-07-16
+## Full `rag` re-audit #2 — 2026-07-16 (post-B2/B3 hardening)
+
+**Current `rag` score: 90.42 %** (1279 killed + 5 timeout / 1420 covered, 136 survived, 0 no-coverage).
+Run at `concurrency: 4` (honest timeouts). Two changes lifted it from the 82.59 % closer below:
+
+- **B2 — stopped mutating the `fake-embedder.ts` test double** (a test helper, not production code):
+  the mutate set drops from 25 → 24 files (1420 vs 1436 mutants). This is a *measurement-correctness*
+  fix — the 82.59 % was scoring the wrong thing for those 6 mutants.
+- **B3 — hardened the 5 weak-tier files** the earlier closer flagged: `health-check` 63.25 % → 92.31 %,
+  `usage-tracker` 55.88 % → 92.65 %, `citation-renderer` 45.45 % → 100 %, `reindex-lock` 75.34 % →
+  94.52 %, `status-report` 78.87 % → 100 %.
+
+Per-file, worst-first on the **remaining** survivors (24 files, `fake-embedder` excluded):
+
+| File | Score | Survived | Tier |
+|---|---|---|---|
+| `search-degradation.ts` | 71.43 % | 2 | small, never hardened |
+| `reindex-scheduler.ts` | 74.19 % | 8 | never hardened |
+| `index-freshness.ts` | 81.13 % | 10 | never hardened |
+| `embedder.ts` | 81.98 % | 20 | **hardened — residual are documented equivalents** |
+| `in-process-embedder.ts` | 82.61 % | 8 | never hardened |
+| `reindex-reporter.ts` | 83.64 % | 9 | never hardened |
+| `openai-compatible-embedder.ts` | 84.00 % | 4 | never hardened |
+| `engine-version.ts` | 84.44 % | 7 | never hardened |
+| `chunker.ts` | 85.88 % | 12 | **hardened — documented equivalents** |
+| `config.ts` | 86.67 % | 4 | **hardened — documented equivalents** |
+| `progress-report.ts` | 88.52 % | 7 | never hardened |
+| `notify.ts` | 90.91 % | 9 | already decent |
+| `health-check.ts` | 92.31 % | 9 | **hardened B3 — effective 100 % (9 documented equivalents)** |
+| `vector-store.ts` | 92.47 % | 11 | **hardened — documented equivalents** |
+| `usage-tracker.ts` | 92.65 % | 5 | **hardened B3 — 4 equivalents + 1 accepted gap** |
+| `indexer.ts` | 94.44 % | 1 | already decent |
+| `reindex-lock.ts` | 94.52 % | 4 | **hardened B3 — documented equivalents** |
+| `index-manager.ts` | 94.87 % | 4 | **hardened — documented equivalents** |
+| `frontmatter-parser.ts` | 97.62 % | 2 | **hardened — documented equivalents** |
+| `citation-renderer.ts` | 100.00 % | 0 | **hardened B3** |
+| `document-scanner.ts` | 100.00 % | 0 | hardened |
+| `native-deps.ts` | 100.00 % | 0 | already 100 % |
+| `status-report.ts` | 100.00 % | 0 | **hardened B3** |
+| `vault-watcher.ts` | 100.00 % | 0 | hardened |
+
+**Reading it.** Of the 136 survivors, the bulk are **documented equivalent mutants** in the already-hardened
+files (embedder 20, chunker 12, vector-store 11, health-check 9, index-manager 4, config 4, reindex-lock 4,
+usage-tracker 4, frontmatter-parser 2 → ~70). The rest sit in files never worst-listed (`reindex-scheduler`,
+`index-freshness`, the embedder adapters, `reindex-reporter`, `engine-version`, `progress-report`, `notify`) —
+a possible future **B4-style** follow-up, non-blocking. Ceiling ~96 % (documented equivalents can't be killed).
+
+Pinned to the release that ships these hardened tests: **v3.4.2** (see the plan's A2).
+
+## Full `rag` re-audit (closer) — 2026-07-16 [SUPERSEDED by re-audit #2 above]
+
+> ⚠️ **SUPERSEDED** by [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening). This closer
+> still mutated the `fake-embedder.ts` test double and predated the B3 weak-tier hardening. Kept for
+> history — do not quote 82.59 % as the current `rag` score.
 
 After hardening all enumerated Step-2 worst-files, a full-package re-audit lifts **`rag` from
 57.23 % → 82.59 %** (1177 killed + 9 timeout / 1436 covered, 250 survived, 0 no-coverage). Run at

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -7,79 +7,20 @@
 > For **what the survivors taught us** (recurring shapes → durable rules), see the
 > retrospective: [`RETROSPECTIVE.md`](RETROSPECTIVE.md).
 
-## Baseline run — 2026-06-23 (engine at v3.4.0, commit `49e46a9`)
+> 📈 **Sections are ordered newest-first (anti-chronological).** The top block is the current
+> state; scroll down for the history back to the 2026-06-23 baseline.
 
-> ⚠️ **SUPERSEDED for `rag` and `local-mirror`.** This is the *pre-hardening* photo. For the current
-> `rag` score after the weak-tier hardening (B3), read **[Full `rag` re-audit #2 — 2026-07-16
-> (post-B2/B3)](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening)** (**82.59 % → 90.42 %**,
-> production-only). The earlier 57.23 % → 82.59 % closer is itself superseded (it still mutated the
-> `fake-embedder` test double). For local-mirror see the re-audit below (67.63 % → 78.69 %). Do not
-> quote the baseline numbers as the current state.
+## Current scores (latest)
 
-Faithful scope: every mutant re-runs the **whole package suite** (command runner, no
-StrykerJS `node:test` runner). Scores are the durable test-quality signal the project lacked.
-
-| Package | Mutation score | Killed | Timeout | **Survived** | Mutants | Read |
-|---|---|---|---|---|---|---|
-| **scripts** (harness) | **97.27 %** | 3612 | 21 | 102 | 3735 | excellent — `scripts/lib/**` is 100 % across the board |
-| **local-mirror** | **67.63 %** | 458 | 12 | 225 | 695 | moderate |
-| **rag** | **57.23 %** | 804 | 7 | 606 | 1417 | weakest — real gaps |
-
-### Worst files (Step 3 hardening targets, worst-first)
-
-**rag/src/lib**
-- `document-scanner.ts` **0 %**, `vault-watcher.ts` **0 %** (I/O wirings, no unit test)
-- `frontmatter-parser.ts` 11.9 %, `chunker.ts` 27.1 %
-- `vector-store.ts` 33.8 %, `embedder.ts` 34.6 %, `index-manager.ts` 39.4 %, `config.ts` 40.0 %
-- well covered (≥90 %): `indexer.ts`, `notify.ts`, `native-deps.ts`
-
-**local-mirror/src**
-- `server.ts` **0 %**, `index.ts` **2.2 %** (entry points, no unit test)
-- `notion-gateway.ts` 21.1 %, `notion-transformers.ts` 57.3 %
-- 100 %: `markdown.ts`, `reconcile.ts`, `system-clock.ts`
-
-**scripts** — only 3 weak files (everything else, incl. all of `lib/**`, is 100 %):
-- `clear-example-notes.mjs` **28.6 %** (30 survivors)
-- `auto-push.mjs` **41.4 %** (51 survivors)
-- `auto-commit.mjs` **47.5 %** (21 survivors)
-- → all three are the git/vault **side-effect** scripts, hard to unit-test.
-
-## Step 3 hardening — scripts worst-files — 2026-07-15
-
-The three git/vault side-effect scripts, hardened by extracting an injectable core
-(git runner / cwd / spawn behind a port) and TDD-ing the glue. Measured per file in a
-**fresh disposable worktree** (`--inPlace`) — never reused (a `clear-example-notes`
-mutant deletes the worktree's `vault/`, so run-1 corrupts run-2's baseline).
-
-| File | Before | After | Note |
+| Package | Mutation score | As of | Detail |
 |---|---|---|---|
-| `clear-example-notes.mjs` | 28.6 % | **100 %** | 46/46, no equivalents — `runClear(argv, deps)` + `realClearDeps` |
-| `auto-push.mjs` | 41.4 % | **92.39 %** | 85/92, 7 equiv. (redundant `.trim()` under `Number()` + the `import.meta.url` guard) |
-| `auto-commit.mjs` | 47.5 % | **98.21 %** | 55/56, 1 equiv. (the `if (isEntryPoint(...))→if(true)` guard) |
+| **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only |
+| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %) |
+| **local-mirror** | **78.69 %** | 2026-07-15 | [re-audit](#step-3-hardening--local-mirror-re-audit--2026-07-15) |
 
-`scripts/lib/**` was already 100 % → **`scripts/**` is now fully hardened**. Enumerated
-Step-2 worst-files across all three packages are done (see the plan's Step 3).
+Pinned to the release that ships the hardened tests: **v3.4.2**.
 
-## Step 3 hardening — local-mirror re-audit — 2026-07-15
-
-After hardening the three Step-2 worst-files, a full-package re-audit lifts **local-mirror
-from 67.63 % → 78.69 %** (550 killed + 4 timeout / 704 covered, 150 survived). Per-file:
-
-| Area | File | Before | After | Note |
-|---|---|---|---|---|
-| entry | `index.ts` | 2.2 % | **100 %** | in-memory Client drives the 7 tools end-to-end |
-| entry | `server.ts` | 0 % | **85.71 %** | boot seams extracted; 2 equiv. = the entry-point guard |
-| adapters | `notion-gateway.ts` | 21.1 % | **97.44 %** | seams injected; 1 equiv. = `new Client({auth})` |
-| adapters | `notion-connector.ts` | — | 85.29 % | already decent |
-| adapters | (fs-*, system-clock) | — | 81–100 % | already decent |
-| domain | `local-mirror.ts` | — | **77.41 %** | 61 survivors — the big Domain Service, next tier |
-| lib | `notion-transformers.ts` | 57.3 % | **94.87 %** | hardened 2026-07-15 (helpers exported + case-tested; 6 equiv.) |
-| lib | `notion-url.ts` | — | 74.47 % | 12 survivors |
-| lib | `fresh-env.ts` / `config.ts` | — | 62.5 % / 71.4 % | small |
-
-Enumerated Step-2 worst-files (`server.ts`, `index.ts`, `notion-gateway.ts`) are **done**.
-The remaining weak tier (`notion-transformers.ts` 57 %, `local-mirror.ts` 77 %, `notion-url.ts`
-74 %) was not flagged in the Step-2 worst-first list; hardening it is optional follow-up.
+---
 
 ## Full `rag` re-audit #2 — 2026-07-16 (post-B2/B3 hardening)
 
@@ -128,8 +69,6 @@ usage-tracker 4, frontmatter-parser 2 → ~70). The rest sit in files never wors
 `index-freshness`, the embedder adapters, `reindex-reporter`, `engine-version`, `progress-report`, `notify`) —
 a possible future **B4-style** follow-up, non-blocking. Ceiling ~96 % (documented equivalents can't be killed).
 
-Pinned to the release that ships these hardened tests: **v3.4.2** (see the plan's A2).
-
 ## Full `rag` re-audit (closer) — 2026-07-16 [SUPERSEDED by re-audit #2 above]
 
 > ⚠️ **SUPERSEDED** by [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening). This closer
@@ -175,7 +114,81 @@ are unkillable by definition. The remaining ~197 sit in files the Step-2 worst-f
 **`health-check.ts` (43), `usage-tracker.ts` (30), `citation-renderer.ts` (18), `reindex-lock.ts` (18),
 `status-report.ts` (15)** — ~124 survivors across 5 files. Hardening those alone would move the package
 toward ~90-93 %; the practical ceiling is ~96 % (the equivalents can't be killed, so chasing 100 % is
-chasing equivalents).
+chasing equivalents). *(Done — see re-audit #2 above: 90.42 %.)*
+
+## Step 3 hardening — local-mirror re-audit — 2026-07-15
+
+After hardening the three Step-2 worst-files, a full-package re-audit lifts **local-mirror
+from 67.63 % → 78.69 %** (550 killed + 4 timeout / 704 covered, 150 survived). Per-file:
+
+| Area | File | Before | After | Note |
+|---|---|---|---|---|
+| entry | `index.ts` | 2.2 % | **100 %** | in-memory Client drives the 7 tools end-to-end |
+| entry | `server.ts` | 0 % | **85.71 %** | boot seams extracted; 2 equiv. = the entry-point guard |
+| adapters | `notion-gateway.ts` | 21.1 % | **97.44 %** | seams injected; 1 equiv. = `new Client({auth})` |
+| adapters | `notion-connector.ts` | — | 85.29 % | already decent |
+| adapters | (fs-*, system-clock) | — | 81–100 % | already decent |
+| domain | `local-mirror.ts` | — | **77.41 %** | 61 survivors — the big Domain Service, next tier |
+| lib | `notion-transformers.ts` | 57.3 % | **94.87 %** | hardened 2026-07-15 (helpers exported + case-tested; 6 equiv.) |
+| lib | `notion-url.ts` | — | 74.47 % | 12 survivors |
+| lib | `fresh-env.ts` / `config.ts` | — | 62.5 % / 71.4 % | small |
+
+Enumerated Step-2 worst-files (`server.ts`, `index.ts`, `notion-gateway.ts`) are **done**.
+The remaining weak tier (`notion-transformers.ts` 57 %, `local-mirror.ts` 77 %, `notion-url.ts`
+74 %) was not flagged in the Step-2 worst-first list; hardening it is optional follow-up.
+
+## Step 3 hardening — scripts worst-files — 2026-07-15
+
+The three git/vault side-effect scripts, hardened by extracting an injectable core
+(git runner / cwd / spawn behind a port) and TDD-ing the glue. Measured per file in a
+**fresh disposable worktree** (`--inPlace`) — never reused (a `clear-example-notes`
+mutant deletes the worktree's `vault/`, so run-1 corrupts run-2's baseline).
+
+| File | Before | After | Note |
+|---|---|---|---|
+| `clear-example-notes.mjs` | 28.6 % | **100 %** | 46/46, no equivalents — `runClear(argv, deps)` + `realClearDeps` |
+| `auto-push.mjs` | 41.4 % | **92.39 %** | 85/92, 7 equiv. (redundant `.trim()` under `Number()` + the `import.meta.url` guard) |
+| `auto-commit.mjs` | 47.5 % | **98.21 %** | 55/56, 1 equiv. (the `if (isEntryPoint(...))→if(true)` guard) |
+
+`scripts/lib/**` was already 100 % → **`scripts/**` is now fully hardened**. Enumerated
+Step-2 worst-files across all three packages are done (see the plan's Step 3).
+
+## Baseline run — 2026-06-23 (engine at v3.4.0, commit `49e46a9`) [OLDEST]
+
+> ⚠️ **SUPERSEDED for `rag` and `local-mirror`.** This is the *pre-hardening* photo. For the current
+> `rag` score after the weak-tier hardening (B3), read **[Full `rag` re-audit #2 — 2026-07-16
+> (post-B2/B3)](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening)** (**82.59 % → 90.42 %**,
+> production-only). The earlier 57.23 % → 82.59 % closer is itself superseded (it still mutated the
+> `fake-embedder` test double). For local-mirror see the re-audit above (67.63 % → 78.69 %). Do not
+> quote the baseline numbers as the current state.
+
+Faithful scope: every mutant re-runs the **whole package suite** (command runner, no
+StrykerJS `node:test` runner). Scores are the durable test-quality signal the project lacked.
+
+| Package | Mutation score | Killed | Timeout | **Survived** | Mutants | Read |
+|---|---|---|---|---|---|---|
+| **scripts** (harness) | **97.27 %** | 3612 | 21 | 102 | 3735 | excellent — `scripts/lib/**` is 100 % across the board |
+| **local-mirror** | **67.63 %** | 458 | 12 | 225 | 695 | moderate |
+| **rag** | **57.23 %** | 804 | 7 | 606 | 1417 | weakest — real gaps |
+
+### Worst files (Step 3 hardening targets, worst-first)
+
+**rag/src/lib**
+- `document-scanner.ts` **0 %**, `vault-watcher.ts` **0 %** (I/O wirings, no unit test)
+- `frontmatter-parser.ts` 11.9 %, `chunker.ts` 27.1 %
+- `vector-store.ts` 33.8 %, `embedder.ts` 34.6 %, `index-manager.ts` 39.4 %, `config.ts` 40.0 %
+- well covered (≥90 %): `indexer.ts`, `notify.ts`, `native-deps.ts`
+
+**local-mirror/src**
+- `server.ts` **0 %**, `index.ts` **2.2 %** (entry points, no unit test)
+- `notion-gateway.ts` 21.1 %, `notion-transformers.ts` 57.3 %
+- 100 %: `markdown.ts`, `reconcile.ts`, `system-clock.ts`
+
+**scripts** — only 3 weak files (everything else, incl. all of `lib/**`, is 100 %):
+- `clear-example-notes.mjs` **28.6 %** (30 survivors)
+- `auto-push.mjs` **41.4 %** (51 survivors)
+- `auto-commit.mjs` **47.5 %** (21 survivors)
+- → all three are the git/vault **side-effect** scripts, hard to unit-test.
 
 ## How each package is run (and why)
 

--- a/maintainers/mutation/stryker.rag.config.mjs
+++ b/maintainers/mutation/stryker.rag.config.mjs
@@ -12,7 +12,10 @@ export default {
   commandRunner: {
     command: 'cd rag && node --import tsx --test src/lib/*.test.ts',
   },
-  mutate: ['rag/src/lib/*.ts', '!rag/src/lib/*.test.ts'],
+  // Exclude fake-embedder.ts: a deterministic test double for the Embedder port
+  // (imported only by its own test, never wired into a production path). Mutating a
+  // test helper measures the wrong thing — it drags the honest signal, not the score.
+  mutate: ['rag/src/lib/*.ts', '!rag/src/lib/*.test.ts', '!rag/src/lib/fake-embedder.ts'],
   inPlace: true,
   coverageAnalysis: 'off',
   // Tuned like the scripts config: the command runner re-runs the WHOLE rag suite per

--- a/maintainers/mutation/stryker.scripts.config.mjs
+++ b/maintainers/mutation/stryker.scripts.config.mjs
@@ -9,8 +9,10 @@ export default {
   commandRunner: {
     command: 'node --test "scripts/*.test.mjs" "scripts/lib/*.test.mjs"',
   },
-  // Prod harness code only; exclude the *.test.mjs siblings.
-  mutate: ['scripts/*.mjs', 'scripts/lib/**/*.mjs', '!scripts/**/*.test.mjs'],
+  // Prod harness code only; exclude the *.test.mjs siblings AND __fixtures__/** (test
+  // doubles like stub-mcp-server.mjs, spawned only by *.test.mjs). Mutating a fixture
+  // measures the wrong thing — same rationale as rag's fake-embedder exclusion.
+  mutate: ['scripts/*.mjs', 'scripts/lib/**/*.mjs', '!scripts/**/*.test.mjs', '!scripts/lib/__fixtures__/**'],
   // ⚠️ NOT inPlace for the harness: the suite exercises vault-MUTATING code
   // (clear-example-notes). Under inPlace, a mutant that redirects the delete target
   // ran against the REAL tree and wiped vault/ demo notes (run #2). Stryker's default

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -64,7 +64,13 @@ unchecked box below.
     fail-safe gatherVitals seams (weightsReady absent/throws, canaryNoteExists throws). The 9 equivalents:
     the `depth="full"→""` default (routes identically), redundant `let x=<init>` (always overwritten) and
     `catch {}` blocks whose fail-safe value equals the init — unkillable without touching prod for nothing.
-  - [ ] `usage-tracker.ts` 55.88 % (30)
+  - [x] `usage-tracker.ts` 55.88 % → **92.65 %** (63 killed, 5 survivors: 4 equivalents + 1 accepted gap)
+    _(2026-07-16 · uncommitted)_ — 7 tests: the `DailyCapExceededError` full message/name/fields (reflex
+    #1/#2), the `timeZone` default (custom honored vs Pacific fallback, reflex #4), and `FileUsageStorage`
+    driven on a real temp file (roundtrip, missing/corrupt/wrong-shape → null, with both `&&`-side twins).
+    Survivors: clock default `()=>undefined` (equiv, `Intl.format(undefined)`=now), the redundant
+    `existsSync` guard (equiv w/ the catch), `"utf-8"`→`""` on read/write (equiv, Node tolerates it), and
+    the no-arg default filename (only reachable via the real-CACHE_DIR constructor — not tested, won't clobber).
   - [x] `citation-renderer.ts` 45.45 % → **100 %** (33/33 killed, 0 survived) _(2026-07-16 · uncommitted)_
     — 7 hardening tests (reflexes #2/#3/#4/#5): verbatim relay banner + `some`/`every` on a mixed set,
     exact 1./2. numbering + `---` join separator, no-noise no-mirror prefix, the 500-char slice/ellipsis

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -75,7 +75,13 @@ unchecked box below.
     — 7 hardening tests (reflexes #2/#3/#4/#5): verbatim relay banner + `some`/`every` on a mixed set,
     exact 1./2. numbering + `---` join separator, no-noise no-mirror prefix, the 500-char slice/ellipsis
     boundary (500 vs 501), a byte-for-byte single-block assertion, and a tab (`%09`) pinning the hex zero-pad.
-  - [ ] `reindex-lock.ts` 75.34 % (18)
+  - [x] `reindex-lock.ts` 75.34 % → **94.52 %** (69 killed, 4 survivors, all equivalents/accepted)
+    _(2026-07-16 · uncommitted)_ — 9 tests: the `now`/`staleAfterMs` defaults (omitted → real clock &
+    30-min default), the `isStale` `>` boundary (age == staleAfterMs), the private `defaultIsAlive`
+    exercised via `activeHolder()` with our live PID vs a dead one, and `FileLockStorage` corrupt +
+    wrong-shape → null and `clear()` on an absent file (the `{ force: true }`). Survivors: `defaultIsAlive`
+    catch→undefined (equiv via boolean coercion), redundant existsSync guard (equiv), `"utf-8"`→`""`
+    (equiv), and the no-arg default filename (real-CACHE_DIR only, not tested).
   - [ ] `status-report.ts` 78.87 % (15)
   - Ceiling ~96 % (documented equivalents can't be killed — do NOT chase 100 %).
 - [ ] **B4 — (optional) local-mirror weak tier** (from the local-mirror re-audit, never worst-listed):

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -55,7 +55,9 @@ unchecked box below.
   `!scripts/lib/__fixtures__/**`); local-mirror already excludes `src/test/**`. All three configs re-parse
   clean. Note: v3.4.1's pinned 82.59 % *included* fake-embedder — the NEXT rag re-audit (production-only)
   is expected to tick up, which is exactly the improved number A2 will cut as the next release.
-- [ ] **B3 — Harden the newly-surfaced rag weak tier** (optional; lifts ~82.6 % → ~90-93 %). Worst-first,
+- [x] **B3 — Harden the newly-surfaced rag weak tier** (optional; lifts ~82.6 % → ~90-93 %). **DONE**
+  — all 5 weak-tier files hardened (health-check 92.31 %, usage-tracker 92.65 %, citation-renderer 100 %,
+  reindex-lock 94.52 %, status-report 100 %). _(2026-07-16)_ Worst-first,
   TDD baby-steps, 6 engraved reflexes (+ reflex #6 = extract a pure seam when I/O glue resists):
   - [x] `health-check.ts` 63.25 % → **92.31 %** (108/108 non-equivalent killed; 9 survivors are all
     documented equivalents = effective 100 %) _(2026-07-16 · uncommitted)_ — 13 tests: exact `{ status,
@@ -82,7 +84,15 @@ unchecked box below.
     wrong-shape → null and `clear()` on an absent file (the `{ force: true }`). Survivors: `defaultIsAlive`
     catch→undefined (equiv via boolean coercion), redundant existsSync guard (equiv), `"utf-8"`→`""`
     (equiv), and the no-arg default filename (real-CACHE_DIR only, not tested).
-  - [ ] `status-report.ts` 78.87 % (15)
+  - [x] `status-report.ts` 78.87 % → **100 %** (71/71 killed, 0 survivors, no equivalents)
+    _(2026-07-16 · `0e6398d`)_ — all 15 survivors were loose regex assertions (fragments, not the
+    whole line). Converted to exact whole-string/whole-report equality (reflex #2) + triangulated the
+    open branches: `formatWatcherLiveness` exact lines + a null/absent-state case pinning the
+    `state?.running`/`state?.scheduled` optional chaining and the no-burst `... : ""` else; whole-report
+    equality pinning the `"\n"` join + the no-null-push when lock/progress absent; all three
+    `embeddingLine` provider branches (explicit `gemini`, transformers-js, openai-compatible, generic
+    `mistral-embed`) asserted verbatim; and the running progress line proving `now` (not startedAt)
+    drives rate/ETA + a now-omitted case pinning the `?? startedAt` fallback.
   - Ceiling ~96 % (documented equivalents can't be killed — do NOT chase 100 %).
 - [ ] **B4 — (optional) local-mirror weak tier** (from the local-mirror re-audit, never worst-listed):
   `local-mirror.ts` 77.41 %, `notion-url.ts` 74.47 %, `config.ts`/`fresh-env.ts` 62.5 %/71.4 %.
@@ -250,13 +260,14 @@ built-in `node --test`. Two realistic paths, in tension:
       chunker, vector-store, embedder, index-manager, config).
     - [x] **Full `rag` re-audit (closer)** — **57.23 % → 82.59 %** (1177 killed + 9 timeout / 1436
       covered, 250 survived). RESULTS.md refreshed with the per-file table. _(2026-07-16)_
-    - [ ] **Optional follow-up — newly-surfaced weak tier** (not in the Step-2 worst-first list; they
-      were dwarfed by the near-0 % files at baseline). Worst-first, ~124 survivors across 5 files:
-      - [ ] `health-check.ts` 63.25 % (43 survivors — most in the package)
-      - [ ] `usage-tracker.ts` 55.88 % (30)
-      - [ ] `citation-renderer.ts` 45.45 % (18 — lowest score)
-      - [ ] `reindex-lock.ts` 75.34 % (18)
-      - [ ] `status-report.ts` 78.87 % (15)
+    - [x] **Optional follow-up — newly-surfaced weak tier** (not in the Step-2 worst-first list; they
+      were dwarfed by the near-0 % files at baseline). **DONE** _(2026-07-16)_. Worst-first, ~124
+      survivors across 5 files — all hardened (see B3 above for the per-file write-ups):
+      - [x] `health-check.ts` 63.25 % → **92.31 %** (effective 100 %) _(2026-07-16 · `7797106`)_
+      - [x] `usage-tracker.ts` 55.88 % → **92.65 %** _(2026-07-16 · `c8cf06f`)_
+      - [x] `citation-renderer.ts` 45.45 % → **100 %** _(2026-07-16 · `71899da`)_
+      - [x] `reindex-lock.ts` 75.34 % → **94.52 %** _(2026-07-16 · `a5f740e`)_
+      - [x] `status-report.ts` 78.87 % → **100 %** _(2026-07-16 · `0e6398d`)_
       - Target ~90-93 %; ceiling ~96 % (documented equivalents can't be killed — do not chase 100 %).
   - [x] **3-local-mirror** — harden `local-mirror/src/**` survivors. Enumerated worst-files done +
     re-audit closer (67.63 % → 78.69 %). _(2026-07-15)_

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -46,14 +46,23 @@ unchecked box below.
 ### Improve + keep-fresh
 
 - [ ] **B1 — Anti-rot NIGHTLY workflow** *(agreed next build; latency analysis done — nightly wins over a PR gate)*
-  - [ ] New `.github/workflows/mutation-nightly.yml` on **`ubuntu-latest`** (NOT macOS/Windows: mutation
-    is OS-agnostic, and macOS billing is ×10). `schedule:` cron + `workflow_dispatch` for manual test.
-  - [ ] Run `mutate:all` — but `scripts/**` must run in a **disposable git worktree** (destructive inPlace,
-    see RESULTS.md § How each package is run). rag + local-mirror run inPlace.
-  - [ ] **Re-tune `concurrency`** for a 4-core runner (start at 2-3; verify no FALSE timeouts before
-    trusting the score — the documented bogus-100 % trap).
-  - [ ] Upload the HTML reports (`maintainers/mutation/reports/`) as a build artifact; non-blocking (informational).
-  - [ ] Ship it via `workflow_dispatch` FIRST (run once, confirm honest scores), THEN enable the cron.
+  - [x] New `.github/workflows/mutation-nightly.yml` on **`ubuntu-latest`** (NOT macOS/Windows: mutation
+    is OS-agnostic, and macOS billing is ×10). `schedule:` cron (`0 3 * * *`) + `workflow_dispatch`.
+    _(2026-07-16 · uncommitted)_
+  - [x] Run the three packages. **Divergence from the original note (justified):** they fan out as a
+    **parallel matrix** (`package: [rag, local-mirror, scripts]`), not a serial `mutate:all`, so the slow
+    `scripts` run doesn't block the others. **No worktree needed for `scripts` in CI**: the committed
+    `stryker.scripts.config.mjs` runs `inPlace: false` (Stryker sandbox), and the runner is itself
+    ephemeral — the worktree guidance in RESULTS.md is for LOCAL inPlace runs that would wipe the real
+    `vault/`. rag + local-mirror run their inPlace configs (non-destructive, restored). _(2026-07-16)_
+  - [x] **Re-tune `concurrency`** for a 4-core runner: workflow passes `--concurrency 2` (GitHub's 4-vCPU
+    runner over-subscribes at the local configs' 4-5 → the bogus-100 % false-timeout trap). _(2026-07-16)_
+    - [ ] **Verify empirically** (via the first `workflow_dispatch` run) that scores are honest at
+      concurrency 2 (no false timeouts); bump/lower if needed.
+  - [x] Upload the HTML reports as a build artifact; non-blocking (informational, `if: always()`).
+    thresholds.break is null in every config → a low score exits 0. _(2026-07-16)_
+  - [ ] Ship it via `workflow_dispatch` FIRST (run once, confirm honest scores), THEN trust the cron.
+    *(workflow_dispatch only fires from the default branch → validate right after the v3.4.2 merge to `main`.)*
   - [ ] (stretch) Add the Stryker **dashboard reporter** → unlocks the LIVE badge we deferred (replace the
     static capability badge in README + release notes).
 - [x] **B2 — Config hygiene: stop mutating test doubles.** `rag/src/lib/fake-embedder.ts` (62.5 %) is a

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -59,7 +59,10 @@ unchecked box below.
   TDD baby-steps, 6 engraved reflexes (+ reflex #6 = extract a pure seam when I/O glue resists):
   - [ ] `health-check.ts` 63.25 % (43 survivors — most in the package)
   - [ ] `usage-tracker.ts` 55.88 % (30)
-  - [ ] `citation-renderer.ts` 45.45 % (18 — lowest score)
+  - [x] `citation-renderer.ts` 45.45 % → **100 %** (33/33 killed, 0 survived) _(2026-07-16 · uncommitted)_
+    — 7 hardening tests (reflexes #2/#3/#4/#5): verbatim relay banner + `some`/`every` on a mixed set,
+    exact 1./2. numbering + `---` join separator, no-noise no-mirror prefix, the 500-char slice/ellipsis
+    boundary (500 vs 501), a byte-for-byte single-block assertion, and a tab (`%09`) pinning the hex zero-pad.
   - [ ] `reindex-lock.ts` 75.34 % (18)
   - [ ] `status-report.ts` 78.87 % (15)
   - Ceiling ~96 % (documented equivalents can't be killed — do NOT chase 100 %).

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -57,7 +57,13 @@ unchecked box below.
   is expected to tick up, which is exactly the improved number A2 will cut as the next release.
 - [ ] **B3 — Harden the newly-surfaced rag weak tier** (optional; lifts ~82.6 % → ~90-93 %). Worst-first,
   TDD baby-steps, 6 engraved reflexes (+ reflex #6 = extract a pure seam when I/O glue resists):
-  - [ ] `health-check.ts` 63.25 % (43 survivors — most in the package)
+  - [x] `health-check.ts` 63.25 % → **92.31 %** (108/108 non-equivalent killed; 9 survivors are all
+    documented equivalents = effective 100 %) _(2026-07-16 · uncommitted)_ — 13 tests: exact `{ status,
+    checks }` deepEqual per scenario (reflex #2, pins every `detail` string + the RELPATH/CANARY_TOKEN
+    constants), boundary triangulation on `canaryHits` (0/3/null) and `indexRows` (-1/0/42), and the
+    fail-safe gatherVitals seams (weightsReady absent/throws, canaryNoteExists throws). The 9 equivalents:
+    the `depth="full"→""` default (routes identically), redundant `let x=<init>` (always overwritten) and
+    `catch {}` blocks whose fail-safe value equals the init — unkillable without touching prod for nothing.
   - [ ] `usage-tracker.ts` 55.88 % (30)
   - [x] `citation-renderer.ts` 45.45 % → **100 %** (33/33 killed, 0 survived) _(2026-07-16 · uncommitted)_
     — 7 hardening tests (reflexes #2/#3/#4/#5): verbatim relay banner + `some`/`every` on a mixed set,

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -32,6 +32,16 @@ unchecked box below.
 - [ ] **A2 — After B2+B3 raise the score, cut the improved numbers as the NEXT release** so the *latest*
   release shows the *improved* scores (e.g. rag ~90-93 %). This is what actually satisfies "associate the
   better numbers with the latest release".
+  - [x] **Re-audit rag production-only (post-B2/B3): 82.59 % → 90.42 %** (1279 killed + 5 timeout / 1420
+    covered, 136 survived). RESULTS.md refreshed (re-audit #2; the 82.59 % closer marked superseded).
+    _(2026-07-16)_
+  - [x] **Decision (Thomas, 2026-07-16): v3.4.1 predates the B3 tests → do NOT retro-edit its note.** Cut
+    a **new patch release v3.4.2** that actually contains the hardened tests and pin 90.42 % there;
+    v3.4.1's note stays the honest tag-time snapshot. Codename: **"The One Where the Survivors Run Out of
+    Places to Hide"**.
+  - [ ] Build **B1 (nightly)** first, then cut **v3.4.2** bundling the hardening + the nightly (Thomas,
+    2026-07-16). Merge branch → `main`, tag `v3.4.2` on `main`, GitHub release with the codename + the
+    pinned `rag 90.42 %, scripts 97.27 %, local-mirror 78.69 %` snapshot.
 
 ### Improve + keep-fresh
 

--- a/maintainers/plans/prospective/mutation-testing-stryker.md
+++ b/maintainers/plans/prospective/mutation-testing-stryker.md
@@ -21,12 +21,14 @@ unchecked box below.
 
 ### Do-first (the "sellable numbers" ask)
 
-- [ ] **A0 — Merge PR #22** → `main`'s RESULTS.md shows **82.59 %** (baseline superseded), so the repo page
-  linked from the badge stops surfacing the stale 57 %.
-- [ ] **A1 — Pin the aggregate scores into the GitHub release notes.**
-  - [ ] Edit the **v3.4.1** note's "Hardened (test quality)" section to state the package aggregates:
+- [x] **A0 — Merge PR #22** → `main`'s RESULTS.md shows **82.59 %** (baseline superseded), so the repo page
+  linked from the badge stops surfacing the stale 57 %. _(2026-07-16 · merge 89a7fa0)_
+- [x] **A1 — Pin the aggregate scores into the GitHub release notes.** _(2026-07-16)_
+  - [x] Edit the **v3.4.1** note's "Hardened (test quality)" section to state the package aggregates:
     **rag 82.59 %, scripts 97.27 %, local-mirror 78.69 %** (honest — the release is frozen).
-  - [ ] Adopt the convention: every future release note carries a mutation-score snapshot pinned to its tag.
+    _(prod code identical between tag v3.4.1 and HEAD → the pinned number is the tag's real score)_
+  - [x] Adopt the convention: every future release note carries a mutation-score snapshot pinned to its
+    tag. _(engraved in `CONVENTIONS.md` §5ter)_
 - [ ] **A2 — After B2+B3 raise the score, cut the improved numbers as the NEXT release** so the *latest*
   release shows the *improved* scores (e.g. rag ~90-93 %). This is what actually satisfies "associate the
   better numbers with the latest release".
@@ -44,9 +46,15 @@ unchecked box below.
   - [ ] Ship it via `workflow_dispatch` FIRST (run once, confirm honest scores), THEN enable the cron.
   - [ ] (stretch) Add the Stryker **dashboard reporter** → unlocks the LIVE badge we deferred (replace the
     static capability badge in README + release notes).
-- [ ] **B2 — Config hygiene: stop mutating test doubles.** `rag/src/lib/fake-embedder.ts` (62.5 %) is a
+- [x] **B2 — Config hygiene: stop mutating test doubles.** `rag/src/lib/fake-embedder.ts` (62.5 %) is a
   **test helper**, not production code — mutating it measures the wrong thing. Exclude it from the rag
   mutate glob (and sweep for other `fake-*`/stub files across the three configs). Improves signal, not just score.
+  _(2026-07-16 · uncommitted)_ Swept all three packages: only two real test doubles in a mutate scope —
+  `rag/src/lib/fake-embedder.ts` (imported solely by its own test) and `scripts/lib/__fixtures__/stub-mcp-server.mjs`
+  (spawned only by `mcp-search`/`mcp-smoke` tests). Excluded both via negation globs (`!…fake-embedder.ts`,
+  `!scripts/lib/__fixtures__/**`); local-mirror already excludes `src/test/**`. All three configs re-parse
+  clean. Note: v3.4.1's pinned 82.59 % *included* fake-embedder — the NEXT rag re-audit (production-only)
+  is expected to tick up, which is exactly the improved number A2 will cut as the next release.
 - [ ] **B3 — Harden the newly-surfaced rag weak tier** (optional; lifts ~82.6 % → ~90-93 %). Worst-first,
   TDD baby-steps, 6 engraved reflexes (+ reflex #6 = extract a pure seam when I/O glue resists):
   - [ ] `health-check.ts` 63.25 % (43 survivors — most in the package)

--- a/rag/src/lib/citation-renderer.test.ts
+++ b/rag/src/lib/citation-renderer.test.ts
@@ -47,6 +47,23 @@ test("a mirror note renders both a real-file local link and a Notion link", () =
   assert.ok(text.includes("https://www.notion.so/abc"), text);
 });
 
+test("a single plain result renders the exact citation block, byte for byte", () => {
+  // Reflex #2 (assert the WHOLE string): one exact expected block pins every literal
+  // and layout fragment at once — the heading, the Path|Type|Score line (score to 3
+  // decimals), the 🧠-only links line whose sourceUrl-absent branch is the empty
+  // string (not an injected literal), the affordance, and the untruncated content.
+  const text = formatSearchCitations([result()], VAULT);
+
+  const expected =
+    "### 1. A note — Intro\n" +
+    "**Path:** `vault/mirrors/facture/a.md` | **Type:** note | **Score:** 0.420\n" +
+    `🧠 [local copy](<${localFileUrl("mirrors/facture/a.md")}>)\n` +
+    '_Ask me to "open citation 1" and I\'ll open it in your Markdown editor (Typora, Obsidian, …)._\n\n' +
+    "hello world";
+
+  assert.equal(text, expected);
+});
+
 test("the Notion link is angle-bracket wrapped so a ')' in the URL can't break the markdown", () => {
   const text = formatSearchCitations(
     [result({ sourceUrl: "https://www.notion.so/a(b)c" })],
@@ -69,6 +86,20 @@ test("a '>' or space in the Notion url is percent-encoded so it can't break the 
   );
 
   assert.ok(text.includes("(<https://www.notion.so/a%3Eb%20c>)"), text);
+});
+
+test("a control char whose hex is a single digit is zero-padded to two digits (%09, not %9)", () => {
+  // Reflex #3 (boundary): the existing '>'/space cases (0x3E, 0x20) are already two
+  // hex digits, so they can't tell `padStart(2, "0")` from `padStart(2, "")`. A TAB
+  // (0x09) is the one-digit case that pins the zero-pad — the escaped byte must be
+  // "%09", never "%9".
+  const text = formatSearchCitations(
+    [result({ sourceUrl: "https://www.notion.so/a\tb" })],
+    VAULT
+  );
+
+  assert.ok(text.includes("a%09b"), text);
+  assert.ok(!text.includes("a%9b"), text);
 });
 
 test("a non-mirror note renders only the local file link, no Notion link", () => {
@@ -94,11 +125,74 @@ test("when a mirror note is present, the output carries an engine-owned relay di
   assert.match(text, /relay[\s\S]*as-is/i, text);
 });
 
+test("the relay directive is emitted VERBATIM as a prefix when SOME (not all) notes are mirrors", () => {
+  // Reflex #2 (assert the whole string) + #5 (mixed set): a single mirror result
+  // makes `.some` and `.every` agree, so it can't tell them apart. A mixed set —
+  // one mirror, one plain — has some=true / every=false, pinning `.some`. And the
+  // banner is asserted verbatim (not just /🧠/ /🔗/), so blanking any fragment dies.
+  const expectedBanner =
+    "> ⚠️ Some cited notes come from a local mirror and carry TWO links — " +
+    "🧠 the local copy AND 🔗 the source. Relay BOTH to the user as-is; do not " +
+    "collapse them into one.\n\n";
+  const text = formatSearchCitations(
+    [result({ sourceUrl: "https://www.notion.so/abc" }), result({ title: "Plain" })],
+    VAULT
+  );
+
+  assert.ok(text.startsWith(expectedBanner), text);
+});
+
 test("a result set with NO mirror note carries no relay directive (no noise)", () => {
   // The belt fires ONLY when at least one cited note actually has a source link;
   // a plain vault search stays clean.
   const text = formatSearchCitations([result()], VAULT);
   assert.ok(!/relay/i.test(text), text);
+  // Reflex #4 (absent twin): the else-branch of the directive must be the empty
+  // string, so the output starts straight at the first heading — no injected noise
+  // (a `: ""` → `"Stryker was here!"` mutant doesn't match /relay/i but breaks this).
+  assert.ok(text.startsWith("### 1. "), text);
+});
+
+test("content of exactly 500 chars is kept whole with NO ellipsis (the > boundary)", () => {
+  // Reflex #3 (the equality boundary): at length 500, `length > 500` is false, so
+  // the else branch ("") wins — no ellipsis, no junk appended. This is the case that
+  // separates `>` from `>=`, the always/never conditional mutants, and the empty
+  // else from an injected string.
+  const text = formatSearchCitations([result({ content: "C".repeat(500) })], VAULT);
+
+  // endsWith pins it wholly: any boundary mutant that appends an ellipsis (`>=`,
+  // always-true conditional) or an injected else-string breaks the exact tail.
+  // (Can't assert `!includes("…")` — the affordance line legitimately carries one.)
+  assert.ok(text.endsWith("C".repeat(500)), text);
+});
+
+test("content longer than 500 chars is sliced to 500 and gets a trailing ellipsis", () => {
+  // Reflex #3 (boundary): the `.slice(0, 500)` + `length > 500 ? "…" : ""` cluster.
+  // A distinctive tail ("B"s past char 500) proves the slice actually drops them —
+  // endsWith alone wouldn't kill "remove slice" (a longer string still ends the same).
+  const text = formatSearchCitations(
+    [result({ content: "A".repeat(500) + "B".repeat(50) })],
+    VAULT
+  );
+
+  assert.ok(text.includes("A".repeat(500) + "…"), text);
+  assert.ok(!text.includes("B"), text); // the tail past char 500 is dropped
+});
+
+test("two results are numbered 1./2. in their headings and joined by a '---' rule", () => {
+  // Reflex #5 (collections of ≥2): numbering, the join separator and the heading
+  // text are all indistinguishable on a single result. Two results, split back on
+  // the exact separator, pin `${i + 1}` (not i, i-1), the `\n\n---\n\n` join, and
+  // that the heading string isn't blanked.
+  const text = formatSearchCitations(
+    [result({ title: "First", section: "S1" }), result({ title: "Second", section: "S2" })],
+    VAULT
+  );
+
+  const blocks = text.split("\n\n---\n\n");
+  assert.equal(blocks.length, 2, text);
+  assert.ok(blocks[0].startsWith("### 1. First — S1\n"), blocks[0]);
+  assert.ok(blocks[1].startsWith("### 2. Second — S2\n"), blocks[1]);
 });
 
 test("each citation carries an 'ask me to open citation N' affordance, numbered + editor-agnostic", () => {

--- a/rag/src/lib/health-check.test.ts
+++ b/rag/src/lib/health-check.test.ts
@@ -17,6 +17,127 @@ function checkNamed(result: { checks: { name: string; status: string }[] }, name
   return entry;
 }
 
+function vitals(over: Partial<HealthVitals> = {}): HealthVitals {
+  return { ...HEALTHY, ...over };
+}
+
+// The three HEALTHY check entries, reused to build exact { status, checks } expectations.
+// Reflex #2: asserting the WHOLE object (status + every detail string) — not just the
+// per-check .status the older tests pinned — is what kills the ~28 detail/boundary
+// mutants that a status-only assertion let survive.
+const OK_CANARY = { name: "canary", status: "ok", detail: "canary found (3)" };
+const OK_INDEX = { name: "index", status: "ok", detail: "42 rows" };
+const OK_EMBEDDER = { name: "embedder", status: "ok", detail: "in-process ready" };
+
+test("healthy full-depth vitals → exact { status, checks } with every detail", () => {
+  assert.deepEqual(buildHealthCheck(vitals()), {
+    status: "ok",
+    checks: [OK_CANARY, OK_INDEX, OK_EMBEDDER],
+  });
+});
+
+test("canary search ran but found nothing (hits 0) → broken, exact detail (the > 0 boundary)", () => {
+  // hits 0 vs the healthy 3 triangulates `canaryHits > 0`: at 0 the verdict flips to
+  // broken, separating `> 0` from `>= 0` and the always-true conditional.
+  assert.deepEqual(buildHealthCheck(vitals({ canaryHits: 0 })), {
+    status: "broken",
+    checks: [
+      { name: "canary", status: "broken", detail: "canary not found in the vault" },
+      OK_INDEX,
+      OK_EMBEDDER,
+    ],
+  });
+});
+
+test("dedicated health-check note missing → canary unknown, detail names the relpath", () => {
+  // Pins the HEALTH_CHECK_NOTE_RELPATH constant too (blanking it empties this detail).
+  assert.deepEqual(buildHealthCheck(vitals({ canaryNotePresent: false, canaryHits: 0 })), {
+    status: "unknown",
+    checks: [
+      {
+        name: "canary",
+        status: "unknown",
+        detail: "health-check note missing (engine-health/health-check.md)",
+      },
+      OK_INDEX,
+      OK_EMBEDDER,
+    ],
+  });
+});
+
+test("light probe (canaryHits null = not searched) → canary ok, 'not searched' detail", () => {
+  // canaryHits null (not 0) pins `canaryHits === null` against `!== null` / true / false.
+  assert.deepEqual(buildHealthCheck(vitals({ canaryHits: null })), {
+    status: "ok",
+    checks: [
+      {
+        name: "canary",
+        status: "ok",
+        detail: "health-check note present (light probe — not searched)",
+      },
+      OK_INDEX,
+      OK_EMBEDDER,
+    ],
+  });
+});
+
+test("embedder could not run the canary (ready false, hits 0) → canary unknown, exact detail", () => {
+  // embedderReady false with a key set makes the embedder check itself "broken", so
+  // the aggregate is "broken" (a broken check outranks the unknown canary).
+  assert.deepEqual(buildHealthCheck(vitals({ embedderReady: false, canaryHits: 0 })), {
+    status: "broken",
+    checks: [
+      { name: "canary", status: "unknown", detail: "embedder could not run the canary search" },
+      OK_INDEX,
+      { name: "embedder", status: "broken", detail: "in-process could not run" },
+    ],
+  });
+});
+
+test("index unreadable (rows -1) → index unknown, 'could not be read' (the < 0 sentinel)", () => {
+  assert.deepEqual(buildHealthCheck(vitals({ indexRows: -1 })), {
+    status: "unknown",
+    checks: [OK_CANARY, { name: "index", status: "unknown", detail: "index could not be read" }, OK_EMBEDDER],
+  });
+});
+
+test("index empty (rows 0) → index broken, 'index empty' (the 0 boundary, not < 0)", () => {
+  // rows 0 vs -1 vs 42 triangulates both `< 0` and `> 0` and their <=/>= twins.
+  assert.deepEqual(buildHealthCheck(vitals({ indexRows: 0 })), {
+    status: "broken",
+    checks: [OK_CANARY, { name: "index", status: "broken", detail: "index empty" }, OK_EMBEDDER],
+  });
+});
+
+test("API mode, no key configured → embedder unknown, '<mode> key not configured'", () => {
+  // A different mode ("gemini") pins the ${embedderMode} interpolation in the detail.
+  assert.deepEqual(
+    buildHealthCheck(vitals({ embedderMode: "gemini", keyConfigured: false, embedderReady: false })),
+    {
+      status: "unknown",
+      checks: [
+        { name: "canary", status: "unknown", detail: "embedder could not run the canary search" },
+        OK_INDEX,
+        { name: "embedder", status: "unknown", detail: "gemini key not configured" },
+      ],
+    },
+  );
+});
+
+test("key set but embedder cannot run → embedder broken, '<mode> could not run'", () => {
+  assert.deepEqual(
+    buildHealthCheck(vitals({ embedderMode: "gemini", keyConfigured: true, embedderReady: false, canaryHits: 0 })),
+    {
+      status: "broken",
+      checks: [
+        { name: "canary", status: "unknown", detail: "embedder could not run the canary search" },
+        OK_INDEX,
+        { name: "embedder", status: "broken", detail: "gemini could not run" },
+      ],
+    },
+  );
+});
+
 test("all vitals healthy → aggregate status ok, every check ok", () => {
   const result = buildHealthCheck(HEALTHY);
   assert.equal(result.status, "ok");
@@ -207,6 +328,69 @@ test("runHealthCheck light depth: composes gather(light)+build, never searches, 
   );
   assert.equal(searched, false);
   assert.equal(result.status, "ok");
+});
+
+test("gatherVitals full depth searches with the exact CANARY_TOKEN 'Quibblethorne'", async () => {
+  // Pins the CANARY_TOKEN constant: blanking it to "" makes the seam receive "".
+  const seen: string[] = [];
+  await gatherVitals({
+    embedderMode: "in-process",
+    keyConfigured: true,
+    readIndexRows: () => 12,
+    searchCanary: async (t) => {
+      seen.push(t);
+      return 1;
+    },
+    canaryNoteExists: () => true,
+  });
+  assert.deepEqual(seen, ["Quibblethorne"]);
+});
+
+test("gatherVitals light: weightsReady seam ABSENT → embedderReady false (the : false fallback)", async () => {
+  // Reflex #4 (absent twin): the existing tests always PROVIDE weightsReady. Omitting
+  // it exercises the `seams.weightsReady ? … : false` else — a `: false` → `: true`
+  // mutant only dies when the seam is missing.
+  const v = await gatherVitals(
+    {
+      embedderMode: "in-process",
+      keyConfigured: true,
+      readIndexRows: () => 12,
+      searchCanary: async () => 4,
+      canaryNoteExists: () => true,
+    },
+    "light",
+  );
+  assert.equal(v.embedderReady, false);
+});
+
+test("gatherVitals light: a throwing weightsReady → embedderReady false (fail-safe catch)", async () => {
+  const v = await gatherVitals(
+    {
+      embedderMode: "in-process",
+      keyConfigured: true,
+      readIndexRows: () => 12,
+      searchCanary: async () => 4,
+      canaryNoteExists: () => true,
+      weightsReady: () => {
+        throw new Error("weights boom");
+      },
+    },
+    "light",
+  );
+  assert.equal(v.embedderReady, false);
+});
+
+test("gatherVitals: a throwing canaryNoteExists → canaryNotePresent false (fail-safe catch)", async () => {
+  const v = await gatherVitals({
+    embedderMode: "in-process",
+    keyConfigured: true,
+    readIndexRows: () => 12,
+    searchCanary: async () => 1,
+    canaryNoteExists: () => {
+      throw new Error("fs boom");
+    },
+  });
+  assert.equal(v.canaryNotePresent, false);
 });
 
 test("gatherVitals: a throwing canary search → embedderReady false, 0 hits", async () => {

--- a/rag/src/lib/reindex-lock.test.ts
+++ b/rag/src/lib/reindex-lock.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -136,6 +136,91 @@ test("activeHolder(): no lock → null", () => {
     pid: 1234,
   });
   assert.equal(lock.activeHolder(), null);
+});
+
+test("now omitted → a real Date clock: acquire stamps a valid ISO timestamp", () => {
+  // Reflex #4: the tests always inject `now`, so the `() => new Date()` default never
+  // ran. A `() => undefined` mutant makes now().toISOString() throw — omitting `now`
+  // and acquiring pins the default to a working clock.
+  const storage = new MemStorage();
+  assert.equal(new ReindexLock({ storage, pid: 1234 }).acquire(), true);
+  assert.match(storage.state!.acquiredAt, /^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+});
+
+test("staleAfterMs omitted → defaults to 30 min (a 2h-old live lock is stale, reclaimable)", () => {
+  // A `?? DEFAULT` → `&& DEFAULT` mutant leaves staleAfterMs undefined (age > undefined
+  // is always false → never stale), so the reclaim would fail. Default 30min → 2h stale.
+  const lock = new ReindexLock({
+    storage: new MemStorage({ pid: 999, acquiredAt: "2026-05-31T16:00:00Z" }),
+    now: at("2026-05-31T18:00:00Z"),
+    pid: 1234,
+    isAlive: () => true,
+  });
+  assert.equal(lock.acquire(), true);
+});
+
+test("isStale boundary: age exactly at staleAfterMs is NOT stale (the > boundary)", () => {
+  // acquired 18:00, now 18:10, staleAfterMs 10min → age == staleAfterMs. `age >
+  // staleAfterMs` is false (still active); a `>=` mutant flips it to stale and reclaims.
+  const lock = new ReindexLock({
+    storage: new MemStorage({ pid: 999, acquiredAt: "2026-05-31T18:00:00Z" }),
+    now: at("2026-05-31T18:10:00Z"),
+    pid: 1234,
+    isAlive: () => true,
+    staleAfterMs: 10 * 60 * 1000,
+  });
+  assert.equal(lock.activeHolder()?.pid, 999); // exactly at the boundary → still active
+  assert.equal(lock.acquire(), false); // a non-stale live lock can't be reclaimed
+});
+
+test("isAlive omitted → the real process check: our own live PID is an active holder", () => {
+  // Exercises the private defaultIsAlive (process.kill(pid, 0)) via the public API:
+  // our own PID is alive → an active holder. Kills the true→false / empty-body mutants.
+  const lock = new ReindexLock({
+    storage: new MemStorage({ pid: process.pid, acquiredAt: "2026-05-31T17:59:30Z" }),
+    now: at("2026-05-31T18:00:00Z"), // 30s → not stale
+  });
+  assert.equal(lock.activeHolder()?.pid, process.pid);
+});
+
+test("isAlive omitted → a non-existent PID is not alive → no active holder", () => {
+  const DEAD_PID = 2 ** 30; // no such process → process.kill throws → not alive
+  const lock = new ReindexLock({
+    storage: new MemStorage({ pid: DEAD_PID, acquiredAt: "2026-05-31T17:59:30Z" }),
+    now: at("2026-05-31T18:00:00Z"),
+  });
+  assert.equal(lock.activeHolder(), null);
+});
+
+test("FileLockStorage: a corrupt file loads as null (reclaimable, never crashes)", () => {
+  const path = resolve(tmpdir(), `reindex-lock-corrupt-${process.pid}.json`);
+  try {
+    writeFileSync(path, "not json {{", "utf-8");
+    assert.equal(new FileLockStorage(path).load(), null);
+  } finally {
+    rmSync(path, { force: true });
+  }
+});
+
+test("FileLockStorage: well-formed JSON of the WRONG shape loads as null (both && sides)", () => {
+  // Reflex #3: twins around `typeof pid === "number" && typeof acquiredAt === "string"`.
+  const path = resolve(tmpdir(), `reindex-lock-shape-${process.pid}.json`);
+  try {
+    const storage = new FileLockStorage(path);
+    writeFileSync(path, JSON.stringify({ pid: "1234", acquiredAt: "2026-05-31T18:00:00Z" }), "utf-8");
+    assert.equal(storage.load(), null); // pid not a number
+    writeFileSync(path, JSON.stringify({ pid: 1234, acquiredAt: 20260531 }), "utf-8");
+    assert.equal(storage.load(), null); // acquiredAt not a string
+  } finally {
+    rmSync(path, { force: true });
+  }
+});
+
+test("FileLockStorage: clear() on an absent file does not throw (the force flag)", () => {
+  const path = resolve(tmpdir(), `reindex-lock-absent-${process.pid}.json`);
+  rmSync(path, { force: true }); // ensure absent
+  // rmSync without { force: true } throws ENOENT on a missing path.
+  assert.doesNotThrow(() => new FileLockStorage(path).clear());
 });
 
 test("FileLockStorage: round-trip load/save/clear on a temp file", () => {

--- a/rag/src/lib/status-report.test.ts
+++ b/rag/src/lib/status-report.test.ts
@@ -10,44 +10,66 @@ import type { SchedulerState } from "./reindex-scheduler.js";
 
 const idle: SchedulerState = { scheduled: false, running: false, pending: false };
 
-test("F.live — watcher inactive → \"inactive\"", () => {
-  const line = formatWatcherLiveness({ active: false });
-  assert.match(line, /watcher.*inactive/i);
+// ─── formatWatcherLiveness — exact strings (reflex #2: pin the whole line) ───
+
+test("F.live — watcher inactive → exact inactive line", () => {
+  assert.equal(
+    formatWatcherLiveness({ active: false }),
+    "Live-stream watcher: inactive.",
+  );
 });
 
-test("F.live — watcher active idle → \"active … idle\"", () => {
-  const line = formatWatcherLiveness({ active: true, state: idle });
-  assert.match(line, /active/i);
-  assert.match(line, /idle/i);
+test("F.live — active + explicit idle state → exact idle line", () => {
+  assert.equal(
+    formatWatcherLiveness({ active: true, state: idle }),
+    "Live-stream watcher: active (idle).",
+  );
 });
 
-test("F.live — active + reindex scheduled (debounce) → \"scheduled\"", () => {
-  const line = formatWatcherLiveness({
-    active: true,
-    state: { ...idle, scheduled: true },
-  });
-  assert.match(line, /active/i);
-  assert.match(line, /scheduled/i);
+test("F.live — active + NO state (null) → idle line, no throw on optional chaining", () => {
+  // Pins the `state?.running` / `state?.scheduled` optional-chaining: dropping
+  // the `?.` would throw a TypeError when state is null/undefined.
+  assert.equal(
+    formatWatcherLiveness({ active: true, state: null }),
+    "Live-stream watcher: active (idle).",
+  );
+  assert.equal(
+    formatWatcherLiveness({ active: true }),
+    "Live-stream watcher: active (idle).",
+  );
 });
 
-test("F.live — active + reindex in progress → \"in progress\"", () => {
-  const line = formatWatcherLiveness({
-    active: true,
-    state: { ...idle, running: true },
-  });
-  assert.match(line, /in progress/i);
+test("F.live — active + reindex scheduled (debounce) → exact scheduled line", () => {
+  assert.equal(
+    formatWatcherLiveness({ active: true, state: { ...idle, scheduled: true } }),
+    "Live-stream watcher: active — write detected, reindex scheduled (debounce).",
+  );
 });
 
-test("F.live — active + run in progress with burst pending → \"in progress\" + \"pending\"", () => {
-  const line = formatWatcherLiveness({
-    active: true,
-    state: { scheduled: false, running: true, pending: true },
-  });
-  assert.match(line, /in progress/i);
-  assert.match(line, /pending/i);
+test("F.live — active + reindex in progress, no burst → exact line, NO pending suffix", () => {
+  // Pins the ternary else-branch (`... : ""`): a mutant appending a suffix here
+  // must change the exact string.
+  assert.equal(
+    formatWatcherLiveness({ active: true, state: { ...idle, running: true } }),
+    "Live-stream watcher: active — reindex in progress.",
+  );
 });
 
-test("3.1a — complete index → \"index up to date\" + Y/X dashboard", () => {
+test("F.live — active + run in progress WITH burst pending → exact line + \"(burst pending)\"", () => {
+  assert.equal(
+    formatWatcherLiveness({
+      active: true,
+      state: { scheduled: false, running: true, pending: true },
+    }),
+    "Live-stream watcher: active — reindex in progress (burst pending).",
+  );
+});
+
+// ─── buildStatusReport — exact whole-report assertions ───
+
+test("3.1a — complete index, gemini/default provider → exact 2-line report", () => {
+  // Whole-report equality pins the "\n" join separator AND that no null line is
+  // pushed when lock/progress are absent (if(lock)/if(progress) guards).
   const report = buildStatusReport({
     docCount: 42,
     scannedCount: 42,
@@ -57,12 +79,14 @@ test("3.1a — complete index → \"index up to date\" + Y/X dashboard", () => {
     lock: null,
   });
 
-  assert.match(report, /index up to date/i);
-  assert.match(report, /42\s*\/\s*42/); // Y/X files indexed
-  assert.match(report, /files indexed/i);
+  assert.equal(
+    report,
+    "Index up to date: 42/42 files indexed.\n" +
+      "Quota: 0/950 used today, 950 remaining (reserve 50 for search).",
+  );
 });
 
-test("3.1b — incomplete index → Y/X indexed + Z pending + auto-resume", () => {
+test("3.1b — incomplete index → exact Y/X indexed + Z pending + auto-resume line", () => {
   const report = buildStatusReport({
     docCount: 30,
     scannedCount: 42,
@@ -72,13 +96,14 @@ test("3.1b — incomplete index → Y/X indexed + Z pending + auto-resume", () =
     lock: null,
   });
 
-  assert.doesNotMatch(report, /index up to date/i);
-  assert.match(report, /30\s*\/\s*42/); // Y/X indexed
-  assert.match(report, /12 pending/i); // 42 - 30
-  assert.match(report, /resume/i);
+  assert.equal(
+    report,
+    "Index incomplete: 30/42 files indexed, 12 pending — auto-resume on the next session.\n" +
+      "Quota: 0/950 used today, 950 remaining (reserve 50 for search).",
+  );
 });
 
-test("3.1c — quota line: used / max / remaining + search reserve", () => {
+test("3.1c — quota line: used / max / remaining + search reserve (exact)", () => {
   const report = buildStatusReport({
     docCount: 42,
     scannedCount: 42,
@@ -88,12 +113,34 @@ test("3.1c — quota line: used / max / remaining + search reserve", () => {
     lock: null,
   });
 
-  assert.match(report, /200\s*\/\s*950/); // used / max
-  assert.match(report, /750 remaining/i); // 950 - 200
-  assert.match(report, /reserve 50.*search/i);
+  assert.equal(
+    report,
+    "Index up to date: 42/42 files indexed.\n" +
+      "Quota: 200/950 used today, 750 remaining (reserve 50 for search).",
+  );
 });
 
-test("3.1d — lock present → \"reindex in progress (PID …)\"", () => {
+test("3.1c-bis — explicit providerId \"gemini\" → the Gemini quota line (not the local line)", () => {
+  // Triangulates the `providerId === "gemini"` branch: an explicit gemini must
+  // route to the quota line, distinct from the undefined (backward-compat) path.
+  const report = buildStatusReport({
+    docCount: 42,
+    scannedCount: 42,
+    quotaUsed: 200,
+    quotaMax: 950,
+    reserve: 50,
+    lock: null,
+    providerId: "gemini",
+  });
+
+  assert.equal(
+    report,
+    "Index up to date: 42/42 files indexed.\n" +
+      "Quota: 200/950 used today, 750 remaining (reserve 50 for search).",
+  );
+});
+
+test("3.1d — lock present → exact \"reindex in progress (PID …)\" third line", () => {
   const report = buildStatusReport({
     docCount: 42,
     scannedCount: 42,
@@ -103,8 +150,12 @@ test("3.1d — lock present → \"reindex in progress (PID …)\"", () => {
     lock: { pid: 12345, acquiredAt: "2026-05-31T11:59:00Z" },
   });
 
-  assert.match(report, /reindex in progress/i);
-  assert.match(report, /12345/);
+  assert.equal(
+    report,
+    "Index up to date: 42/42 files indexed.\n" +
+      "Quota: 0/950 used today, 950 remaining (reserve 50 for search).\n" +
+      "Reindex in progress (PID 12345).",
+  );
 });
 
 test("3.1d — no lock → no mention of reindex in progress", () => {
@@ -120,18 +171,22 @@ test("3.1d — no lock → no mention of reindex in progress", () => {
   assert.doesNotMatch(report, /reindex in progress/i);
 });
 
-test("4.2 — incompleteIndexWarning: incomplete index → resume message", () => {
-  const warning = incompleteIndexWarning({ docCount: 30, scannedCount: 42 });
-  assert.notEqual(warning, null);
-  assert.match(warning!, /incomplete/i);
-  assert.match(warning!, /resume/i);
+// ─── incompleteIndexWarning (leaf) ───
+
+test("4.2 — incompleteIndexWarning: incomplete index → exact resume message", () => {
+  assert.equal(
+    incompleteIndexWarning({ docCount: 30, scannedCount: 42 }),
+    "Index incomplete: 30/42 files indexed, 12 pending — auto-resume on the next session.",
+  );
 });
 
 test("4.2 — incompleteIndexWarning: complete index → null (nothing to surface)", () => {
   assert.equal(incompleteIndexWarning({ docCount: 42, scannedCount: 42 }), null);
 });
 
-test("C.13 — progress running provided → Catch-up section added to the report", () => {
+// ─── progress line — the `now ?? startedAt` fallback drives rate/ETA ───
+
+test("C.13 — progress running with `now` → exact 3-line report (now, not startedAt, drives ETA)", () => {
   const progress: RunProgress = {
     status: "running",
     startedAt: "2026-05-31T18:00:00Z",
@@ -153,11 +208,47 @@ test("C.13 — progress running provided → Catch-up section added to the repor
     reserve: 50,
     lock: null,
     progress,
-    now: "2026-05-31T18:01:00Z",
+    now: "2026-05-31T18:01:00Z", // 1 min after startedAt → rate 120/min, ETA 5 min
   });
 
-  assert.match(report, /Catch-up in progress/i);
-  assert.match(report, /120\/660/); // chunks done / total
+  // Using startedAt instead of `now` (the `?? → &&` mutant) would zero the
+  // elapsed time → "~0/min, ETA unknown".
+  assert.equal(
+    report,
+    "Index incomplete: 120/211 files indexed, 91 pending — auto-resume on the next session.\n" +
+      "Quota: 200/950 used today, 750 remaining (reserve 50 for search).\n" +
+      "Catch-up in progress: 120/660 chunks (18 %), ~120/min, ETA ~5 min, 0 error(s).",
+  );
+});
+
+test("C.13 — progress running with `now` OMITTED → falls back to startedAt (elapsed 0 → ETA unknown)", () => {
+  // Triangulates the other side of `now ?? progress.startedAt`: with no `now`,
+  // the fallback to startedAt gives zero elapsed → rate 0 → ETA unknown.
+  const progress: RunProgress = {
+    status: "running",
+    startedAt: "2026-05-31T18:00:00Z",
+    totalChunks: 660,
+    doneChunks: 120,
+    scanned: 211,
+    indexed: 18,
+    skipped: 50,
+    removed: 0,
+    errors: [],
+    hitCap: false,
+  };
+
+  const report = buildStatusReport({
+    docCount: 120,
+    scannedCount: 211,
+    quotaUsed: 200,
+    quotaMax: 950,
+    reserve: 50,
+    lock: null,
+    progress,
+    // now omitted
+  });
+
+  assert.match(report, /Catch-up in progress: 120\/660 chunks \(18 %\), ~0\/min, ETA unknown, 0 error\(s\)\./);
 });
 
 test("C.13 — no progress → no Catch-up section", () => {
@@ -173,7 +264,9 @@ test("C.13 — no progress → no Catch-up section", () => {
   assert.doesNotMatch(report, /catch-up/i);
 });
 
-test("3.1e — in-process embedder: honest local line, NO Gemini quota", () => {
+// ─── embedding line per provider — exact, triangulated across all 3 branches ───
+
+test("3.1e — in-process embedder (transformers-js) → exact local line, NO Gemini quota", () => {
   const report = buildStatusReport({
     docCount: 7,
     scannedCount: 7,
@@ -184,16 +277,14 @@ test("3.1e — in-process embedder: honest local line, NO Gemini quota", () => {
     providerId: "transformers-js",
   });
 
-  // The daily quota is specific to Gemini: it must NOT appear in local mode.
-  assert.doesNotMatch(report, /quota\s*:/i);
-  assert.doesNotMatch(report, /7600/);
-  assert.doesNotMatch(report, /today/i);
-  // Instead, an honest local line that names the embedder and says unlimited.
-  assert.match(report, /in-process/i);
-  assert.match(report, /unlimited/i);
+  assert.equal(
+    report,
+    "Index up to date: 7/7 files indexed.\n" +
+      "Local embeddings (in-process): unlimited, offline — no API quota.",
+  );
 });
 
-test("3.1f — OpenAI-compatible embedder: no Gemini quota, without promising offline", () => {
+test("3.1f — OpenAI-compatible embedder → exact endpoint line (no offline promise)", () => {
   const report = buildStatusReport({
     docCount: 7,
     scannedCount: 7,
@@ -204,9 +295,29 @@ test("3.1f — OpenAI-compatible embedder: no Gemini quota, without promising of
     providerId: "openai-compatible",
   });
 
-  assert.doesNotMatch(report, /7600/);
-  assert.doesNotMatch(report, /today/i);
-  // Endpoint named, but we do NOT promise "offline" (it may be remote).
-  assert.match(report, /OpenAI-compatible/i);
-  assert.doesNotMatch(report, /offline/i);
+  assert.equal(
+    report,
+    "Index up to date: 7/7 files indexed.\n" +
+      "Embeddings via OpenAI-compatible endpoint: no Gemini quota tracked.",
+  );
+});
+
+test("3.1g — any other provider → exact generic \"Embeddings via <id>\" fallback line", () => {
+  // Triangulates the third branch of localEmbeddingLine: a provider that is
+  // neither transformers-js nor openai-compatible names itself verbatim.
+  const report = buildStatusReport({
+    docCount: 7,
+    scannedCount: 7,
+    quotaUsed: 0,
+    quotaMax: 7600,
+    reserve: 50,
+    lock: null,
+    providerId: "mistral-embed",
+  });
+
+  assert.equal(
+    report,
+    "Index up to date: 7/7 files indexed.\n" +
+      "Embeddings via mistral-embed: no Gemini quota tracked.",
+  );
 });

--- a/rag/src/lib/usage-tracker.test.ts
+++ b/rag/src/lib/usage-tracker.test.ts
@@ -1,8 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   UsageTracker,
   DailyCapExceededError,
+  FileUsageStorage,
   dayKey,
   type UsageState,
   type UsageStorage,
@@ -138,6 +142,98 @@ test("remainingForIndexing reflects the reserve, floored at 0", () => {
   // a priority request draws from the reserve → indexing runs dry
   t.consumePriority(3);
   assert.equal(t.remainingForIndexing(), 0); // floored, not negative
+});
+
+test("DailyCapExceededError carries used/max, its name, and the full guidance message", () => {
+  // Reflex #1/#2: the older `assert.throws(…, DailyCapExceededError)` tests never
+  // matched the message, so every string fragment (and the `name`) survived. Assert
+  // the exact message and both fields.
+  const err = new DailyCapExceededError(5, 7);
+  assert.equal(err.used, 5);
+  assert.equal(err.max, 7);
+  assert.equal(err.name, "DailyCapExceededError");
+  assert.equal(
+    err.message,
+    "Daily embedding cap reached (5/7). Try again tomorrow (the quota resets at midnight Pacific time) or raise MAX_EMBED_REQUESTS_PER_DAY in .env.",
+  );
+});
+
+test("a custom timeZone is honored, not silently swapped for the Pacific default", () => {
+  // tz="UTC" with a clock at 05:00Z: the UTC day is the 30th, the Pacific day the 29th.
+  // A state seeded for the 30th reads as "today" ONLY under UTC — so a `?? ` → `&&`
+  // mutant (which would force the LA default) reads the 29th, sees no match, returns 0.
+  const t = new UsageTracker({
+    maxPerDay: 100,
+    timeZone: "UTC",
+    now: at("2026-05-30T05:00:00Z"),
+    storage: new MemStorage({ date: "2026-05-30", count: 5 }),
+  });
+  assert.equal(t.usedToday(), 5);
+});
+
+test("timeZone omitted → defaults to Pacific (America/Los_Angeles)", () => {
+  // Reflex #4 (absent twin): no timeZone. At 05:00Z the Pacific day is the 29th, so a
+  // state seeded for the 29th reads as today. A `?? ""` mutant makes the tz invalid and
+  // the day computation throw — so this pins the default value, not just its presence.
+  const t = new UsageTracker({
+    maxPerDay: 100,
+    now: at("2026-05-30T05:00:00Z"),
+    storage: new MemStorage({ date: "2026-05-29", count: 7 }),
+  });
+  assert.equal(t.usedToday(), 7);
+});
+
+test("FileUsageStorage: save then load round-trips the state through a real file", () => {
+  // Reflex #6: the file I/O was never exercised (all tests used MemStorage), so the
+  // whole load/save body survived. Drive it on a real temp file via the injectable
+  // path. The temp dir already exists, so an mkdir without `recursive` throws EEXIST —
+  // which is exactly what kills the `{ recursive: true }` / `"utf-8"` mutants at save.
+  const dir = mkdtempSync(join(tmpdir(), "usage-"));
+  const path = join(dir, "embed-usage.json");
+  try {
+    new FileUsageStorage(path).save({ date: "2026-05-30", count: 7 });
+    assert.equal(existsSync(path), true);
+    assert.deepEqual(new FileUsageStorage(path).load(), { date: "2026-05-30", count: 7 });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileUsageStorage: a missing file loads as null (no crash)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "usage-"));
+  try {
+    assert.equal(new FileUsageStorage(join(dir, "absent.json")).load(), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileUsageStorage: a corrupt file loads as null (start-from-zero, never crashes)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "usage-"));
+  const path = join(dir, "embed-usage.json");
+  try {
+    writeFileSync(path, "{ not valid json", "utf-8");
+    assert.equal(new FileUsageStorage(path).load(), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileUsageStorage: well-formed JSON of the WRONG shape loads as null (both && sides)", () => {
+  // Reflex #3: two twins around the `typeof date === "string" && typeof count === "number"`
+  // guard — date-valid/count-invalid and date-invalid/count-valid — so `&&`→`||`, each
+  // `===`→`!==` and each type-string mutant flips exactly one side and gets caught.
+  const dir = mkdtempSync(join(tmpdir(), "usage-"));
+  const path = join(dir, "embed-usage.json");
+  try {
+    const storage = new FileUsageStorage(path);
+    writeFileSync(path, JSON.stringify({ date: "2026-05-30", count: "seven" }), "utf-8");
+    assert.equal(storage.load(), null); // count not a number
+    writeFileSync(path, JSON.stringify({ date: 20260530, count: 7 }), "utf-8");
+    assert.equal(storage.load(), null); // date not a string
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("dayKey correctly uses the Pacific time zone boundary", () => {


### PR DESCRIPTION
## v3.4.2: The One Where the Survivors Run Out of Places to Hide

Test-quality release (no production behaviour change). It closes the rag weak-tier
hardening (B3), corrects the mutation measurement (B2), and adds the anti-rot nightly
(B1).

### Mutation scores (current)

| Package | Score | Note |
|---|---|---|
| rag | **90.42 %** | was 82.59 % (which still mutated the fake-embedder test double) |
| scripts | 97.27 % | 3 weak files since hardened to 92-100 %; `lib/**` already 100 % |
| local-mirror | 78.69 % | re-audit 2026-07-15 |

### What's in it

- **B3: rag weak-tier hardened.** `health-check` 63.25 -> 92.31 %, `usage-tracker`
  55.88 -> 92.65 %, `citation-renderer` 45.45 -> 100 %, `reindex-lock` 75.34 -> 94.52 %,
  `status-report` 78.87 -> 100 %. All survivors came from loose assertions; converted to
  exact whole-string / whole-report equality plus boundary and null triangulation.
- **B2: stopped mutating test doubles.** `fake-embedder.ts` and the scripts
  `__fixtures__/**` stubs are test helpers, not production code, so they no longer drag
  the honest signal.
- **B1: nightly anti-rot workflow.** `.github/workflows/mutation-nightly.yml`, ubuntu-only,
  parallel matrix over the three packages, `--concurrency 2` against the false-timeout
  trap, HTML reports as artifacts. Informational only (never a gate).
- **Docs:** `RESULTS.md` reordered newest-first with a current-scores summary; the plan
  and retrospective reflect the closed work.

### Why v3.4.2 and not a retro-edit of v3.4.1's note

v3.4.1 was tagged before these hardened tests existed, so its frozen note stays the honest
snapshot for that tag. The improved numbers ship with the release that actually contains
the tests, which is this one.
