### PR TITLE
feat(skills): upstream two generic skills to the engine (open-note, mcp-token-expired)

### DIFF
--- a/engine-skills/mcp-token-expired/SKILL.md
+++ b/engine-skills/mcp-token-expired/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: mcp-token-expired
+description: "What to do when a native claude.ai MCP connector (Slack, Calendar, Notion, Google Drive, Gmail — mcp__claude_ai_* or an equivalent connector) returns an authentication error (invalid_auth_token, not_authed, token_expired, auth_failed…): visual alert, guided reconnection, fallback without blocking. Load it AS SOON AS such an error appears."
+version: 1.0.0
+---
+
+# Expired MCP token — visual alert + reconnection
+
+As soon as a tool of a native claude.ai connector (Slack, Gmail, Calendar, Notion, Google Drive)
+returns an **authentication error** (`invalid_auth_token`, `not_authed`, `token_expired`,
+`auth_failed`…), run the procedure below.
+
+## ⚠️ Exception: a connector that is unavailable by design
+
+Some connectors may be **unavailable by design** — not because of an expired token, but because an
+**org policy or a provider restriction** blocks them for this account. This is **not a token to
+refresh**: do NOT show the alert below and do NOT run the reconnection. Treat the connector as an
+**unavailable source by default**: use the fallback, briefly note "<connector> unavailable
+(org/provider restriction)", and continue without blocking.
+
+## Procedure (real authentication error)
+
+1. **Immediately show this alert block** (as-is, emojis included):
+
+   ```
+   🚨🚨🚨 MCP TOKEN EXPIRED 🚨🚨🚨
+   ⚠️  Connector: <name> (mcp__claude_ai_<...>)
+   ⚠️  Error: <error code>
+   🔌 Impact: <what becomes unavailable> → fallback used.
+
+   👉 TO RECONNECT: type  /mcp  → select <connector> → Re-authenticate
+      (browser OAuth flow, ~20 s, and everything works again)
+
+   🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
+   ```
+
+2. **Push `/mcp` in the terminal as the first attempt.** If the token is simply expired and
+   `/mcp` offers a re-authentication, this is the fastest path.
+
+3. **If `/mcp` shows `connected` but the call still fails with `invalid_auth_token`**
+   → the downstream token is stale **despite** the "connected" status; a `/mcp` will not
+   regenerate it (it believes it is already connected). **Real fix: `Disconnect` then `Reconnect`
+   the connector on claude.ai** (`open "https://claude.ai/settings/connectors"`). On reconnect,
+   **explicitly authorize the right account / workspace** (the SSO or identity this connector
+   expects) — otherwise the connector stays "connected" but on an invalid token.
+
+4. **Continue with the fallback** without blocking (e.g. an alternative MCP connector, or a
+   channel/timestamp search for Slack — see the Sourcing rule in CLAUDE.md). Do not stop and
+   wait for the reconnection.
+
+## Pitfalls ruled out in practice
+
+- A `connected` state in `/mcp` or on the connectors page **does not imply** a valid downstream token.
+- Rule out an **account mismatch** (CLI and browser on the same identity) before concluding the
+  token is expired.
+- Claude **cannot** trigger the OAuth handshake itself (interactive command, URL not exposed,
+  security restriction by design) — pushing the user toward `/mcp` then Disconnect/Reconnect is
+  the most it can do.

--- a/engine-skills/open-note/SKILL.md
+++ b/engine-skills/open-note/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: open-note
+description: "Open a vault note from an 'open X for me' intent. First looks for a relevant markdown in the vault (semantic + exact match) and opens it as-is in Obsidian if it exists; otherwise synthesizes the topic from the vault, writes a note that follows the conventions, and opens it. Triggered when the user says 'open X for me', 'open the note about X', 'ouvre-moi X'."
+version: 1.0.0
+---
+
+# open-note — "open X for me"
+
+> Default behavior of the natural command **"open <topic> for me"**.
+> Goal: the user always has something to read in Obsidian — either the existing note,
+> or a fresh synthesis created on the fly and persisted into the vault.
+
+## Principle
+
+One promise only: **"open X for me" never falls into the void.**
+- If a vault doc is about X → open it **as-is** (do not modify it).
+- If nothing covers X → **synthesize** from the vault, write a note that follows the
+  conventions, and open it.
+
+The judgment (which doc, whether to create one, where to file it) stays in the skill; the only
+deterministic part is the opening (`open -a "Obsidian" <path>`).
+
+## Procedure
+
+### 1. Understand the target
+Extract the topic from the request. Three cases:
+- **Known file** (exact path, precise date, obvious note name: `daily/2026-06-12`,
+  "the prep for <first-name>", "the backlog for <initiative>") → go straight to step 3
+  (direct open, **no RAG**).
+- **Semantic topic** ("what we know about front-end governance", "the <theme> topic") →
+  step 2 (search).
+- **Ambiguous** → treat as semantic, and resolve the ambiguity by surfacing the candidates.
+
+### 2. Search the vault
+- `mcp__vault-rag__search_vault` first (semantic, ~300ms, free).
+- `grep`/`find` as a complement for exact matches (name, identifier, date).
+- Judge the **relevance** of the best match: does this doc really cover X, or just
+  mention it in passing?
+
+### 3. If a relevant doc exists → open it as-is
+```bash
+open -a "Obsidian" <absolute-path-to-md>
+```
+- **Do not modify it** (respect append-only for dailies, living notes for people/topics —
+  never overwrite a living doc on a mere "open X for me").
+- State **which** file is being opened and its **freshness** (`updated` date).
+- If several docs are equally relevant: open the best one, **cite the other candidates**
+  in one line (do not block on a choice).
+
+### 4. If nothing relevant → synthesize, write, open
+1. **Synthesize from the vault alone** (RAG + grep). No live source sync by default —
+   "open X for me" is a quick consultation. (If the vault is clearly empty on the topic,
+   **say so** rather than inventing; offer the user a source sync if they want one.)
+2. **Choose folder + name** per the vault conventions (see CLAUDE.md §2 "Note format"):
+   | Nature of the topic | Destination |
+   |---|---|
+   | Cross-cutting topic / concept | `vault/topics/<topic-kebab>.md` (default) |
+   | Person | `vault/people/<first-last>.md` |
+   | Decision | `vault/decisions/YYYY-MM-DD-short-title.md` |
+   | Initiative | `vault/initiatives/<name>.md` |
+
+   **Never create a `daily/` note through this flow** (append-only, handled elsewhere).
+3. **Check for collision**: if the target name already exists → a doc existed after all;
+   go back to step 3 and open it instead of overwriting.
+4. **Write** the markdown with compliant frontmatter (`type`, `created`, `updated`, `tags`) and
+   `[[…]]` backlinks to related notes. Tone: the user's own (factual, concise).
+5. **Open** it in Obsidian.
+6. **Qualify the reliability**: make clear the note was just **created by AI synthesis** from
+   the vault (≠ verbatim), so the user rereads it with a critical eye.
+
+## Guardrails
+- **Never overwrite** an existing doc on an "open X for me".
+- **Always via Obsidian** (`open -a "Obsidian" <path>`). If the file does not open (vault not
+  registered in the app), ask the user for the vault name and use
+  `obsidian://open?vault=<name>&file=<relative-path>`.
+- **Timestamp**: run `date` in bash before writing a dated note (correct created/updated).
+- Persistence (commit/push) is handled by the hook — **do not run git** yourself.
+
+## Out of scope
+- Modifying / enriching an existing doc (that is a different, explicit gesture — not the
+  default of "open X for me").
+- Fetching live sources (Slack/Drive): only if the user explicitly asks.

--- a/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
+++ b/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
@@ -1,11 +1,9 @@
 # Migrate a pre-existing second brain into a generated brain — capability gap analysis & strategy
 
-> **Branch:** `feat/chunker-degenerate-body-pruning` carries Track A (code-complete). The remaining
-> launcher-bound work (Tracks B/C generic) will branch off `main`.
-> **Status:** in progress upstream (refreshed 2026-07-17). **Track A is code-complete and
-> mutation-proven on `feat/chunker-degenerate-body-pruning`** (commits `dd13be0`, `746eaf0`) — one
-> read-only re-measurement remains, to run from the source vault. Engine still `1.1.5`; the branch
-> is not merged to `main` yet. Tracks B/C/D/F not started.
+> **Status:** in progress upstream (refreshed 2026-07-17). **Track A DONE** (merged to `main` via
+> PR #29, squash `9448230`, cross-platform CI green). **Track B DONE** for the launcher-bound part
+> (2 generic skills upstreamed on branch `feat/skills-open-note-mcp-token-expired`, commit `235bae2`
+> — not merged yet). **Next: Track C** (constitution merge). Tracks D/F not started.
 > This is the **canonical** plan (repo = single source of truth). The plan-mode scratch file
 > `~/.claude/plans/shimmering-snacking-tome.md` is superseded.
 
@@ -58,7 +56,11 @@ This splits the work into **three bodies**, in order:
 - [x] **Track A — Engine: embedder/chunker degenerate-chunk pruning** (upstream to launcher)
       — DONE: merged to `main` via PR #29 (squash `9448230`, 2026-07-17), cross-platform CI green;
       mutation-proven; re-measurement confirmed (105 exact).
-- [ ] **Track B — Skills: classify & route** (generic → launcher, private → personal brain)
+- [x] **Track B — Skills: classify & route** (generic → launcher, private → personal brain)
+      — DONE for the launcher-bound part: 2 generic skills upstreamed as English
+      `engine-skills/` sources (`open-note`, `mcp-token-expired`), delivery proven to fresh
+      installs + upgraders. Private skills classified (stay in personal brain, layered in Track D).
+      _(2026-07-17 · 235bae2)_
 - [ ] **Track C — Constitution merge** (distill generic disciplines to template; keep newer template wins)
 - [ ] **Track D — Corpus migration** (generate brain → `/import` 405 notes → layer private capabilities)
 - [x] **Track E — Canonical plan** relocated to `maintainers/plans/prospective/` — done (this file, 2026-07-11)
@@ -121,19 +123,23 @@ Representative files: `rag/src/lib/chunker.ts`, `rag/src/lib/chunker.test.ts`,
 
 **Generic → launcher (de-identified):**
 
-- [ ] `open-note` — open/synthesize a vault note from natural-language intent. Genericize any
-      hard-coded vault-path / Obsidian-namespace assumptions.
-- [ ] `mcp-token-expired` — connector reconnection guidance on auth errors. Strip the
-      contractor/Gmail-specific caveat (make it a generic "connector unavailable" note).
-- [ ] (Optional) extract the *pattern* of the source brain's structured-report skill as a generic
-      "structured report" skill — with **no** names / executive-committee content.
+- [x] `open-note` — open/synthesize a vault note from natural-language intent. Genericized to a
+      neutral user + placeholder examples; ships English at `engine-skills/open-note/`.
+      _(2026-07-17 · 235bae2)_
+- [x] `mcp-token-expired` — connector reconnection guidance on auth errors. Contractor/Gmail-specific
+      caveat generalized to a neutral "connector unavailable by design" note; ships English at
+      `engine-skills/mcp-token-expired/`. _(2026-07-17 · 235bae2)_
+- [x] ~~(Optional) extract the *pattern* of the source brain's structured-report skill~~ — **dropped
+      on decision**: the report was for a past context, will not be regenerated → not ported (not even
+      the pattern). _(2026-07-17)_
 
-**Private → personal brain ONLY (never this repo):**
+**Private → personal brain ONLY (never this repo):** — classified; actioned in Track D (layering).
 
-- [ ] `refresh-*` (security / quality / deploy KPI refreshers), `setup-kpi`, and the concrete
-      report skill (nominative content) stay in the personal brain.
+- [ ] `refresh-*` (security / quality / deploy KPI refreshers — `refresh-aikido`, `refresh-deploys`,
+      `refresh-sonar`), `setup-kpi`, and the concrete report skill (`rapport-etonnement`, nominative
+      content) stay in the personal brain. _(classified 2026-07-17; layered in Track D)_
 - [ ] The employer Slack connector and KPI data files (`scripts/data/*.json`) stay private
-      (personal brain's `.mcp.json` / `scripts/`).
+      (personal brain's `.mcp.json` / `scripts/`). _(classified 2026-07-17; layered in Track D)_
 
 **Already gained for free at install (nothing to do):** `coach`, `improve`, `local-mirror`,
 `prepare-1-1`, `tdd-discipline`, `update-engine`, `import`.


### PR DESCRIPTION
## What

Track B of the second-brain migration plan: upstream two **de-identified, generic** skills from a pre-existing hand-built brain into the launcher engine, so **every future brain AND every upgrader** gets them.

- **`open-note`** — "open X for me": find a relevant vault note (semantic + exact) and open it as-is in Obsidian; else synthesize from the vault, write a compliant note, and open it. Never falls into the void.
- **`mcp-token-expired`** — guided reconnection when a native claude.ai connector returns an auth error (alert block → `/mcp` → Disconnect/Reconnect → fallback). The former contractor/Gmail-specific caveat is generalized to a neutral "connector unavailable by design" note.

## How

Both ship as **English canonical sources** under `engine-skills/<name>/` (ADR 0026): the sacred scrub forbids the engine from writing under `.claude/skills/`, so the staging path is delivered **install-if-absent** to fresh brains (installer step 2ter) and to upgraders (`reconcile-brain.mjs`), and is already covered by the manifest `replace` bucket (`engine-skills/**`). No manifest edit needed; no test hardcodes the staged set.

## Privacy

De-identification is the non-negotiable guardrail: all references to the former employer, colleagues, org SSO, account emails and private connectors were scrubbed. Leak scan is clean.

## Verification

- 24 tests green (`staged-skills`, `installer-staged-skills`, `reconcile-brain`).
- End-to-end proof against the real `engine-skills/` dir: `installStagedSkills` delivers both new skills into a temp brain (same code path as fresh install + upgrader converge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)