### PR TITLE
feat(chunker): prune degenerate section bodies below a meaningful-char floor — The One Where Empty Scaffolds Leave the Index

### DIFF
--- a/maintainers/plans/archived/golden-source-sync-action.md
+++ b/maintainers/plans/archived/golden-source-sync-action.md
@@ -1,10 +1,20 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🚧 ACTIVE — Steps 0–8 done. Step 9 IN PROGRESS: live-Notion QA started against a throwaway personal test zone (10 pages). PROVEN against the real API: setup_source (scope OK), first sync (1 .md/page + correct frontmatter, token only via token_env), delta no-op, watermark, check_freshness. BLOCKING FINDING B1: pages embedding Notion-hosted files/images churn on every sync (notion-to-md emits rotating S3 pre-signed URLs with X-Amz-* params → hash differs → rewrite) → violates "no-change sync rewrites nothing"; fix = normalize/strip X-Amz-* before hashing (TDD) + ADR. STILL NEEDS THOMAS: real rename/delete reconciliation in Notion, installed-brain demo (FileWatcher index + bounded answer + citation). Branch: golden-source-sync. -->
+<!-- STATUS: ✅ SHIPPED / SUPERSEDED (archived 2026-07-17). This engine was renamed
+     `golden-source-sync` → `local-mirror` (archived plan `local-mirror-rename-action.md`)
+     and SHIPPED as the `local-mirror/` package + `local-mirror` skill. The scheduled
+     self-refresh landed in v3.5.0 ("The One Where the Mirror Refreshes Itself", PR #28;
+     archived plan `golden-source-scheduled-sync-action.md`). Finding B1 (X-Amz-* pre-signed
+     URL churn) was fixed during the ship. Proof: `local-mirror/` package present, skill
+     available, tag v3.5.0. Kept for history only — do NOT resume from this file. -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Action plan — `golden-source-sync`: synchronize golden-source content into the second brain's vault
 
-> **STATUS: 🚧 ACTIVE — not started** (created 2026-06-17). Implements the frozen design in
+> **STATUS: ✅ SHIPPED / SUPERSEDED** (created 2026-06-17, archived 2026-07-17). Renamed to
+> `local-mirror` and shipped (package + skill); scheduled self-refresh shipped in **v3.5.0**.
+> Superseded by the archived `local-mirror-rename-action.md` and
+> `golden-source-scheduled-sync-action.md`. Kept for history only. Implements the frozen design in
 > [`prd-golden-source-sync.md`](./prd-golden-source-sync.md) (the PRD — copy it next to this plan
 > for reference). A **new MCP server** that declares *golden sources* and **synchronizes their
 > content** into the local vault as plain Markdown. It **writes/deletes files, full stop**: the

--- a/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
+++ b/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
@@ -32,6 +32,8 @@ overwrites). It does **not** migrate skills, hooks, `.mcp.json`, or `CLAUDE.md` 
 ## Tracking
 
 - [ ] **Track A — Engine: embedder/chunker degenerate-chunk pruning** (upstream to launcher)
+      — code shipped on `feat/chunker-degenerate-body-pruning` (dd13be0, 2026-07-17), mutation-proven;
+      only the source-vault re-measurement (~105) remains, to run from Thomas's pre-existing brain.
 - [ ] **Track B — Skills: classify & route** (generic → launcher, private → personal brain)
 - [ ] **Track C — Constitution merge** (distill generic disciplines to template; keep newer template wins)
 - [ ] **Track D — Corpus migration** (generate brain → `/import` 405 notes → layer private capabilities)
@@ -51,22 +53,27 @@ falls back to the filename, `frontmatter-parser.ts:48-60`); the `isSubstantialBo
 **only** to section bodies, never to the title chunk → every doc keeps ≥1 chunk. Gain is primarily
 **index-noise / search-quality**, secondarily a small one-time quota saving.
 
-- [ ] Add `isSubstantialBody(body)` + `MIN_BODY_MEANINGFUL_CHARS = 25` (count `\p{L}\p{N}` only) to
+- [x] Add `isSubstantialBody(body)` + `MIN_BODY_MEANINGFUL_CHARS = 25` (count `\p{L}\p{N}` only) to
       `rag/src/lib/chunker.ts`, applied **only** inside the section loop (keep the unconditional
-      `(title)` chunk untouched).
-- [ ] TDD baby-steps (fail-first, one test at a time). Test cases:
-  - [ ] title-only page still yields ≥1 chunk (F8 guard) — the invariant, as an explicit test.
-  - [ ] degenerate section (`---`, `<!-- ... -->`, `- ` stub) is pruned.
-  - [ ] substantial section is kept.
-  - [ ] threshold false-positive guards: URL-only, code-snippet-only, image-only section → decide
-        keep vs prune and lock the decision with a test.
-- [ ] Keep `rag/src/lib/indexer.ts`'s **loud 0-chunk surface** as backstop. Do **NOT** adopt the
+      `(title)` chunk untouched). _(2026-07-17 · dd13be0)_
+- [x] TDD baby-steps (fail-first, one test at a time). Test cases: _(2026-07-17 · dd13be0)_
+  - [x] title-only page still yields ≥1 chunk (F8 guard) — the invariant, as an explicit test
+        (pre-existing empty-body test + new "title + degenerate body → title chunk survives").
+  - [x] degenerate section (`---`, `<!-- ... -->`, `- ` stub) is pruned.
+  - [x] substantial section is kept.
+  - [x] threshold false-positive guards: URL-only + code-snippet → **KEPT**; image-only (no alt) +
+        stub → **pruned**; boundary triangulated (`>= 25` inclusive: 25 kept / 24 pruned) + char
+        class (punctuation/whitespace don't count).
+- [x] Keep `rag/src/lib/indexer.ts`'s **loud 0-chunk surface** as backstop. Do **NOT** adopt the
       source brain's silent `persist-0-chunk-with-hash` (it pairs with a no-title-chunk design and
-      would re-open the F8 silent-drop).
-- [ ] Run mutation testing on `chunker` (Stryker) to confirm the new guard is covered.
-- [ ] Ensure `chunker.ts` is engine-owned in `engine-manifest.json` so the fix reaches upgraders via
-      `update-engine`.
+      would re-open the F8 silent-drop). _(verified intact at `indexer.ts:44-49`, untouched · 2026-07-17)_
+- [x] Run mutation testing on `chunker` (Stryker) to confirm the new guard is covered.
+      _(87.37% — 83 killed / 12 documented equivalent survivors; the new `isSubstantialBody` guard
+      contributes **zero** survivors, boundary + char-class mutants all killed · 2026-07-17)_
+- [x] Ensure `chunker.ts` is engine-owned in `engine-manifest.json` so the fix reaches upgraders via
+      `update-engine`. _(`rag/src/**` already in the manifest `replace` bucket · verified 2026-07-17)_
 - [ ] Re-run the read-only measurement after the change to confirm the pruned count matches (~105).
+      _(needs the source vault path — Thomas's pre-existing brain, not in this repo; run from there.)_
 
 Representative files: `rag/src/lib/chunker.ts`, `rag/src/lib/chunker.test.ts`,
 `rag/src/lib/indexer.ts`, `engine-manifest.json`.

--- a/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
+++ b/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
@@ -1,9 +1,11 @@
 # Migrate a pre-existing second brain into a generated brain — capability gap analysis & strategy
 
-> **Branch:** to be created off `main` for the launcher-bound work (Tracks A/B/C generic).
-> Track A (chunker) may also continue in the `test/rag-mutation-hardening` context since it pairs
-> with mutation testing on `chunker`.
-> **Status:** planned, not started (2026-07-11).
+> **Branch:** `feat/chunker-degenerate-body-pruning` carries Track A (code-complete). The remaining
+> launcher-bound work (Tracks B/C generic) will branch off `main`.
+> **Status:** in progress upstream (refreshed 2026-07-17). **Track A is code-complete and
+> mutation-proven on `feat/chunker-degenerate-body-pruning`** (commits `dd13be0`, `746eaf0`) — one
+> read-only re-measurement remains, to run from the source vault. Engine still `1.1.5`; the branch
+> is not merged to `main` yet. Tracks B/C/D/F not started.
 > This is the **canonical** plan (repo = single source of truth). The plan-mode scratch file
 > `~/.claude/plans/shimmering-snacking-tome.md` is superseded.
 
@@ -29,15 +31,40 @@ overwrites). It does **not** migrate skills, hooks, `.mcp.json`, or `CLAUDE.md` 
 > Slack channels, account emails, product teams, or private KPIs may enter this repo. Every
 > launcher-bound artifact is de-identified first.
 
+## Strategy: migrate early, explore later
+
+The single most important sequencing decision: **migrate the personal brain as soon as the generic
+delta is upstreamed — do not gate migration on open-ended product exploration.**
+
+Rationale: while the source brain stays a hand-built harness decoupled from this launcher, every
+product improvement made here has to be *re-ported by hand* to the personal brain. Once migrated, the
+personal brain is a **clean launcher instance**, so any engine improvement shipped afterwards flows
+back to it automatically via `update-engine`. Closing that loop early is the whole point — later
+exploration then benefits the personal brain for free instead of doubling the work. Migrating early
+does **not** lock anything in: `update-engine` is designed to propagate engine changes after the fact.
+The only class of change worth deciding *before* generating is one that alters **vault structure / note
+conventions** — a content-layer concern, adjustable post-hoc, not a blocker.
+
+This splits the work into **three bodies**, in order:
+
+1. **Catch the launcher up** (Tracks A / B-generic / C-generic) — prerequisite, else the freshly
+   generated brain regresses below the source brain. **Track A is already all-but-done here.**
+2. **Migrate** (Track D) — generate → `/import` → layer private capabilities.
+3. **Product exploration** (Track F) — net-new ideas (regular content ingestion, new capture flows,
+   inspiration from other second brains). **After** migration, flowing back via `update-engine`.
+
 ## Tracking
 
 - [ ] **Track A — Engine: embedder/chunker degenerate-chunk pruning** (upstream to launcher)
       — code shipped on `feat/chunker-degenerate-body-pruning` (dd13be0, 2026-07-17), mutation-proven;
-      only the source-vault re-measurement (~105) remains, to run from Thomas's pre-existing brain.
+      re-measurement confirmed (105 exact, 2026-07-17). **Only the merge to `main` remains.**
 - [ ] **Track B — Skills: classify & route** (generic → launcher, private → personal brain)
 - [ ] **Track C — Constitution merge** (distill generic disciplines to template; keep newer template wins)
 - [ ] **Track D — Corpus migration** (generate brain → `/import` 405 notes → layer private capabilities)
-- [ ] **Track E — Canonical plan** relocated to `maintainers/plans/prospective/` — ✅ done (this file, 2026-07-11)
+- [x] **Track E — Canonical plan** relocated to `maintainers/plans/prospective/` — done (this file, 2026-07-11)
+- [ ] **Track F — Product exploration** (regular content ingestion + ideas from other second brains) — *post-migration; may be prepared in parallel*
+
+Recommended order: **A → generic B/C → ship launcher → D (generate → import → layer private) → F**.
 
 ---
 
@@ -72,8 +99,17 @@ falls back to the filename, `frontmatter-parser.ts:48-60`); the `isSubstantialBo
       contributes **zero** survivors, boundary + char-class mutants all killed · 2026-07-17)_
 - [x] Ensure `chunker.ts` is engine-owned in `engine-manifest.json` so the fix reaches upgraders via
       `update-engine`. _(`rag/src/**` already in the manifest `replace` bucket · verified 2026-07-17)_
-- [ ] Re-run the read-only measurement after the change to confirm the pruned count matches (~105).
-      _(needs the source vault path — Thomas's pre-existing brain, not in this repo; run from there.)_
+- [x] Re-run the read-only measurement after the change to confirm the pruned count matches (~105).
+      _(confirmed 2026-07-17: **exactly 105** prunable chunks across 405 docs — 63 docs affected,
+      2.59% of body chunks — all degenerate scaffolds (`---`, empty comments, bare bullets), **zero
+      false positives**; title chunks untouched → F8 preserved. Read-only, no writes to the vault.)_
+- [ ] Merge `feat/chunker-degenerate-body-pruning` to `main` once the measurement confirms.
+
+> **Note on the source brain's companion hardenings (NOT in this branch).** The source brain shipped
+> the chunk filter together with three more tweaks on 2026-07-07: Gemini-boilerplate stripping,
+> top-k per-doc dedup in search, and transient-network retry in the embedder. These are **generic**
+> and worth a follow-up upstream pass if the launcher targets transcript-fed vaults — but they are
+> out of scope for this branch, which is chunker-only. Track separately if desired.
 
 Representative files: `rag/src/lib/chunker.ts`, `rag/src/lib/chunker.test.ts`,
 `rag/src/lib/indexer.ts`, `engine-manifest.json`.
@@ -138,12 +174,31 @@ names/IDs, org/account emails, product-team names, and any private-project refer
 
 ---
 
+## Track F — Product exploration (post-migration)
+
+**WHY here:** open-ended R&D on the launcher itself — how a second brain captures and ingests
+content over time. Explicitly sequenced **after** migration so it never delays it, and so every
+result flows back to the (now clean) personal brain via `update-engine`. Can be *prepared* in
+parallel (a research pass on how popular second-brain tools handle continuous capture) without
+blocking A→D.
+
+- [ ] Research pass — survey patterns from other second brains / PKM tools (regular content
+      ingestion, capture inbox flows, review/resurfacing loops, marketing-visible ideas). Deliver a
+      triaged idea list, not a build order.
+- [ ] Triage the ideas against the launcher's design; decide which are engine-owned (propagate via
+      `update-engine`) vs. content-convention (adjust in each brain).
+- [ ] For any note-convention change, note it may be cleaner to fold into the generate step for
+      *future* brains — but never a blocker for the already-migrated personal brain.
+
+---
+
 ## Sequencing & rationale
 
 Recommended order: **A (engine)** → distill generic **C** + generic **B** into the launcher →
-cut/ship the launcher → **generate** the brain → **D** import → layer private B/C on top.
-Upstream-first means the freshly generated brain already carries the wins; the private, non-shareable
-layer is applied last, directly in the personal brain.
+cut/ship the launcher → **generate** the brain → **D** import → layer private B/C on top → **F**
+exploration. Upstream-first means the freshly generated brain already carries the wins; the private,
+non-shareable layer is applied last, directly in the personal brain; exploration comes last and
+benefits the personal brain automatically because the loop is now closed.
 
 ## Verification
 

--- a/rag/src/lib/chunker.test.ts
+++ b/rag/src/lib/chunker.test.ts
@@ -16,7 +16,10 @@ test("title-only doc (empty body) still yields at least one chunk carrying the t
 });
 
 test("a doc with a body still gets its title seeded as a search signal", () => {
-  const chunks = chunkMarkdown("## History\n\nSome island history.", "Naxos");
+  const chunks = chunkMarkdown(
+    "## History\n\nThis is a substantial passage recounting the island history in detail.",
+    "Naxos"
+  );
 
   assert.ok(
     chunks.some((c) => c.section === "(title)" && c.content === "Naxos"),
@@ -29,32 +32,37 @@ test("a doc with a body still gets its title seeded as a search signal", () => {
 });
 
 test("no title given → behaves as before (body-only chunks)", () => {
-  const chunks = chunkMarkdown("## History\n\nSome island history.");
+  const chunks = chunkMarkdown(
+    "## History\n\nThis is a substantial passage recounting the island history in detail."
+  );
 
   assert.ok(chunks.every((c) => c.section !== "(title)"));
   assert.ok(chunks.some((c) => c.content.includes("island history")));
 });
 
 test("each heading becomes its own section chunk, in order, as `heading\\n\\nbody`", () => {
-  const md = "# Alpha\n\nFirst body.\n\n## Beta\n\nSecond body.";
+  const md =
+    "# Alpha\n\nThe first section body has plenty of real words here.\n\n## Beta\n\nThe second section body has plenty of real words too.";
 
   const chunks = chunkMarkdown(md);
 
   // The heading text drives the section name (regex capture + trim), the body lines
   // are joined under it, and the chunk content is exactly `heading\n\nbody`.
   assert.deepEqual(chunks, [
-    { section: "Alpha", content: "Alpha\n\nFirst body.", index: 0 },
-    { section: "Beta", content: "Beta\n\nSecond body.", index: 1 },
+    { section: "Alpha", content: "Alpha\n\nThe first section body has plenty of real words here.", index: 0 },
+    { section: "Beta", content: "Beta\n\nThe second section body has plenty of real words too.", index: 1 },
   ]);
 });
 
 test("body before any heading lands under `(intro)`, and empty-body sections are dropped", () => {
   // Text precedes the first heading → it must be captured under the synthetic
   // `(intro)` heading; the trailing heading with no body must NOT yield a chunk.
-  const chunks = chunkMarkdown("Intro text.\n\n# Empty Section");
+  const chunks = chunkMarkdown(
+    "Introductory text with clearly enough meaningful words here.\n\n# Empty Section"
+  );
 
   assert.deepEqual(chunks, [
-    { section: "(intro)", content: "(intro)\n\nIntro text.", index: 0 },
+    { section: "(intro)", content: "(intro)\n\nIntroductory text with clearly enough meaningful words here.", index: 0 },
   ]);
 });
 
@@ -84,18 +92,22 @@ test("a multi-line body keeps its line-breaks when flushed by the next heading; 
   // `# Head` has a two-line body flushed when `## Next` arrives (joins body on \n, not "");
   // the trailing heading whitespace is trimmed; `Refer to ## later` starts with text, so its
   // mid-line `##` must NOT be promoted to a heading (the `^` anchor).
-  const md = "# Head  \n\nFirst line\nSecond line\n\n## Next\n\nRefer to ## later";
+  const md =
+    "# Head  \n\nFirst meaningful line of text\nSecond meaningful line of text\n\n## Next\n\nRefer to ## later in this sufficiently long line";
 
   const chunks = chunkMarkdown(md);
 
   assert.deepEqual(chunks, [
-    { section: "Head", content: "Head\n\nFirst line\nSecond line", index: 0 },
-    { section: "Next", content: "Next\n\nRefer to ## later", index: 1 },
+    { section: "Head", content: "Head\n\nFirst meaningful line of text\nSecond meaningful line of text", index: 0 },
+    { section: "Next", content: "Next\n\nRefer to ## later in this sufficiently long line", index: 1 },
   ]);
 });
 
 test("the title is trimmed and seeded first, then body chunks follow in increasing index order", () => {
-  const chunks = chunkMarkdown("## History\n\nSome history.", "  Naxos  ");
+  const chunks = chunkMarkdown(
+    "## History\n\nSome substantial history worth several meaningful words.",
+    "  Naxos  "
+  );
 
   assert.deepEqual(chunks[0], { section: "(title)", content: "Naxos", index: 0 });
   assert.equal(chunks[1].index, 1, "the body chunk follows the title (index increments, not decrements)");
@@ -104,9 +116,11 @@ test("the title is trimmed and seeded first, then body chunks follow in increasi
 test("a heading-only section (empty body) between two headings yields no chunk", () => {
   // `# A` has no body before `# B` → it must be skipped entirely, not emitted as
   // an empty `A\n\n` chunk.
-  const chunks = chunkMarkdown("# A\n\n# B\n\nbody");
+  const chunks = chunkMarkdown("# A\n\n# B\n\nThe B section carries a real body with enough words here.");
 
-  assert.deepEqual(chunks, [{ section: "B", content: "B\n\nbody", index: 0 }]);
+  assert.deepEqual(chunks, [
+    { section: "B", content: "B\n\nThe B section carries a real body with enough words here.", index: 0 },
+  ]);
 });
 
 test("when splitting a long section, blank-line runs collapse and each piece is whitespace-trimmed", () => {
@@ -136,14 +150,123 @@ test("packing fills a piece up to exactly CHUNK_MAX_CHARS before splitting (no o
   assert.equal(chunks.length, 2, "the heading+p1 piece packs up to the limit; only p2 spills over");
 });
 
-// ── Equivalent mutants (mutation audit, Step 3-rag) ──────────────────────────
-// Stryker reaches ~85.9% here; the 12 remaining survivors are EQUIVALENT mutants —
-// they cannot change observable behaviour, so no test can kill them. Effective score
-// on non-equivalent mutants is 73/73 = 100%. Grouped by reason:
-//   • `currentBody.length > 0` → `>= 0` / `true` (lines 35, 44): the only currentBody
-//     of length 0 is an empty section, which is filtered downstream by the
-//     `if (!bodyTrimmed) continue` guard — so pushing it changes nothing.
-//   • `fullText.length <= MAX` → `<` / `false` (line 66): on content that fits, the
+// ── Degenerate-body pruning (Track A) ────────────────────────────────────────
+// Empty template scaffolds (`---` rules, placeholder comments, bare list stubs)
+// carry no searchable content but pollute the index. They are pruned — while the
+// title chunk and the F8 title-only invariant above stay untouched.
+
+test("a section whose body carries no meaningful text (a `---` rule) is pruned", () => {
+  // A divider-only section has zero letters/digits → it is index noise, not content.
+  const chunks = chunkMarkdown(
+    "# Real\n\nThis is a clearly substantial paragraph with plenty of real words.\n\n# Divider\n\n---"
+  );
+
+  assert.deepEqual(chunks, [
+    {
+      section: "Real",
+      content: "Real\n\nThis is a clearly substantial paragraph with plenty of real words.",
+      index: 0,
+    },
+  ]);
+});
+
+test("a stub body with only a handful of meaningful chars (a placeholder comment) is pruned", () => {
+  // `<!-- TODO -->` has just 4 letters — far below the meaningful floor → still index noise,
+  // even though it is not literally empty of letters. Forces a count-and-threshold, not a
+  // "has at least one letter" test.
+  const chunks = chunkMarkdown(
+    "# Real\n\nThis is a clearly substantial paragraph with plenty of real words.\n\n# Stub\n\n<!-- TODO -->"
+  );
+
+  assert.deepEqual(chunks, [
+    {
+      section: "Real",
+      content: "Real\n\nThis is a clearly substantial paragraph with plenty of real words.",
+      index: 0,
+    },
+  ]);
+});
+
+test("the meaningful-char floor is inclusive: exactly 25 is kept, 24 is pruned", () => {
+  // Locks the `>=` boundary (kills `> 25`): a body with exactly MIN_BODY_MEANINGFUL_CHARS
+  // meaningful chars survives; one fewer is pruned to nothing (no title here).
+  const body25 = "abcdefghijklmnopqrstuvwxy"; // 25 letters
+  const body24 = "abcdefghijklmnopqrstuvwx"; // 24 letters
+
+  assert.deepEqual(chunkMarkdown(`# S\n\n${body25}`), [
+    { section: "S", content: `S\n\n${body25}`, index: 0 },
+  ]);
+  assert.deepEqual(chunkMarkdown(`# S\n\n${body24}`), []);
+});
+
+test("only letters/digits count toward the floor — punctuation and whitespace don't lift a stub over it", () => {
+  // 24 letters padded with punctuation/spaces still scores 24 meaningful → pruned.
+  // Kills a mutant that would count all characters instead of just \p{L}\p{N}.
+  const chunks = chunkMarkdown("# S\n\nabcdefghijklmnopqrstuvwx  ...  ???  ---  !!!");
+
+  assert.deepEqual(chunks, []);
+});
+
+test("a URL-only section is KEPT — a saved link carries enough alphanumerics to be real content", () => {
+  // Decision (Track A): a bookmark-style section holding just a link is real, searchable
+  // content, not scaffold noise → kept (the URL's letters/digits clear the floor).
+  const chunks = chunkMarkdown("# Link\n\nhttps://example.com/some/long/article-path-here");
+
+  assert.deepEqual(chunks, [
+    { section: "Link", content: "Link\n\nhttps://example.com/some/long/article-path-here", index: 0 },
+  ]);
+});
+
+test("a code-snippet-only section is KEPT — code carries searchable identifiers/keywords", () => {
+  // Decision (Track A): a fenced code block is real content whose identifiers clear the
+  // floor → kept, not scaffold noise.
+  const chunks = chunkMarkdown(
+    "# Snippet\n\n```ts\nconst total = items.reduce((a, b) => a + b, 0);\n```"
+  );
+
+  assert.deepEqual(chunks, [
+    {
+      section: "Snippet",
+      content: "Snippet\n\n```ts\nconst total = items.reduce((a, b) => a + b, 0);\n```",
+      index: 0,
+    },
+  ]);
+});
+
+test("an image-only section with no descriptive alt text is pruned — nothing textual to search", () => {
+  // Decision (Track A): a bare image embed with an empty/near-empty alt has no searchable
+  // text → pruned. (A descriptive alt would clear the floor and keep it — covered by the
+  // substantial-body cases.)
+  const chunks = chunkMarkdown("# Pic\n\n![](assets/x.png)");
+
+  assert.deepEqual(chunks, []);
+});
+
+test("a bare list-marker stub (`- `) is pruned — zero meaningful chars", () => {
+  const chunks = chunkMarkdown("# Todo\n\n- ");
+
+  assert.deepEqual(chunks, []);
+});
+
+test("a titled page whose only section body is degenerate still yields the title chunk (F8)", () => {
+  // The body (`---`) is pruned as noise, yet the unconditional title chunk survives →
+  // an effectively title-only page stays embedded and findable by title. The pruning
+  // filter must NEVER reach the title chunk.
+  const chunks = chunkMarkdown("# Heading\n\n---", "Naxos");
+
+  assert.deepEqual(chunks, [{ section: "(title)", content: "Naxos", index: 0 }]);
+});
+
+// ── Equivalent mutants (mutation audit, Step 3-rag + Track A) ─────────────────
+// Stryker reaches 87.37% here (83 killed / 12 survived); the 12 survivors are all
+// EQUIVALENT mutants — they cannot change observable behaviour, so no test can kill
+// them. Effective score on non-equivalent mutants is 83/83 = 100%. The Track A
+// `isSubstantialBody` guard added mutants that are ALL killed (boundary + char-class
+// tests) — it contributes zero survivors. Grouped by reason:
+//   • `currentBody.length > 0` → `>= 0` / `true` (lines 48, 57): the only currentBody
+//     of length 0 is an empty section, whose body has 0 meaningful chars and so is
+//     filtered downstream by the `isSubstantialBody` guard — pushing it changes nothing.
+//   • `fullText.length <= MAX` → `<` / `false` (line 79): on content that fits, the
 //     split path is the identity (splitAtParagraphs returns the whole as one piece),
 //     so "always split" and the exact `<` boundary produce the same single chunk.
 //   • `current.length > 0` → `>= 0` / `true` (line 15) and `if (current.trim())` →

--- a/rag/src/lib/chunker.ts
+++ b/rag/src/lib/chunker.ts
@@ -23,6 +23,19 @@ function splitAtParagraphs(text: string, maxChars: number): string[] {
   return pieces;
 }
 
+// A section body is "substantial" — worth embedding — when it carries enough
+// meaningful text: at least MIN_BODY_MEANINGFUL_CHARS letters/digits. Empty
+// template scaffolds (`---`, placeholder comments, bare list stubs) fall short and
+// are pruned as index noise. Only letters/digits count, so punctuation-only or
+// markup-only bodies score zero. The `(title)` chunk is never subjected to this
+// filter, so the F8 title-only invariant is preserved.
+const MIN_BODY_MEANINGFUL_CHARS = 25;
+
+function isSubstantialBody(body: string): boolean {
+  const meaningful = body.match(/[\p{L}\p{N}]/gu);
+  return (meaningful?.length ?? 0) >= MIN_BODY_MEANINGFUL_CHARS;
+}
+
 export function chunkMarkdown(content: string, title?: string): Chunk[] {
   const lines = content.split("\n");
   const sections: { heading: string; body: string }[] = [];
@@ -59,7 +72,7 @@ export function chunkMarkdown(content: string, title?: string): Chunk[] {
 
   for (const section of sections) {
     const bodyTrimmed = section.body.trim();
-    if (!bodyTrimmed) continue;
+    if (!isSubstantialBody(bodyTrimmed)) continue;
 
     const fullText = `${section.heading}\n\n${bodyTrimmed}`;
 


### PR DESCRIPTION
## What & why

Empty template scaffolds — `---` rules, placeholder comments (`<!-- … -->`), bare
list stubs (`- `) — were embedded as full chunks, polluting the vector index with
non-searchable noise. This adds a small, deterministic filter so those bodies are
dropped before embedding, improving search quality (and shaving a little one-time
embedding quota).

This is **Track A** of the second-brain migration & engine-upstream plan
(`maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md`):
de-identify and port the source brain's chunk-pruning fix into this launcher's engine
so every future brain — and every upgrader via `update-engine` — gets it.

## How

- `isSubstantialBody(body)` keeps a section body only when it carries at least
  `MIN_BODY_MEANINGFUL_CHARS` (25) letters/digits (`\p{L}\p{N}`). Punctuation, markup
  and whitespace score zero, so a `---` or an empty bullet is pruned.
- The filter applies **only inside the section loop** — never to the unconditional
  `(title)` chunk. So the **F8 invariant holds by construction**: a title-only or
  degenerate-body page still yields its title chunk and stays searchable. Verified in
  the real pipeline (`index-manager.ts` always passes a non-empty title; `extractTitle`
  falls back to the filename).
- `indexer.ts` keeps its **loud 0-chunk backstop** (never a silent drop).

## Design decisions locked by test

- **KEPT** (real content clears the floor): URL-only sections, code-snippet sections.
- **PRUNED** (below the floor): image-only-without-alt, bare stubs, dividers, empty
  comments.
- Boundary triangulated: `>= 25` is inclusive (25 kept / 24 pruned); char class checked
  (punctuation/whitespace don't lift a stub over the floor).

## Quality

- TDD baby-steps, fail-first. `rag/` suite: **375/375 green** (20 chunker tests).
- **Stryker on `chunker.ts`: 87.37%** (83 killed / 12 documented equivalent survivors);
  the new guard contributes **zero** survivors — all its boundary and char-class
  mutants are killed.
- **Empirical measurement (read-only, source vault, 405 docs):** exactly **105**
  prunable chunks (2.59% of body chunks, 63 docs), all degenerate scaffolds, **zero
  false positives** — matching the plan's estimate.

## Scope

Chunker-only. The source brain shipped three companion hardenings alongside this on the
same day (Gemini-boilerplate stripping, top-k per-doc search dedup, transient-network
retry in the embedder). They are generic and worth a follow-up upstream pass, but are
**out of scope** for this branch (the embedder retry already exists here as
`embedWithRetry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)