### PR TITLE
feat(axis-1): give the LLM-Wiki compile discipline real mechanics (The One Where the Brain Compiles Itself)

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -97,6 +97,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "{{NODE}} \"{{PROJECT_ROOT}}/scripts/session-wiki-health.mjs\"",
+            "timeout": 20000
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "command": "{{NODE}} \"{{PROJECT_ROOT}}/scripts/session-status.mjs\"",
             "timeout": 20000
           }

--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -107,6 +107,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "{{NODE}} \"{{PROJECT_ROOT}}/scripts/session-actions-log.mjs\"",
+            "timeout": 20000
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "command": "{{NODE}} \"{{PROJECT_ROOT}}/scripts/session-status.mjs\"",
             "timeout": 20000
           }

--- a/.claude/skills/sync-sources/SKILL.md
+++ b/.claude/skills/sync-sources/SKILL.md
@@ -241,14 +241,16 @@ No empty section — omit it. Each signal cites its source (brackets or backlink
 
 ### Step 5 — Append to `vault/actions-log.md`
 
-**Append** (create the file if it doesn't exist) one flat line per action, prefixed with the date —
-no frontmatter, *grep-able* file:
+The ledger is a **first-class, seeded artifact**: it is created at install and re-seeded (if ever
+missing) on session start by the `session-actions-log` hook, so it normally already exists — just
+**append** one flat, *grep-able* line per action below its header (still create it if it is somehow
+absent):
 
 ```markdown
 ## [YYYY-MM-DD] <action> — #channel [[people/recipient]]
 ```
 
-**Append-only**: never rewrite the existing lines. Usage: "what did I do on
+**Append-only**: never rewrite the existing lines or the seeded header. Usage: "what did I do on
 X?" → `grep -i "X" vault/actions-log.md` then enrich via the referenced briefings.
 
 ## Re-run mode (same day)

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -4,7 +4,7 @@
     "rag": "1.1.5",
     "local-mirror": "0.2.0",
     "constitutionTemplate": "1.0.0",
-    "scripts": "1.3.0"
+    "scripts": "1.4.0"
   },
   "indexSchemaVersion": 1,
   "regimes": {
@@ -28,6 +28,7 @@
       "scripts/health-probe-run.mjs",
       "scripts/lint-vault.mjs",
       "scripts/file-back-note.mjs",
+      "scripts/consolidate-scan.mjs",
       "scripts/lib/**",
       ".claude/settings.json.template",
       ".mcp.json.template",

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -4,7 +4,7 @@
     "rag": "1.1.5",
     "local-mirror": "0.2.0",
     "constitutionTemplate": "1.0.0",
-    "scripts": "1.1.0"
+    "scripts": "1.2.0"
   },
   "indexSchemaVersion": 1,
   "regimes": {
@@ -26,6 +26,7 @@
       "scripts/session-health.mjs",
       "scripts/session-obsidian-hint.mjs",
       "scripts/health-probe-run.mjs",
+      "scripts/lint-vault.mjs",
       "scripts/lib/**",
       ".claude/settings.json.template",
       ".mcp.json.template",

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -4,7 +4,7 @@
     "rag": "1.1.5",
     "local-mirror": "0.2.0",
     "constitutionTemplate": "1.0.0",
-    "scripts": "1.5.0"
+    "scripts": "1.6.0"
   },
   "indexSchemaVersion": 1,
   "regimes": {
@@ -26,6 +26,7 @@
       "scripts/session-health.mjs",
       "scripts/session-obsidian-hint.mjs",
       "scripts/session-wiki-health.mjs",
+      "scripts/session-actions-log.mjs",
       "scripts/health-probe-run.mjs",
       "scripts/lint-vault.mjs",
       "scripts/file-back-note.mjs",

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -4,7 +4,7 @@
     "rag": "1.1.5",
     "local-mirror": "0.2.0",
     "constitutionTemplate": "1.0.0",
-    "scripts": "1.4.0"
+    "scripts": "1.5.0"
   },
   "indexSchemaVersion": 1,
   "regimes": {
@@ -25,6 +25,7 @@
       "scripts/session-status.mjs",
       "scripts/session-health.mjs",
       "scripts/session-obsidian-hint.mjs",
+      "scripts/session-wiki-health.mjs",
       "scripts/health-probe-run.mjs",
       "scripts/lint-vault.mjs",
       "scripts/file-back-note.mjs",

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -4,7 +4,7 @@
     "rag": "1.1.5",
     "local-mirror": "0.2.0",
     "constitutionTemplate": "1.0.0",
-    "scripts": "1.2.0"
+    "scripts": "1.3.0"
   },
   "indexSchemaVersion": 1,
   "regimes": {
@@ -27,6 +27,7 @@
       "scripts/session-obsidian-hint.mjs",
       "scripts/health-probe-run.mjs",
       "scripts/lint-vault.mjs",
+      "scripts/file-back-note.mjs",
       "scripts/lib/**",
       ".claude/settings.json.template",
       ".mcp.json.template",

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -4,7 +4,7 @@
     "rag": "1.1.5",
     "local-mirror": "0.2.0",
     "constitutionTemplate": "1.0.0",
-    "scripts": "1.6.0"
+    "scripts": "1.7.0"
   },
   "indexSchemaVersion": 1,
   "regimes": {

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: consolidate
 description: "Consolidate raw captures into durable entity/topic pages (Axis 1, Track C): review recent meetings / daily / transcripts and PROMOTE their substance into the higher-order wiki — create the page for a person mentioned but never filed, refresh a topic page a fresher note left behind, weave the backlinks. A deterministic scan surfaces WHAT needs consolidating; parallel read-only sub-agents draft each merge; you PROPOSE, the user confirms, and the write reuses the /file-back builder (never overwrites). Triggered by '/consolidate', 'consolidate my captures', 'promote my raw notes', 'update my entity pages', 'compile my wiki', 'consolide mes captures', 'mets à jour mes pages', 'promeus mes notes brutes'."
-version: 1.0.0
+version: 1.1.0
 ---
 
 # consolidate — promote raw captures into the durable wiki ("compile the notes")
@@ -22,6 +22,10 @@ One promise: **turn what raw captures already say into durable, well-linked page
 - **The write is deterministic and confirmed** (reuse Track B / `/file-back`): a new page goes through
   the builder (conformant by construction, refuses to overwrite); a living page gets a confirmed dated
   append. So consolidation never re-introduces the defects `/lint` reports.
+- **Contradictions are flagged, never adjudicated silently** (Track D): when a fresher capture CONFLICTS
+  with a fact the page already states (not merely adds to it), the draft surfaces it as a
+  `### contradictions` entry and the human decides which truth stands. Consolidation folds in additively;
+  it never overwrites a stated fact to resolve a conflict on its own.
 - **Bounded, resumable (stateless), honest**: a capture is a candidate purely because it is *fresher
   than the page it feeds* (or that page doesn't exist). Refresh a page and its `updated:` moves past the
   capture, so the candidate drops off on its own — no state file, nothing to seed or corrupt.
@@ -60,17 +64,22 @@ You are a wiki-consolidation drafting agent. READ-ONLY. Native tools only.
 
 TASK:
 1. Read ONLY these source captures via the Read tool: <list the candidate's source paths>.
-2. For a NEW page: distil who/what this is from what the captures actually say — a person's role, a
-   topic's definition and current state. For a REFRESH: read the existing page too and draft the dated
-   section that folds in what the fresher captures add (do NOT restate what the page already holds).
+2. For a NEW page: distil who/what this is from what the captures actually say (a person's role, a
+   topic's definition and current state). For a REFRESH: read the existing page too, then draft the dated
+   section that folds in what the fresher captures ADD (do NOT restate what the page already holds), AND
+   watch for CONTRADICTIONS: a capture that asserts something CONFLICTING with a fact the page already
+   states (a changed role, a reversed decision, a different number / date / owner). Do NOT silently
+   overwrite, and do NOT fold a conflict in as if it were an addition: list it under `### contradictions`
+   for the human to adjudicate.
 3. Return a compact draft (~500 tokens max):
 
 ## Draft — <target>
-### type        # person | topic (the durable zone this belongs to)
-### tags        # at least one
-### body        # the distilled synthesis, in the user's language, self-contained
-### links       # existing notes to weave in as [[people/...]] / [[topics/...]] paths (prefer targets that EXIST)
-### sources     # [[raw-sources/...]] / [[meetings/...]] backlinks this was distilled from
+### type          # person | topic (the durable zone this belongs to)
+### tags          # at least one
+### body          # the distilled synthesis, in the user's language, self-contained
+### links         # existing notes to weave in as [[people/...]] / [[topics/...]] paths (prefer targets that EXIST)
+### sources       # [[raw-sources/...]] / [[meetings/...]] backlinks this was distilled from
+### contradictions # (refresh only) each conflict as: PAGE SAYS "<x>" / CAPTURE SAYS "<y>" [source]; empty if none
 
 RULES:
 - Do NOT invent anything absent from the captures.
@@ -83,7 +92,12 @@ RULES:
 ### 4. Synthesise + propose (main context, never write yet)
 Collect the drafts. For each, show the user plainly: the **target path**, **type/tags**, the **[[links]]**
 and **sources**, and the **body** (or, for a refresh, the dated section to append). Ask for a yes. Adjust
-to their edits. Present it as a reviewable diff — this is the honesty requirement.
+to their edits. Present it as a reviewable diff (this is the honesty requirement).
+
+**If a draft carries `### contradictions`, surface those FIRST and distinctly** (⚠️ the page says X, this
+capture says Y). Do not bundle a conflict into the additive merge: the user resolves it explicitly (keep
+the page as is, adopt the capture, or record both as a dated "as of …" update). Only then proceed with the
+additive part of the refresh. A contradicting claim is **never** appended without that explicit decision.
 
 ### 5a. New page → write via the deterministic builder (Track B)
 Once confirmed, pipe a JSON spec to the `/file-back` builder (it stamps today's date, writes under
@@ -97,7 +111,9 @@ echo '{"type":"topic","title":"Capacity Management","tags":["capacity"],"body":"
 
 ### 5b. Existing page (refresh) → append a dated section
 Filing never overwrites. Append a dated section that folds in what's new and bump the page's `updated:`,
-mirroring the builder's shape (this is the brain's normal confirmed write; the auto-commit hook persists it):
+mirroring the builder's shape (this is the brain's normal confirmed write; the auto-commit hook persists it).
+Append **only** the parts the user accepted: a flagged contradiction goes in solely as the user adjudicated
+it (e.g. a dated `As of 2026-07-18, X is now Y (was Z)` line), never as a silent replacement of the old fact:
 ```markdown
 
 ## 2026-07-17 — <what the fresher captures add>
@@ -117,13 +133,15 @@ now sit at or past the captures' dates) — so a next pass naturally resumes on 
 - **Never overwrite.** New pages go through the builder (which refuses to clobber); existing pages are
   appended to, not rewritten.
 - **Conformant by construction.** Let the builder produce frontmatter/links so `/lint` stays clean.
-- **Read-only sub-agents, native tools only** (no shell for text) — the `sync-sources` constraint.
+- **Read-only sub-agents, native tools only** (no shell for text): the `sync-sources` constraint.
+- **Flag contradictions, don't adjudicate them.** A capture that conflicts with a stated fact is
+  surfaced for the user (Track D); consolidation never overwrites a fact to resolve a conflict on its own.
 - **Do not run git** (the auto-commit hook persists any accepted change).
 - **Trust the exit code.** `0` = nothing to consolidate; don't manufacture work.
 
 ## Out of scope
 - Deciding on its own to consolidate and writing unattended (always proposed, always confirmed).
-- Flagging a *contradiction* between a capture and a page's stated fact (Track D — needs deeper judgment;
-  here we fold in additively, we don't adjudicate conflicts).
+- ADJUDICATING a contradiction on the brain's own authority (Track D flags conflicts for the user; it
+  never decides which of two truths wins, nor overwrites a stated fact to resolve one).
 - The one-shot "file this exchange back" gesture (that is `/file-back`, Track B — a single note, not a
   batch promotion of existing captures).

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: consolidate
+description: "Consolidate raw captures into durable entity/topic pages (Axis 1, Track C): review recent meetings / daily / transcripts and PROMOTE their substance into the higher-order wiki — create the page for a person mentioned but never filed, refresh a topic page a fresher note left behind, weave the backlinks. A deterministic scan surfaces WHAT needs consolidating; parallel read-only sub-agents draft each merge; you PROPOSE, the user confirms, and the write reuses the /file-back builder (never overwrites). Triggered by '/consolidate', 'consolidate my captures', 'promote my raw notes', 'update my entity pages', 'compile my wiki', 'consolide mes captures', 'mets à jour mes pages', 'promeus mes notes brutes'."
+version: 1.0.0
+---
+
+# consolidate — promote raw captures into the durable wiki ("compile the notes")
+
+> A second brain accretes raw capture fast (meetings, daily logs, transcripts) but the *higher-order*
+> pages — the person, the topic, the project — lag behind: a name gets mentioned ten times and still has
+> no page, a topic page goes stale while fresher notes discuss it. This skill is the "compile" half of
+> the Karpathy LLM-Wiki discipline (see ADR 0033): on demand, it promotes the substance of raw captures
+> into the entity/topic pages and weaves the backlinks, so the wiki (and the RAG's neighbourhood signal)
+> stays current.
+
+## Principle
+
+One promise: **turn what raw captures already say into durable, well-linked pages — proposed first, written only on yes.**
+- **Detection is deterministic** (ADR 0009): a pure scanner lists exactly what needs consolidating.
+- **The merge is judgment** (LLM): parallel read-only sub-agents draft each page, never the main context
+  (the `sync-sources` fan-out/fan-in shape, to avoid context rot).
+- **The write is deterministic and confirmed** (reuse Track B / `/file-back`): a new page goes through
+  the builder (conformant by construction, refuses to overwrite); a living page gets a confirmed dated
+  append. So consolidation never re-introduces the defects `/lint` reports.
+- **Bounded, resumable (stateless), honest**: a capture is a candidate purely because it is *fresher
+  than the page it feeds* (or that page doesn't exist). Refresh a page and its `updated:` moves past the
+  capture, so the candidate drops off on its own — no state file, nothing to seed or corrupt.
+
+## Procedure
+
+### 1. Scan for candidates (deterministic)
+From the brain folder:
+```bash
+node scripts/consolidate-scan.mjs
+```
+- Exit **0** = nothing to consolidate (say so plainly, do not invent work).
+- Exit **1** = candidates found; the report has two sections. Read it verbatim.
+  - **New pages to create** — an entity/person `[[mentioned]]` in captures but with **no page** yet,
+    with the count of citing captures (its signal strength) and their paths.
+  - **Entity pages to refresh** — a curated page a **fresher** capture has left behind, with the
+    captures that overtook it.
+- To scan a different path: `node scripts/consolidate-scan.mjs <vault-dir>`.
+
+### 2. Bound the batch (judgment)
+Do not consolidate everything blindly. Prioritise by signal: a name cited by many captures is worth a
+page; a one-off mention or an obvious typo is not (that is a `/lint` dangling-link fix, not a page).
+Pick a handful; tell the user what you're leaving for later.
+
+### 3. Fan out — one read-only sub-agent per candidate (parallel, a single message)
+Reuse the `sync-sources` architecture: each sub-agent reads **only its candidate's source captures** and
+returns a compact draft (~500 tokens), so the raw text never floods the main context. Sub-agents are
+**READ-ONLY** and use **native tools only** (`Read` on the vault files — never a shell like `grep`/`cat`/
+`node -e` to load or split text; that re-triggers auth prompts and some are refused outright).
+
+```
+Agent(
+  description="Draft consolidation for <candidate>",
+  prompt="""
+You are a wiki-consolidation drafting agent. READ-ONLY. Native tools only.
+
+TASK:
+1. Read ONLY these source captures via the Read tool: <list the candidate's source paths>.
+2. For a NEW page: distil who/what this is from what the captures actually say — a person's role, a
+   topic's definition and current state. For a REFRESH: read the existing page too and draft the dated
+   section that folds in what the fresher captures add (do NOT restate what the page already holds).
+3. Return a compact draft (~500 tokens max):
+
+## Draft — <target>
+### type        # person | topic (the durable zone this belongs to)
+### tags        # at least one
+### body        # the distilled synthesis, in the user's language, self-contained
+### links       # existing notes to weave in as [[people/...]] / [[topics/...]] paths (prefer targets that EXIST)
+### sources     # [[raw-sources/...]] / [[meetings/...]] backlinks this was distilled from
+
+RULES:
+- Do NOT invent anything absent from the captures.
+- Backlinks kebab-case, no accents, never a first name alone.
+- NEVER a shell (grep/cat/node -e/awk/sed/jq…) to read or split content — use the Read tool; summarise by reasoning.
+"""
+)
+```
+
+### 4. Synthesise + propose (main context, never write yet)
+Collect the drafts. For each, show the user plainly: the **target path**, **type/tags**, the **[[links]]**
+and **sources**, and the **body** (or, for a refresh, the dated section to append). Ask for a yes. Adjust
+to their edits. Present it as a reviewable diff — this is the honesty requirement.
+
+### 5a. New page → write via the deterministic builder (Track B)
+Once confirmed, pipe a JSON spec to the `/file-back` builder (it stamps today's date, writes under
+`vault/`, and **refuses to overwrite**):
+```bash
+echo '{"type":"topic","title":"Capacity Management","tags":["capacity"],"body":"…","links":["topics/rag","raw-sources/2026-07-15-revue"]}' \
+  | node scripts/file-back-note.mjs
+```
+- Exit **0** = written (prints `✓ Filed back: vault/<path>`); relay the path.
+- Exit **1** = refused (already exists) or invalid → it's a living page, go to 5b.
+
+### 5b. Existing page (refresh) → append a dated section
+Filing never overwrites. Append a dated section that folds in what's new and bump the page's `updated:`,
+mirroring the builder's shape (this is the brain's normal confirmed write; the auto-commit hook persists it):
+```markdown
+
+## 2026-07-17 — <what the fresher captures add>
+
+<the distilled update>
+
+- [[meetings/2026-07-15-revue]]
+```
+
+### 6. Report what changed + resumability
+List the pages created/refreshed and what you deliberately skipped. Because detection is stateless,
+re-running `consolidate-scan` after the writes will show the consolidated candidates gone (their pages
+now sit at or past the captures' dates) — so a next pass naturally resumes on what's left.
+
+## Guardrails
+- **Propose first, write on yes.** Never consolidate a page the user hasn't agreed to.
+- **Never overwrite.** New pages go through the builder (which refuses to clobber); existing pages are
+  appended to, not rewritten.
+- **Conformant by construction.** Let the builder produce frontmatter/links so `/lint` stays clean.
+- **Read-only sub-agents, native tools only** (no shell for text) — the `sync-sources` constraint.
+- **Do not run git** (the auto-commit hook persists any accepted change).
+- **Trust the exit code.** `0` = nothing to consolidate; don't manufacture work.
+
+## Out of scope
+- Deciding on its own to consolidate and writing unattended (always proposed, always confirmed).
+- Flagging a *contradiction* between a capture and a page's stated fact (Track D — needs deeper judgment;
+  here we fold in additively, we don't adjudicate conflicts).
+- The one-shot "file this exchange back" gesture (that is `/file-back`, Track B — a single note, not a
+  batch promotion of existing captures).

--- a/engine-skills/file-back/SKILL.md
+++ b/engine-skills/file-back/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: file-back
+description: "File a hard-won answer back into the vault as a durable note (Axis 1): after a substantive exchange, PROPOSE distilling it into a topic / decision / person / meeting page — with a suggested target zone, tags and [[links]] — then write it only once the user says yes. The write goes through a deterministic builder so the note is taxonomy-conformant by construction (never re-introduces the defects /lint reports). Triggered by '/file-back', 'file this back', 'save this answer', 'turn this into a note', 'garde cette réponse', 'classe ça dans mon cerveau', 'fais-en une note durable'."
+version: 1.0.0
+---
+
+# file-back — file the good answer back ("don't let this evaporate")
+
+> A second brain that only ever captures raw input slowly rots: the hard-won *synthesis* of a good
+> exchange evaporates when the session ends. This skill is the "answers filed back" half of the
+> Karpathy LLM-Wiki compile discipline (see ADR 0033): when a conversation produced something worth
+> keeping, offer to distil it into a durable, well-linked note — so next time the brain *knows* it.
+
+## Principle
+
+One promise: **turn a substantive answer into a durable, conformant note — proposed first, written only on yes.**
+- The **judgment is yours** (and the user's): is this worth keeping? what type of note? where does it belong?
+- The **write is deterministic** (ADR 0009): the note's path, its frontmatter (`type`/`created`/
+  `updated`/`tags`) and its woven `[[links]]` are built by a tested helper, conformant **by
+  construction** — so a filed-back note never shows up later in a `/lint` report.
+- The **write is confirmed, never silent** (the brain's write posture): propose, let the user say yes.
+
+## When to use it
+
+After an exchange that produced durable value: a synthesised answer, a decision reached, a profile of
+a person that emerged, the notes of a meeting. Offer it; do not nag on every trivial turn. Good signals:
+the user says "keep this" / "garde ça", or you can feel the answer took real work and would be costly
+to reconstruct.
+
+## Procedure
+
+### 1. Decide the shape (judgment)
+Pick, from the vault taxonomy (see the constitution, §"Note format"):
+- **type** → one of `topic`, `decision`, `person`, `meeting` (the four durable, non-raw zones).
+  - `topic` → a cross-cutting concept (`topics/<slug>.md`).
+  - `decision` → a dated decision record (`decisions/<date>-<slug>.md`).
+  - `person` → a person page (`people/<firstname-lastname>.md`).
+  - `meeting` → dated meeting notes (`meetings/<date>-<slug>.md`).
+- **title** → a clear, human title (the builder slugifies it: kebab-case, no accents).
+- **tags** → at least one (required for conformance).
+- **body** → the distilled synthesis, in the user's language. Be concise and self-contained.
+- **links** → the existing notes this connects to, as `[[people/jane-doe]]`, `[[topics/rag]]` paths.
+  Prefer targets that **already exist** (run `/lint` if unsure) so you don't create dangling links.
+
+### 2. Propose (never write yet)
+Show the user, plainly: the **target path**, the **type/tags**, the **[[links]]**, and the **body** you
+intend to file. Ask for a yes. Adjust to their edits.
+
+### 3a. New page → write via the deterministic builder
+Once confirmed, from the brain folder, pipe a JSON spec to the builder (it stamps today's date, writes
+under `vault/`, and **refuses to overwrite**):
+```bash
+echo '{"type":"topic","title":"Capacity Management","tags":["capacity"],"body":"…","links":["topics/rag"]}' \
+  | node scripts/file-back-note.mjs
+```
+- `date` is required for dated types (`decision`, `meeting`), e.g. `"date":"2026-07-17"`.
+- Exit **0** = written (it prints `✓ Filed back: vault/<path>`); relay that path.
+- Exit **1** = refused (note already exists) or invalid spec; read the message verbatim — if it already
+  exists, this is a *living page*, so go to 3b instead.
+
+### 3b. Existing living page (person / topic) → append a dated section
+Filing back never overwrites. When the target already exists, **refine it additively**: append a dated
+section and bump its `updated:`. Keep it conformant, mirroring the builder's shape:
+```markdown
+
+## 2026-07-17 — <short heading>
+
+<the distilled synthesis>
+
+- [[people/jane-doe]]
+```
+This edit is the brain's normal confirmed write (the auto-commit hook persists it).
+
+## Guardrails
+- **Propose first, write on yes.** This skill never files a note the user hasn't agreed to.
+- **Never overwrite.** New pages go through the builder (which refuses to clobber); existing living
+  pages are appended to, not replaced.
+- **Conformant by construction.** Let the builder produce the frontmatter and links — do not hand-roll
+  a note that `/lint` would then flag.
+- **Do not run git** (the auto-commit hook persists any accepted change).
+- **Prefer existing link targets** so you don't trade evaporation for dangling links.
+
+## Out of scope
+- Deciding on its own that an exchange is worth keeping and filing it unattended (always proposed).
+- Bulk-consolidating many raw captures into higher-order pages (that is Track C, a separate gesture).
+- Merging/deduping against an existing page's *content* beyond appending a dated section (Track C / D).

--- a/engine-skills/lint/SKILL.md
+++ b/engine-skills/lint/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: lint
+description: "Health-check the vault's wiki (Axis 1): report where it bleeds — dangling [[links]], orphan notes nobody links to, stale entity pages left behind by fresher notes, and malformed frontmatter. Runs a deterministic scanner and reads its binary report, then proposes (never silently applies) fixes. Triggered by '/lint', 'lint my vault', 'check my wiki health', 'what links are broken', 'où mon wiki fuit', 'vérifie la santé de mes notes'."
+version: 1.0.0
+---
+
+# lint — wiki-health check ("where is my wiki bleeding?")
+
+> The retrieval side of the brain (the RAG) is a versioned, tested engine. The **curation**
+> side — keeping the wiki itself healthy: links that resolve, notes woven in, entity pages kept
+> fresh — is this skill's job. It is the deterministic half of the Karpathy "LLM-Wiki compile"
+> discipline (see ADR 0033): the scan is exact and fail-loud; the *judgment* of what to fix is
+> yours (and the user's).
+
+## Principle
+
+One promise: **an honest, binary health report of the vault, then help acting on it.**
+- The **scan is deterministic** (ADR 0009): pure code over the parsed notes, no LLM guessing.
+- The **fixes are proposed, never silently written** (the brain's write posture): surface the
+  problem, suggest the gesture, let the user say yes.
+
+## Procedure
+
+### 1. Run the scanner
+From the brain folder:
+```bash
+node scripts/lint-vault.mjs
+```
+- Exit **0** = clean (say so plainly, do not invent problems).
+- Exit **1** = issues found; the report lists them by category. Read it verbatim.
+- To check a different path: `node scripts/lint-vault.mjs <vault-dir>`.
+
+### 2. Read the report — four categories
+- **Dangling links** `from → [[target]]`: a `[[link]]` whose target note does not exist.
+  Usually a typo, a renamed/moved note, or a note that was meant to be written and never was.
+- **Orphans**: a note with **zero inbound links** (raw-capture zones `daily/`, `raw-sources/`,
+  `inbox/` are already excluded — they are legitimately unlinked). An orphan is knowledge that
+  is filed but never woven in, so the wiki (and the RAG's neighbourhood signal) can't reach it.
+- **Stale entity pages**: a curated entity page (`type: person|topic|company|project|concept`)
+  whose `updated:` trails the freshest note that cites it by more than the threshold (default
+  90 days). The world moved on; the canonical page didn't.
+- **Frontmatter issues**: a note missing a required key (`type` / `created` / `updated` /
+  `tags`), so it indexes and sorts poorly.
+
+### 3. Propose fixes (never apply silently)
+Group the findings and, for the ones worth acting on, **suggest the concrete gesture** and ask
+before writing:
+- **Dangling** → fix the target spelling, or create the missing note (offer to synthesize it
+  from the vault, like `open-note` does), or remove the dead link.
+- **Orphan** → propose where to weave it in: which existing note(s) should gain a `[[link]]` to
+  it, or which entity/topic page it belongs under.
+- **Stale entity page** → offer to refresh it from the fresher notes that cite it (a Track-C
+  consolidation gesture) and bump `updated:`.
+- **Frontmatter** → offer to add the missing keys (run `date` for correct `created`/`updated`).
+
+Prioritise: dangling links and frontmatter are cheap, high-signal fixes; orphans and stale pages
+are judgment calls — present them, don't force them.
+
+## Guardrails
+- **Report first, write never-without-consent.** This skill diagnoses; it does not rewrite the
+  vault on its own.
+- **Trust the exit code.** `0` means clean — do not manufacture findings to look useful.
+- **Do not run git** (the auto-commit hook persists any accepted change).
+- The scanner is **read-only** and **offline** (no network, no LLM): safe to run anytime.
+
+## Out of scope
+- Bulk auto-fixing the whole vault unattended (a future, explicit gesture).
+- Contradiction detection between a note and an entity page's stated fact (needs LLM judgment —
+  a later track).

--- a/installer.mjs
+++ b/installer.mjs
@@ -38,6 +38,7 @@ import { resolveLocale, chooseLocale } from "./scripts/lib/locale.mjs";
 import { overlayLocale } from "./scripts/lib/locale-overlay.mjs";
 import { installStagedSkills } from "./scripts/lib/staged-skills.mjs";
 import { seedHealthNote } from "./scripts/lib/staged-health-note.mjs";
+import { seedActionsLog } from "./scripts/lib/actions-log-seed.mjs";
 import {
   buildShLauncher,
   buildCmdLauncher,
@@ -344,6 +345,10 @@ if (stagedSkills.length) {
 // (engine-health/health-check.md, vault/ is sacred — ADR 0026). Seed the runtime
 // vault note from it so a FRESH brain has the canary indexed from the first run.
 seedHealthNote({ sourceDir: TARGET, brainDir: TARGET });
+// Track E: seed the append-only activity ledger (vault/actions-log.md) so it is a
+// first-class artifact from the first run, not a `sync-sources` side-effect. Written
+// once, never overwritten; the session-actions-log hook maintains it thereafter.
+seedActionsLog({ brainDir: TARGET, today: new Date().toISOString().slice(0, 10) });
 // Canary question for the vault actually installed (the overlaid locale, or `en`
 // at the root when no overlay applies) — so an fr brain probes/suggests the fr
 // question, matching its fr vault and its demo-locale.mjs marker.

--- a/maintainers/decisions/0033-descends-from-karpathy-llm-wiki-not-graphify.md
+++ b/maintainers/decisions/0033-descends-from-karpathy-llm-wiki-not-graphify.md
@@ -1,0 +1,73 @@
+# ADR 0033 — Kenjaku descends from Karpathy's LLM Wiki (prior art), not from Graphify
+
+- **STATUS:** ACCEPTED (2026-07-17).
+- **Scope:** Project positioning + Second brain (runtime). No installer surface. This is a
+  lineage / positioning decision; it also **frames** the Axis-1 engine features it justifies (plan
+  [`../plans/prospective/wiki-health-axis1-mechanisms-action.md`](../plans/prospective/wiki-health-axis1-mechanisms-action.md)).
+- **Related:** study
+  [`../plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md`](../plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md)
+  (the two-axis model + the wiki-health audit);
+  [`0007-three-embedder-adapters-privacy-scale.md`](0007-three-embedder-adapters-privacy-scale.md)
+  and [`0008-lightrag-graph-rag-deferred.md`](0008-lightrag-graph-rag-deferred.md) (the Axis-2 / RAG
+  investment this is the counterweight to).
+
+## Crux
+
+**Prior art (why this isn't NIH):** this project's retrieval philosophy is **Andrej Karpathy's
+"LLM Wiki"** pattern — an LLM compiles sources into an interlinked Markdown wiki you point an agent at,
+rather than a stateless embed-and-search index. We adopted it **deliberately and credited it from day
+one** (the originating private brain's `README` / `PLAN` cite Karpathy, and the clarifying write-up by
+Leo @defileo). **Graphify** is a **sibling** implementation of the **same public idea**, not our source.
+The decision: **position Kenjaku as a *superset* of the LLM Wiki** — a personal second brain that keeps
+the wiki (Axis 1) **and** adds an embedding RAG (Axis 2) **and** connectors — and **defend against
+"you copied Graphify" with the truth, not with a false priority claim**: common public ancestor +
+independent implementation + credited prior art + a different problem domain.
+
+## Context
+
+A cluster of July 2026 posts spotlighted Graphify (a code-knowledge-graph tool for coding agents) as
+"the" implementation of Karpathy's LLM Wiki. Because Kenjaku's vault *is* an interlinked Markdown wiki,
+the surface resemblance invites a "did you copy Graphify?" reflex. The dates settle it, and they do
+**not** support a "we were first" story — so we must not lean on one:
+
+| Element | Date | Source |
+|---|---|---|
+| Karpathy's "LLM Wiki" idea | ~early April 2026 | the posts frame Graphify as shipping "48 h after Karpathy posted" |
+| **Graphify** repo created | **2026-04-03** | GitHub API `created_at` |
+| **Originating private brain** (first commit; credits Karpathy the same day) | **2026-04-16** | `git log` |
+| **This launcher (Kenjaku)** (first commit) | **2026-06-02** | `git log` |
+
+So Graphify slightly **predates** the originating brain, and both descend from Karpathy's **publicly
+posted** idea. "We were first" is false and trivially refuted; it is also unnecessary.
+
+Two further facts matter. **(1)** Different problem domains: Graphify's centre of gravity is a
+*codebase* knowledge graph (typed edges: calls, imports, defs) for coding agents; Kenjaku is a
+*personal* second brain (connectors, briefings, 1-1s, decisions) with a RAG. **(2)** The two-axis model
+(study, §3): the LLM Wiki is not an alternative to our RAG — Kenjaku is a **superset** that already has
+the wiki artifact and *added* the vector RAG on top.
+
+## Decision
+
+1. **Adopt and credit Karpathy's "LLM Wiki" as the acknowledged prior art** for the retrieval
+   philosophy (per the repo's "name the prior art / not-NIH" convention). Keep the credit visible in
+   public-facing docs, never claim the pattern as ours.
+2. **Position Kenjaku as a superset of the LLM Wiki**, not a competitor to Graphify: personal second
+   brain = LLM wiki (Axis 1) + embedding RAG (Axis 2) + connectors. State the differentiator (personal
+   knowledge + connectors, **not** a code-knowledge-graph for coding agents) wherever the comparison
+   arises.
+3. **Do not claim temporal priority over Graphify.** The defensible, truthful stance on "you copied
+   Graphify" is: *common public ancestor (Karpathy), independent implementation, credited prior art,
+   different problem domain.* This is stronger than a date race and cannot be refuted.
+4. **Invest in Axis-1 mechanics** (wiki-health `/lint`, file-back, consolidation) as **engine features**
+   — the counterweight to the heavy Axis-2 investment the audit exposed — per the plan cited above.
+
+## Consequences
+
+- **Positive.** A truthful, un-refutable positioning; a documented lineage that survives `/clear` and
+  travels with the repo; a clear product boundary vs Graphify; a justified investment direction (Axis 1).
+- **Cost / trade-off.** We explicitly **forgo** the (tempting, punchier) "we did it before Graphify"
+  narrative because it is false. Marketing must lead with *"a personal second brain built on Karpathy's
+  LLM Wiki, plus a private RAG and connectors"*, not with a priority claim.
+- **Non-goal.** This ADR does not adopt Graphify's code, its knowledge-graph format, or its
+  code-agent framing; the Axis-1 mechanics are brain-flavoured (people/topics/decisions), designed
+  independently.

--- a/maintainers/decisions/0033-descends-from-karpathy-llm-wiki-not-graphify.md
+++ b/maintainers/decisions/0033-descends-from-karpathy-llm-wiki-not-graphify.md
@@ -15,9 +15,11 @@
 
 **Prior art (why this isn't NIH):** this project's retrieval philosophy is **Andrej Karpathy's
 "LLM Wiki"** pattern — an LLM compiles sources into an interlinked Markdown wiki you point an agent at,
-rather than a stateless embed-and-search index. We adopted it **deliberately and credited it from day
-one** (the originating private brain's `README` / `PLAN` cite Karpathy, and the clarifying write-up by
-Leo @defileo). **Graphify** is a **sibling** implementation of the **same public idea**, not our source.
+rather than a stateless embed-and-search index. It began from a **concrete personal need**, and from
+**day one** the brief was to **evaluate whether the LLM-Wiki ideas could serve that need** — not to
+adopt them blindly: we imported them **deliberately and credited them from the start** (the originating
+private brain's `README` / `PLAN` cite Karpathy, and the clarifying write-up by Leo @defileo).
+**Graphify** is a **sibling** implementation of the **same public idea**, not our source.
 The decision: **position Kenjaku as a *superset* of the LLM Wiki** — a personal second brain that keeps
 the wiki (Axis 1) **and** adds an embedding RAG (Axis 2) **and** connectors — and **defend against
 "you copied Graphify" with the truth, not with a false priority claim**: common public ancestor +

--- a/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
+++ b/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
@@ -134,10 +134,41 @@ embedder watch: **eval-first, measure, don't assume** (that note's §6).
 - [ ] Read Graphify's actual extraction pipeline (AST pass + subagent prompts) for reusable ideas on the **consolidation layer**, ignoring the code-graph specifics
 - [ ] Frame a tiny spike: an **ingestion-time consolidation** step (entity/topic pages + cross-links) on top of the current vault, measured against today's embedding-RAG on the FR eval-set
 - [ ] Confirm/deny the token-efficiency claim **against Kenjaku's RAG** (not vs raw-file reading) before quoting any multiplier
-- [ ] Audit whether Kenjaku still carries the wiki-health disciplines of its originating brain (a `/lint`-equivalent, an append-only log, "answers filed back") or whether the vector index became the only retrieval investment
+- [x] Audit whether Kenjaku still carries the wiki-health disciplines of its originating brain (a `/lint`-equivalent, an append-only log, "answers filed back") or whether the vector index became the only retrieval investment — **done (2026-07-17), see §8: intuition confirmed, Axis 1 ships as conventions only, zero enforcement**
 - [ ] Cross-link this note from the sibling `etude-rag-local-criteres-et-veille.md` if the direction firms up
 
-## 8. Sources
+## 8. Audit result — is Axis 1 under-invested in Kenjaku? (2026-07-17)
+
+**Verdict: yes, clearly.** Kenjaku ships Axis 2 (retrieval / RAG) as a complete, versioned, tested,
+auto-updating engine, and ships Axis 1 (wiki-health / consolidation) as **writing conventions in the
+constitution template with zero deterministic enforcement**. The constitution carries the *spirit*
+of an LLM wiki; the *mechanics* went entirely into the RAG.
+
+Discipline-by-discipline (evidence gathered across `CLAUDE.md.template`, the shipped
+`.claude/skills/**`, `rag/**`, `scripts/**`):
+
+| Axis-1 discipline | Status | Note |
+|---|---|---|
+| Wiki-health / `/lint` (orphans, dangling links, stale pages) | **ABSENT** | No lint skill, link-checker, orphan/stale scanner anywhere shipped |
+| Append-only log | **PARTIAL** | A convention (dailies never edited) + a `vault/actions-log.md` idiom inside `sync-sources`, but no standing/seeded artifact or hook |
+| "Answers filed back" (good Q&A → durable note) | **ABSENT** | No skill/hook turns a good answer into a filed knowledge page |
+| Backlink / entity-page consolidation | **ABSENT** as mechanism | `[[wikilink]]` syntax is documented; nothing actively cross-links, merges topics, or propagates a new person into a `people/` page — purely implicit, in-conversation |
+| Contradiction flagging | **ABSENT** | No rule/skill detects or flags contradictions between notes |
+
+**Contrast (Axis 2).** `rag/` is ~9k source lines (chunker, 3-adapter Embedder SPI, SQLite vector
+store, incremental index manager + single-writer lock, vault watcher, quota/degradation), plus
+`local-mirror/` (~14k lines) and deterministic harness scripts (`verify-rag.mjs`, `reindex-trigger`,
+`rag-launcher`), a versioned `engine-manifest.json` + `update-engine` skill, and mutation-tested
+coverage. The constitution devotes a full named section to the RAG. **No comparable code, test, or
+constitution section exists for any Axis-1 discipline.**
+
+**Implication (for a future ADR / spike, not decided here).** The highest-leverage move is not a new
+retrieval engine but **giving Axis 1 some mechanics**: a wiki-health check (orphans / dangling links
+/ stale entity pages), a light "file the good answer back" reflex, and consolidation prompts — all of
+which also *improve the RAG* (better notes ⇒ better chunks). This is the concrete shape the §7 spike
+could take.
+
+## 9. Sources
 
 - [Karpathy — LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
 - [Graphify repo — safishamsi/graphify](https://github.com/safishamsi/graphify) · [Graphify-Labs mirror](https://github.com/Graphify-Labs/graphify)

--- a/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
+++ b/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
@@ -1,0 +1,146 @@
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- STATUS: 🔬 STUDY / WATCH (created 2026-07-17) — NOTHING DECIDED, capture only. -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+
+# Study — "LLM Wiki" (Karpathy) / Graphify: compiled-wiki retrieval as an alternative (or complement) to embedding-RAG
+
+> **STATUS: 🔬 STUDY / WATCH** (created 2026-07-17). **Nothing is decided here.** This is a
+> capture of a pattern that surfaced repeatedly (X / GitHub, July 2026) and that sits **right on
+> the crux of Kenjaku's engine**: how a second brain retrieves. It is the **sibling** of the
+> embedder watch [`etude-rag-local-criteres-et-veille.md`](etude-rag-local-criteres-et-veille.md):
+> that note studies *which embedder* powers our vector RAG; **this** note studies a **different
+> retrieval philosophy** that questions whether we need embeddings + a vector index at all for
+> some of the value.
+>
+> **Origin:** a cluster of July 2026 posts Thomas flagged (chewa., MyWestLord, cyrilXBT,
+> SpikeCalls, andreysuperior, Wes Roth). Stripped of the marketing hooks ("76k stars in 48h", "a
+> guy in China revived a dead 15k-note Obsidian vault"), 4 of the 6 point at **the same idea**.
+
+---
+
+## 1. The idea — Karpathy's "LLM Wiki"
+
+Instead of stateless RAG over **raw** documents (embed everything, vector-search at every
+question), an LLM agent **compiles** the sources **at ingestion time** into a persistent, growing
+directory of **interlinked Markdown files**: entity pages, topic summaries, explicit cross-links,
+flagged contradictions. You then point a coding agent (Claude Code) at that already-digested folder
+and ask your questions; the agent **navigates** the compiled wiki rather than re-deriving meaning
+from raw text each time.
+
+- **RAG is stateless**; the LLM Wiki is a **compounding artifact** that gets richer with each source.
+- Knowledge is **compiled once, kept current** (adding a source updates entity pages, revises
+  summaries, flags conflicts) instead of re-retrieved from scratch.
+- Source: Karpathy's gist `llm-wiki.md`.
+
+## 2. Graphify — the implementation that made the buzz
+
+[`safishamsi/graphify`](https://github.com/safishamsi/graphify) (also
+[`Graphify-Labs/graphify`](https://github.com/Graphify-Labs/graphify)), MIT, on-device:
+
+- `uv tool install graphifyy` (double `y`), then `graphify install` registers it as a Claude Code
+  skill / MCP tool set.
+- **Deterministic AST pass first** (tree-sitter, no LLM) extracts structure from code; **then Claude
+  subagents in parallel** extract concepts, relationships and design rationale from docs, papers,
+  images.
+- Output: a local knowledge graph (`graph.json` / `graph.html` / `GRAPH_REPORT.md`); a `--obsidian`
+  flag writes the whole graph as a **fully-linked Obsidian vault**.
+- Headline claims: **0 vector databases**, **~71.5x fewer tokens per query**, persistent across
+  sessions, "honest about what it found vs guessed", nothing leaves the machine by default.
+
+> Note: Graphify's centre of gravity is **codebases** (typed edges: calls, imports, defs, refs). The
+> *code* is only partially relevant to us; the **retrieval philosophy** is what matters.
+
+## 3. Why it matters for Kenjaku — and where Kenjaku already sits
+
+The "LLM Wiki *vs* RAG" framing is a **false opposition** once you split the pattern into **two
+independent axes**:
+
+- **Axis 1 — compile (ingestion / write).** An LLM digests raw sources into interlinked Markdown:
+  entity pages, topic summaries, cross-links, flagged contradictions. The compounding artifact.
+- **Axis 2 — retrieve (query / read).** How you find things: the agent **navigates** the wiki
+  (grep / read / follow `[[links]]`, "0 vector DB" à la Graphify) **or** you **embed and
+  semantic-search**.
+
+On that grid, **Kenjaku is not an alternative to the LLM Wiki — it is a superset of it**:
+
+- **Axis 1:** Kenjaku *is* an LLM Wiki. Its vault is interlinked Markdown (Obsidian wikilinks;
+  entity notes for people, meetings, decisions, topics) written and linked by Claude
+  **in-conversation**. Same artifact as Karpathy's; the only difference is **cadence** — Kenjaku
+  compiles incrementally (in chat) rather than in a batch "point Graphify at a folder" pass.
+- **Axis 2:** Kenjaku **added** the embedding RAG (vector index + `vault-rag` MCP, `Embedder` SPI
+  over in-process ONNX / Ollama / Gemini) **on top of** the wiki, as a **recall accelerator** once
+  the vault outgrows pure agent-navigation. It did not replace the wiki.
+
+**Lineage (confirmed, not retrofitted theory).** The private second brain Kenjaku was extracted
+from **started explicitly from Karpathy's "LLM Wiki" pattern**: a 3-layer *raw / wiki / schema*
+architecture, an append-only global log, a `/lint` wiki-health operation, "good answers filed
+back" — then grew a RAG as it scaled. The RAG is an **augmentation of the principle, not a
+departure from it**.
+
+**Compatible or exclusive? Complementary.** The only genuine either/or is the *retrieval mechanism
+at query time*, and even there the two cover each other's blind spots: embeddings give **semantic
+recall** (find the right note even if poorly linked or differently worded) but are flat and
+structure-blind; agent-navigation gives **precision and reasoning** (follow links, read the entity
+page, cross-check) but misses what isn't linked. The strongest design **chains them**: RAG for
+recall → wiki-navigation for precision. And the unifying point: **the better Axis 1 is compiled,
+the better BOTH retrievals get** — richer entity pages and links improve navigation *and* yield
+better chunks to embed.
+
+## 4. What is worth stealing (and what is not)
+
+**Worth a spike — the ingestion-time consolidation layer.** The genuinely new idea is *compiling*
+knowledge as notes enter (entity pages, topic summaries, explicit cross-links, contradiction flags),
+not just chunk-and-embed. That is the piece a pure embedding-RAG lacks, and it is the kind of thing
+that would make a Kenjaku vault "smarter" **without touching the search engine or the MCP contract**.
+It rhymes with the "Contextual Retrieval" lever already parked in the sibling note (§5 there) — same
+family: enrich/consolidate before retrieval.
+
+**The real reminder Karpathy gives us.** Not "drop the RAG" but "**don't let Axis 1 (the
+compile/consolidation discipline) atrophy just because a RAG exists**". The RAG is only ever as good
+as the notes it indexes. The originating brain shipped explicit wiki-health mechanisms (`/lint`,
+append-only log, "answers filed back"); the open question is whether Kenjaku still carries their
+equivalents, or whether the vector index quietly became the only retrieval investment.
+
+**Adjacent, low-lift.** The `--obsidian` fully-linked output overlaps with what Kenjaku already
+emits; the explicit-links angle could feed navigation / citations.
+
+**Treat with skepticism — the numbers.** The "71.5x fewer tokens" is measured **vs re-reading raw
+files**, not **vs a competent RAG**. Kenjaku's RAG already does not re-read everything, so the real
+delta against Kenjaku is **unproven** and must be measured, not swallowed. Same discipline as the
+embedder watch: **eval-first, measure, don't assume** (that note's §6).
+
+## 5. Relationship to existing work
+
+- Sibling: [`etude-rag-local-criteres-et-veille.md`](etude-rag-local-criteres-et-veille.md) —
+  embedder alternatives for the *vector* RAG. This note is the *retrieval-paradigm* companion.
+- The `Embedder` SPI plan [`embedder-spi.md`](embedder-spi.md) and the stable MCP contract
+  (ADR 0006) mean a consolidation layer could be added **behind** the contract, as an
+  ingestion-side transform, without breaking the harness.
+- Any decision to actually pursue this belongs in an **ADR** ("embedding-RAG vs compiled-wiki
+  retrieval"), not in this capture note.
+
+## 6. Low-signal items from the same cluster (parked, not pursued)
+
+- **andreysuperior** — Obsidian-as-a-service business angle ($1,500/mo/client). Product
+  positioning, zero engine value.
+- **Wes Roth / "Fable"** — promo for a note-taking app; no architectural idea.
+- **cyrilXBT / SpikeCalls** — re-shares of the Karpathy/Graphify article already covered above.
+
+---
+
+## 7. Tracking — possible next steps (nothing committed)
+
+- [ ] Decide whether this warrants an ADR ("embedding-RAG vs compiled-wiki retrieval") or stays a watch note
+- [ ] Read Graphify's actual extraction pipeline (AST pass + subagent prompts) for reusable ideas on the **consolidation layer**, ignoring the code-graph specifics
+- [ ] Frame a tiny spike: an **ingestion-time consolidation** step (entity/topic pages + cross-links) on top of the current vault, measured against today's embedding-RAG on the FR eval-set
+- [ ] Confirm/deny the token-efficiency claim **against Kenjaku's RAG** (not vs raw-file reading) before quoting any multiplier
+- [ ] Audit whether Kenjaku still carries the wiki-health disciplines of its originating brain (a `/lint`-equivalent, an append-only log, "answers filed back") or whether the vector index became the only retrieval investment
+- [ ] Cross-link this note from the sibling `etude-rag-local-criteres-et-veille.md` if the direction firms up
+
+## 8. Sources
+
+- [Karpathy — LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
+- [Graphify repo — safishamsi/graphify](https://github.com/safishamsi/graphify) · [Graphify-Labs mirror](https://github.com/Graphify-Labs/graphify)
+- [AnalyticsVidhya — from Karpathy's LLM Wiki to Graphify](https://www.analyticsvidhya.com/blog/2026/04/graphify-guide/)
+- [MindStudio — what is Karpathy's LLM Wiki](https://www.mindstudio.ai/blog/andrej-karpathy-llm-wiki-knowledge-base-claude-code)
+- Origin posts (X, July 2026): [chewa. — graphify/76k stars](https://x.com/chewadot/status/2075300253969035393) · [MyWestLord — Karpathy method in Claude Code](https://x.com/mywestlord/status/2076703919871348767) · [SpikeCalls article](https://x.com/spikecalls/status/2069815843186176126)

--- a/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
+++ b/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
@@ -71,11 +71,21 @@ On that grid, **Kenjaku is not an alternative to the LLM Wiki — it is a supers
   over in-process ONNX / Ollama / Gemini) **on top of** the wiki, as a **recall accelerator** once
   the vault outgrows pure agent-navigation. It did not replace the wiki.
 
-**Lineage (confirmed, not retrofitted theory).** The private second brain Kenjaku was extracted
-from **started explicitly from Karpathy's "LLM Wiki" pattern**: a 3-layer *raw / wiki / schema*
-architecture, an append-only global log, a `/lint` wiki-health operation, "good answers filed
-back" — then grew a RAG as it scaled. The RAG is an **augmentation of the principle, not a
-departure from it**.
+**Lineage (confirmed, not retrofitted theory).** Kenjaku did **not** start from an idea to copy — it
+started from a **concrete personal need** (a working second brain). From **day one**, the brief to
+Claude was explicitly to **evaluate whether Karpathy's "LLM Wiki" ideas could serve that need**, not
+to adopt them blindly: the originating private brain's `PLAN` states the need first, then
+**deliberately imports four LLM-Wiki ideas** (a 3-layer *raw / wiki / schema* architecture, an
+append-only global log, a `/lint` wiki-health operation, "good answers filed back"), and even runs a
+"Karpathy-style critique" of its own first plan. So the wiki discipline (Axis 1) was there **by
+design, from the start** — need-driven, then a public pattern weighed against it.
+
+**How the gap opened (the honest arc).** What eroded Axis 1 was **success on Axis 2**: the sheer
+power of the answers, and then the **RAG (which came second)**, pulled the investment toward
+retrieval and let the **curation / consolidation / lint discipline quietly lapse**. The RAG is an
+**augmentation of the principle, not a departure from it** — but it also **eclipsed** the compile
+discipline. **Reclaiming Axis 1 is precisely what this study, and its action plan
+([`wiki-health-axis1-mechanisms-action.md`](wiki-health-axis1-mechanisms-action.md)), are for.**
 
 **Compatible or exclusive? Complementary.** The only genuine either/or is the *retrieval mechanism
 at query time*, and even there the two cover each other's blind spots: embeddings give **semantic

--- a/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
+++ b/maintainers/plans/prospective/llm-wiki-vs-embedding-rag-karpathy-graphify.md
@@ -18,6 +18,29 @@
 
 ---
 
+## Kenjaku's origin story — need-first, LLM-Wiki by design, then Axis 1 lapsed
+
+> This is the framing that matters most, so it leads.
+
+**Where Kenjaku came from.** Kenjaku did **not** start from an idea to copy — it started from a
+**concrete personal need**: a second brain that actually works. From **day one**, the brief to Claude
+was explicit: **evaluate whether Karpathy's "LLM Wiki" ideas could serve that need**, not adopt them
+blindly. The originating private brain's `PLAN` states the **need first**, then **deliberately imports
+four LLM-Wiki ideas** (a 3-layer *raw / wiki / schema* architecture, an append-only global log, a
+`/lint` wiki-health operation, "good answers filed back"), and even runs a "Karpathy-style critique" of
+its own first plan. So the wiki / curation discipline (**Axis 1**, defined precisely in §3) was there
+**by design, from the very start** — need-driven, with a public pattern weighed **against** that need.
+
+**How the gap opened (the honest arc).** What eroded Axis 1 was **success on Axis 2**: the sheer power
+of the answers, and then the **RAG (which came second)**, pulled all the investment toward retrieval
+and let the **curation / consolidation / lint discipline quietly lapse**. The RAG is an **augmentation
+of the LLM-Wiki principle, not a departure from it** — but its success **eclipsed** the compile
+discipline. **Reclaiming Axis 1 is precisely what this study, and its action plan
+([`wiki-health-axis1-mechanisms-action.md`](wiki-health-axis1-mechanisms-action.md)), are for** — and
+the §8 audit confirms Axis 1 is, today, under-invested.
+
+---
+
 ## 1. The idea — Karpathy's "LLM Wiki"
 
 Instead of stateless RAG over **raw** documents (embed everything, vector-search at every
@@ -71,21 +94,10 @@ On that grid, **Kenjaku is not an alternative to the LLM Wiki — it is a supers
   over in-process ONNX / Ollama / Gemini) **on top of** the wiki, as a **recall accelerator** once
   the vault outgrows pure agent-navigation. It did not replace the wiki.
 
-**Lineage (confirmed, not retrofitted theory).** Kenjaku did **not** start from an idea to copy — it
-started from a **concrete personal need** (a working second brain). From **day one**, the brief to
-Claude was explicitly to **evaluate whether Karpathy's "LLM Wiki" ideas could serve that need**, not
-to adopt them blindly: the originating private brain's `PLAN` states the need first, then
-**deliberately imports four LLM-Wiki ideas** (a 3-layer *raw / wiki / schema* architecture, an
-append-only global log, a `/lint` wiki-health operation, "good answers filed back"), and even runs a
-"Karpathy-style critique" of its own first plan. So the wiki discipline (Axis 1) was there **by
-design, from the start** — need-driven, then a public pattern weighed against it.
-
-**How the gap opened (the honest arc).** What eroded Axis 1 was **success on Axis 2**: the sheer
-power of the answers, and then the **RAG (which came second)**, pulled the investment toward
-retrieval and let the **curation / consolidation / lint discipline quietly lapse**. The RAG is an
-**augmentation of the principle, not a departure from it** — but it also **eclipsed** the compile
-discipline. **Reclaiming Axis 1 is precisely what this study, and its action plan
-([`wiki-health-axis1-mechanisms-action.md`](wiki-health-axis1-mechanisms-action.md)), are for.**
+> **How this superset actually came to be** — need-first, LLM-Wiki by design from day one, then Axis 1
+> lapsing under the success of the answers and the RAG — is told up front in **"Kenjaku's origin
+> story"** at the top of this note. The two-axis definitions in this section are what that story
+> refers to.
 
 **Compatible or exclusive? Complementary.** The only genuine either/or is the *retrieval mechanism
 at query time*, and even there the two cover each other's blind spots: embeddings give **semantic

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -31,7 +31,7 @@
   - [x] Stale entity pages (`updated:` old while cited in fresher notes) _(2a509fd)_
   - [x] Frontmatter conformance (required `type` / `created` / `updated` / `tags`) _(2a509fd)_
   - [x] Ship as an engine skill + a deterministic script, binary report _(a193743, 767caad)_
-- [x] **Track B — The brain files a good answer back** into a durable note (semi-automatic, confirmed write) _(2026-07-17 · `/file-back` engine skill + deterministic `filed-note` core, TDD)_
+- [x] **Track B — The brain files a good answer back** into a durable note (semi-automatic, confirmed write) _(2026-07-17 · 87bf2f7 · `/file-back` engine skill + deterministic `filed-note` core, TDD)_
   - [x] Deterministic core `scripts/lib/filed-note.mjs` (slugify, path, conformant render — 15 tests)
   - [x] Thin CLI `scripts/file-back-note.mjs` (JSON spec on stdin, writes under vault/, never overwrites — 4 tests)
   - [x] Engine skill `engine-skills/file-back/SKILL.md` (propose → confirm → file; append path for living pages)

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -1,8 +1,10 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🟢 Tracks A + B SHIPPED (2026-07-17). Track A = `/lint` wiki-health   -->
-<!-- scanner (TDD, proven on the real 405-note vault). Track B = `/file-back`      -->
-<!-- deterministic filer (TDD, proven: a filed note passes /lint clean, never      -->
-<!-- overwrites). Both are engine skills. Tracks C–E still prospective.            -->
+<!-- STATUS: 🟢 Tracks A + B + C SHIPPED (2026-07-17). A = `/lint` wiki-health      -->
+<!-- scanner. B = `/file-back` deterministic filer (a filed note passes /lint       -->
+<!-- clean, never overwrites). C = `/consolidate`: a deterministic candidate finder -->
+<!-- (stateless "fresher-than-the-page" rule) + a fan-out/fan-in skill that writes  -->
+<!-- via B. All TDD, all engine skills, all proven on the real 405-note vault.      -->
+<!-- Tracks D + E still prospective.                                                -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Action plan — give Axis 1 (wiki-health / consolidation) real mechanics
@@ -36,7 +38,7 @@
   - [x] Thin CLI `scripts/file-back-note.mjs` (JSON spec on stdin, writes under vault/, never overwrites — 4 tests)
   - [x] Engine skill `engine-skills/file-back/SKILL.md` (propose → confirm → file; append path for living pages)
   - [x] Wired into `update-engine` manifest (`replace` + `scripts` 1.2.0→1.3.0); proven: filed note passes /lint clean
-- [ ] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven
+- [x] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven _(2026-07-17 · deterministic candidate finder + `/consolidate` skill, TDD, proven on the real 405-note vault)_
 - [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
 - [ ] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect)
 - [ ] **Cross-cutting — Measure the effect on retrieval** on the eval-set (better notes ⇒ better chunks)
@@ -90,13 +92,42 @@ a session. This is the "answers filed back" Karpathy discipline, absent today.
 
 ## Track C — Consolidate raw captures into entity/topic pages
 
-**WHAT.** On demand (or scheduled), the brain reviews recent raw captures (`meetings/`, `daily/`) and
-**promotes / updates** the higher-order pages: propagate a newly-mentioned person into `people/`, merge
-topic fragments, weave backlinks. This is the heart of the compile discipline and where the audit found
-the biggest gap (raw capture dominates; higher-order consolidation lags).
+**WHAT.** On demand (or scheduled), the brain reviews recent raw captures (`meetings/`, `daily/`,
+`raw-sources/`) and **promotes / updates** the higher-order pages: propagate a newly-mentioned person
+into `people/`, merge topic fragments, weave backlinks. This is the heart of the compile discipline and
+where the audit found the biggest gap (raw capture dominates; higher-order consolidation lags).
 
-- [ ] A consolidation skill reusing the `sync-sources` fan-out/fan-in shape
-- [ ] Bounded, resumable, and honest about what it changed (a diff/report the user reviews)
+> **Design (agreed 2026-07-17).** Same three-rung shape as Tracks A/B: a **deterministic candidate
+> finder** (rung 1) surfaces *what* needs consolidating; the **LLM fan-out** (`sync-sources` shape) does
+> the *merge* (judgment); the **write reuses Track B** (`filed-note` builder for new pages, confirmed
+> dated append for living pages — never overwrites). **Resumability is stateless** (owner's call): a
+> capture is a candidate purely because it is **fresher than the page it feeds** (or that page doesn't
+> exist yet) — no state file to seed or corrupt, most in the spirit of ADR 0009. Once a page is
+> refreshed its `updated:` moves past the capture, so the candidate drops off on its own.
+
+- [x] **Deterministic candidate finder** (`scripts/lib/consolidation-candidates.mjs`, pure/I/O-free, TDD
+      rung 1) — reuses Track A's `extractWikiLinks` + resolver + note shape. Given parsed notes it returns
+      candidates grouped by target page _(17 tests)_
+  - [x] *new-page* — an entity/person `[[mention]]` in a **capture** note that resolves to **no page**
+        (grouped by target, with its source captures + a count = signal strength)
+  - [x] *refresh* — an existing **entity page** cited by a **capture** note that is **fresher** than the
+        page's `updated:` (reuses `buildResolver`, now exported from wiki-lint; stateless, no threshold)
+  - [x] Capture zones (`meetings/`, `daily/`, `raw-sources/`, `inbox/`) and entity types configurable;
+        deterministic ordering (sorted by target, sources sorted) + `hasCandidates` / `reportLines`
+- [x] **Thin CLI** (rung 2) over the fs adapter — reads the vault, prints a human candidate report,
+      binary exit (0 nothing to consolidate / 1 candidates found) _(`scripts/consolidate-scan.mjs`, 3 tests)_
+- [x] **Consolidation skill** (`engine-skills/consolidate/`) reusing the `sync-sources` fan-out/fan-in
+      shape: one sub-agent per candidate drafts the merge; **propose → confirm → write via Track B**
+      _(`engine-skills/consolidate/SKILL.md`)_
+- [x] Bounded, resumable (stateless), and honest about what it changed (a diff/report the user reviews)
+      _(skill steps 2 "bound the batch", 4 "propose as a reviewable diff", 6 "report + stateless resume")_
+- [x] Wire into `update-engine` manifest so the fleet receives it (ADR 0012 / 0025) _(`scripts/consolidate-scan.mjs`
+      declared in `replace`; core + skill ride `scripts/lib/**` + `engine-skills/**`; `scripts` 1.3.0→1.4.0;
+      installer + self-heal enumerate `engine-skills/` dynamically → no hardcoded list)_
+- [x] Measure on a **real** vault (the 405-note local corpus), not the demo — the scan meaningfully
+      exercised both rules: 3 new-page candidates (entities cited in captures with no page) + 9 refresh
+      candidates (entity/topic pages a fresher meeting/transcript overtook, one cited by 3), exit 1,
+      read-only. The stateless "fresher-than-the-page" rule fires exactly where consolidation lags.
 
 ## Track D — (v2) Contradiction flagging
 

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -1,10 +1,11 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🟢 Tracks A + B + C SHIPPED (2026-07-17). A = `/lint` wiki-health      -->
+<!-- STATUS: 🟢 Tracks A + B + C + F SHIPPED (2026-07-17). A = `/lint` wiki-health   -->
 <!-- scanner. B = `/file-back` deterministic filer (a filed note passes /lint       -->
 <!-- clean, never overwrites). C = `/consolidate`: a deterministic candidate finder -->
 <!-- (stateless "fresher-than-the-page" rule) + a fan-out/fan-in skill that writes  -->
-<!-- via B. All TDD, all engine skills, all proven on the real 405-note vault.      -->
-<!-- Tracks D + E still prospective.                                                -->
+<!-- via B. F = a SessionStart trigger fires the scans on a real event and surfaces  -->
+<!-- them in the chat (Desktop-visible), the write stays confirmed. All TDD, all     -->
+<!-- proven on the real 405-note vault. Tracks D + E still prospective.              -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Action plan — give Axis 1 (wiki-health / consolidation) real mechanics
@@ -41,9 +42,9 @@
 - [x] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven _(2026-07-17 · deterministic candidate finder + `/consolidate` skill, TDD, proven on the real 405-note vault)_
 - [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
 - [ ] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect)
-- [ ] **Track F — Run the Axis-1 mechanics from a deterministic trigger** (a hook/event, not only on-demand)
-  - [ ] `/lint` (read-only) auto-runs on a real event and surfaces its report
-  - [ ] `/consolidate` **scan** auto-runs and surfaces candidates — the write stays confirmed (never auto-filed)
+- [x] **Track F — Run the Axis-1 mechanics from a deterministic trigger** (a hook/event, not only on-demand) _(2026-07-17 · b81d937 · SessionStart hook `session-wiki-health.mjs` + pure `wiki-health-nudge` core, TDD, proven on the real 405-note vault)_
+  - [x] `/lint` (read-only) auto-runs on a real event and surfaces its report _(SessionStart hook; only dangling links surface here, orphans/stale stay on-demand)_
+  - [x] `/consolidate` **scan** auto-runs and surfaces candidates — the write stays confirmed (never auto-filed) _(scan only; the merge stays propose → yes)_
 - [ ] **Cross-cutting — Measure the effect on retrieval** on the eval-set (better notes ⇒ better chunks)
 - [ ] **Sequencing decided** — import-before vs import-after (see §Sequencing; recommendation recorded)
 
@@ -153,18 +154,33 @@ conversational trigger). The goal: let them fire **on their own**, from a **dete
 real event** (rung 3 of ADR 0009), so wiki-health stops depending on the user remembering to ask — while
 never turning a silent auto-write loose.
 
-- [ ] Pick the **event** (deterministic, verifiable): SessionStart, post-`sync-sources`, a periodic cron,
-      or a "N new captures since last pass" threshold — prefer a real event over a timer where possible
-- [ ] **`/lint` is read-only → safe to auto-run**: fire the scan on the chosen event, surface the report
-      (or stay silent when clean). No write, no confirmation needed.
-- [ ] **`/consolidate` writes → auto-run only the SCAN**: surface the candidates on the event, but the
-      merge/write **stays confirmed** (propose → the user says yes). Never auto-file. This is the load-
-      bearing guardrail — the brain's write posture must survive automation.
-- [ ] Honour the determinism ladder: the **trigger** is deterministic (hook/event), the **detection** is
-      deterministic (the pure cores already are), only the **merge** stays LLM+confirmed
+- [x] Pick the **event** (deterministic, verifiable): **SessionStart** — the established maintenance
+      rendez-vous (self-heal / health / obsidian-hint / status already fire there). No timer, no counter:
+      the scans are **stateless** (a candidate exists purely because a capture is fresher than its page),
+      so the event alone is enough; the hook stays quiet when there's nothing actionable.
+- [x] **`/lint` is read-only → safe to auto-run**: the scan fires on SessionStart. **Only dangling links**
+      surface here (true regressions); orphans/stale/frontmatter are a standing backlog on a real vault →
+      they stay in the on-demand `/lint` (the noise guardrail, locked by a test).
+- [x] **`/consolidate` writes → auto-run only the SCAN**: candidates surface on the event, the merge/write
+      **stays confirmed** (propose → the user says yes). Never auto-file. The directive itself carries this
+      posture ("OPTIONAL housekeeping … NEVER auto-file … stays confirmed").
+- [x] Honour the determinism ladder: **trigger** deterministic (SessionStart hook, rung 3), **detection**
+      deterministic (`lintVault` + `consolidationCandidates`, rung 1), **surface** an `additionalContext`
+      directive the agent relays in the chat (rung 6, the only Desktop-visible channel), **merge** stays
+      LLM+confirmed on-demand.
 - [ ] Sibling to Track E (both are "maintain Axis 1 via a hook on a real event, not a by-product") — share
-      the wiring/lesson where they overlap
-- [ ] Keep the on-demand skills working unchanged; the hook is an **addition**, not a replacement
+      the wiring/lesson where they overlap _(Track E still prospective; reuse this hook's shape when built)_
+- [x] Keep the on-demand skills working unchanged; the hook is an **addition**, not a replacement
+      (`/lint` and `/consolidate` skills untouched; the hook only reuses their pure cores)
+
+> **Shipped (2026-07-17 · b81d937).** `scripts/session-wiki-health.mjs` (fail-open SessionStart hook) +
+> `scripts/lib/wiki-health-nudge.mjs` (pure core, 7 tests), wired as the 5th SessionStart group after
+> `session-self-heal`, carried in the manifest (`scripts` 1.4.0 → 1.5.0), delivered fleet-wide by the
+> existing `reconcileHooks` add-if-absent. Surface channel = `additionalContext` (chat, Desktop-visible),
+> mirroring `buildSelfHealHookOutput`. A linter false positive surfaced en passant and was fixed at the
+> root: `extractWikiLinks` now ignores `[[links]]` inside fenced/inline code (Obsidian doesn't linkify
+> code), so the shipped demo vault is lint-clean and a **fresh brain stays silent on day one**. Proven on
+> the real 405-note vault (nudge: 12 consolidation candidates + 47 dangling links); full suite 642/642.
 
 ---
 

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -1,5 +1,7 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🟡 PROSPECTIVE / NOT STARTED (created 2026-07-17). Nothing built yet. -->
+<!-- STATUS: 🟢 Track A SHIPPED (2026-07-17). `/lint` wiki-health scanner built   -->
+<!-- in TDD, proven on the real 405-note vault, shipped as an engine skill.       -->
+<!-- Tracks B–E still prospective. -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Action plan — give Axis 1 (wiki-health / consolidation) real mechanics
@@ -22,12 +24,12 @@
 
 ## Tracking
 
-- [ ] **Track A — The brain can detect where its wiki is bleeding** (`/lint` wiki-health)
-  - [ ] Dangling `[[links]]` (target note missing)
-  - [ ] Orphan notes (zero inbound links)
-  - [ ] Stale entity pages (`updated:` old while cited in fresher notes)
-  - [ ] Frontmatter conformance (required `type` / `created` / `updated` / `tags`)
-  - [ ] Ship as an engine skill + a deterministic script, binary report
+- [x] **Track A — The brain can detect where its wiki is bleeding** (`/lint` wiki-health) _(2026-07-17 · 131a72e…767caad)_
+  - [x] Dangling `[[links]]` (target note missing) _(131a72e)_
+  - [x] Orphan notes (zero inbound links) _(131a72e)_
+  - [x] Stale entity pages (`updated:` old while cited in fresher notes) _(2a509fd)_
+  - [x] Frontmatter conformance (required `type` / `created` / `updated` / `tags`) _(2a509fd)_
+  - [x] Ship as an engine skill + a deterministic script, binary report _(a193743, 767caad)_
 - [ ] **Track B — The brain files a good answer back** into a durable note (semi-automatic, confirmed write)
 - [ ] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven
 - [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
@@ -44,17 +46,23 @@ vault: what links point nowhere, what notes nobody links to, what entity pages h
 frontmatter is malformed. This is the highest-leverage, lowest-risk Axis-1 mechanic and the most
 "Kenjaku" (deterministic, fail-loud).
 
-- [ ] A deterministic scanner (pure JS, injected fs) that, given a vault path, returns a structured
+- [x] A deterministic scanner (pure JS, injected fs) that, given a vault path, returns a structured
       report: `danglingLinks[]`, `orphans[]`, `staleEntityPages[]`, `frontmatterViolations[]`
-  - [ ] TDD, rung 1 of the determinism ladder (ADR 0009): correctness in an I/O-free function, faked fs
-  - [ ] Stale rule = an entity page (`type: person|topic|…`) whose `updated:` predates the newest note
-        that `[[links]]` to it by more than a threshold (config, default e.g. 90 days)
-  - [ ] Orphan rule = a note with zero inbound `[[links]]` (excluding `daily/`, `raw-sources/`, inbox)
-- [ ] A thin CLI wrapper with a **binary exit code** (rung 2): `exit 0` clean / `exit 1` + report
-- [ ] An **engine skill** (`engine-skills/`) so the brain can run it conversationally and read the report
-- [ ] Wire into `update-engine` manifest so the fleet receives it (ADR 0012 / 0025)
-- [ ] Measure: run against a **real** vault (see §Sequencing), not the 7-note demo — the demo cannot
-      exercise orphan/stale/dangling logic meaningfully
+      _(`scripts/lib/wiki-lint.mjs`, 25 tests · 131a72e, 2a509fd)_
+  - [x] TDD, rung 1 of the determinism ladder (ADR 0009): correctness in an I/O-free function, faked fs
+        _(the pure core takes already-parsed notes; the fs adapter `wiki-lint-io.mjs` is the rung-2 seam)_
+  - [x] Stale rule = an entity page (`type: person|topic|…`) whose `updated:` predates the newest note
+        that `[[links]]` to it by more than a threshold (config, default e.g. 90 days) _(2a509fd)_
+  - [x] Orphan rule = a note with zero inbound `[[links]]` (excluding `daily/`, `raw-sources/`, inbox) _(131a72e)_
+- [x] A thin CLI wrapper with a **binary exit code** (rung 2): `exit 0` clean / `exit 1` + report
+      _(`scripts/lint-vault.mjs`, injected deps port · a193743)_
+- [x] An **engine skill** (`engine-skills/`) so the brain can run it conversationally and read the report
+      _(`engine-skills/lint/SKILL.md` · 767caad)_
+- [x] Wire into `update-engine` manifest so the fleet receives it (ADR 0012 / 0025)
+      _(manifest `replace` + `engineVersion.scripts` 1.1.0→1.2.0 · 767caad)_
+- [x] Measure: run against a **real** vault (see §Sequencing), not the 7-note demo — the demo cannot
+      exercise orphan/stale/dangling logic meaningfully _(405-note vault: found the path-form link
+      resolution bug — dangling 795→47, orphans 352→175 once fixed · 24b6c7f)_
 
 ## Track B — File the good answer back
 
@@ -110,8 +118,9 @@ artifacts**:
 
 **Recommendation (deterministic-first, validate on real not demo — [[validate-shipped-not-test-instance]]):**
 
-- [ ] **Build Track A (`/lint`) now, using the real local vault as the dev/test corpus** (read-only
+- [x] **Build Track A (`/lint`) now, using the real local vault as the dev/test corpus** (read-only
       fixture) — it is the linter's killer use case and its only honest test bed
+      _(done 2026-07-17 — the real vault immediately paid off by exposing the path-form link bug)_
 - [ ] **Then run the formal import** into the generated brain — by then the linter is ready to
       health-check the arriving notes, and the import becomes the linter's first real job (compile-on-
       ingestion, the Karpathy discipline applied to the migration itself)

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -1,11 +1,13 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🟢 Tracks A + B + C + F SHIPPED (2026-07-17). A = `/lint` wiki-health   -->
-<!-- scanner. B = `/file-back` deterministic filer (a filed note passes /lint       -->
-<!-- clean, never overwrites). C = `/consolidate`: a deterministic candidate finder -->
-<!-- (stateless "fresher-than-the-page" rule) + a fan-out/fan-in skill that writes  -->
-<!-- via B. F = a SessionStart trigger fires the scans on a real event and surfaces  -->
-<!-- them in the chat (Desktop-visible), the write stays confirmed. All TDD, all     -->
-<!-- proven on the real 405-note vault. Tracks D + E still prospective.              -->
+<!-- STATUS: 🟢 Tracks A + B + C + E + F SHIPPED (2026-07-17). A = `/lint` wiki-      -->
+<!-- health scanner. B = `/file-back` deterministic filer (a filed note passes /lint -->
+<!-- clean, never overwrites). C = `/consolidate`: a deterministic candidate finder  -->
+<!-- (stateless "fresher-than-the-page" rule) + a fan-out/fan-in skill that writes   -->
+<!-- via B. E = the append-only activity ledger (vault/actions-log.md) becomes a      -->
+<!-- seeded, first-class artifact, maintained by a SessionStart hook (seed-if-absent, -->
+<!-- never overwrites). F = a SessionStart trigger fires the scans on a real event    -->
+<!-- and surfaces them in the chat (Desktop-visible), the write stays confirmed. All  -->
+<!-- TDD, all proven on the real 405-note vault. Track D still prospective.           -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Action plan — give Axis 1 (wiki-health / consolidation) real mechanics
@@ -41,7 +43,7 @@
   - [x] Wired into `update-engine` manifest (`replace` + `scripts` 1.2.0→1.3.0); proven: filed note passes /lint clean
 - [x] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven _(2026-07-17 · deterministic candidate finder + `/consolidate` skill, TDD, proven on the real 405-note vault)_
 - [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
-- [ ] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect)
+- [x] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect) _(2026-07-17 · e2c71f4 · seeded ledger + SessionStart maintainer hook, TDD, proven end-to-end + on the real 405-note vault)_
 - [x] **Track F — Run the Axis-1 mechanics from a deterministic trigger** (a hook/event, not only on-demand) _(2026-07-17 · b81d937 · SessionStart hook `session-wiki-health.mjs` + pure `wiki-health-nudge` core, TDD, proven on the real 405-note vault)_
   - [x] `/lint` (read-only) auto-runs on a real event and surfaces its report _(SessionStart hook; only dangling links surface here, orphans/stale stay on-demand)_
   - [x] `/consolidate` **scan** auto-runs and surfaces candidates — the write stays confirmed (never auto-filed) _(scan only; the merge stays propose → yes)_
@@ -145,7 +147,26 @@ flags it for the user rather than letting the wiki hold two truths. Needs LLM ju
 **WHAT.** The append-only activity log becomes a seeded, maintained artifact (not a by-product of a
 `sync-sources` run), so the "what happened" ledger always exists.
 
-- [ ] Seed the artifact at install + maintain it via a hook bound to a real event (rung 3, ADR 0009)
+> **Shipped (2026-07-17 · e2c71f4).** Same three-rung shape as Tracks A/B/F. A pure core
+> (`scripts/lib/actions-log-seed.mjs`, 6 tests) owns the /lint-conformant seed content and a
+> write-if-absent fs seam that never overwrites real history; a SessionStart hook
+> (`scripts/session-actions-log.mjs`, 5 tests) is the maintainer on a real event. The seed carries
+> `type: log` frontmatter and fences its format example (so it is neither a frontmatter violation nor
+> a dangling link), and `actions-log.md` joins the linter's raw-zone orphan exclusion — proven
+> lint-clean through the real rung-2 reader. `sync-sources` (en + fr) reconciled: the ledger is now a
+> seeded artifact to append to. Wired fleet-wide (manifest `replace` + `scripts` 1.5.0 → 1.6.0,
+> settings template after `session-wiki-health`, delivered by `reconcileHooks` add-if-absent).
+
+- [x] Seed the artifact at install + maintain it via a hook bound to a real event (rung 3, ADR 0009)
+  - [x] Pure core: `/lint`-conformant seed content + write-if-absent fs seam (never overwrites) +
+        the SessionStart hook output builder (quiet unless it just seeded) _(6 tests)_
+  - [x] SessionStart hook seeds-if-absent on a real event → upgraders that never re-run the installer
+        still gain the ledger; a one-time chat note, then silent _(5 tests, fail-open)_
+  - [x] Installer seeds it for fresh brains from the first run
+  - [x] Linter: `actions-log.md` joins the raw-zone orphan exclusion (a grep-able ledger is not a wiki
+        node) — proven lint-clean on the real rung-2 reader; a fresh brain stays silent on day one
+  - [x] Wired fleet-wide (manifest `replace` + `scripts` 1.5.0 → 1.6.0, settings template, reconcileHooks);
+        `sync-sources` docs (en + fr) reconciled
 
 ## Track F — Run the Axis-1 mechanics from a deterministic trigger
 

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -1,13 +1,17 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🟢 Tracks A + B + C + E + F SHIPPED (2026-07-17). A = `/lint` wiki-      -->
-<!-- health scanner. B = `/file-back` deterministic filer (a filed note passes /lint -->
-<!-- clean, never overwrites). C = `/consolidate`: a deterministic candidate finder  -->
-<!-- (stateless "fresher-than-the-page" rule) + a fan-out/fan-in skill that writes   -->
-<!-- via B. E = the append-only activity ledger (vault/actions-log.md) becomes a      -->
-<!-- seeded, first-class artifact, maintained by a SessionStart hook (seed-if-absent, -->
-<!-- never overwrites). F = a SessionStart trigger fires the scans on a real event    -->
-<!-- and surfaces them in the chat (Desktop-visible), the write stays confirmed. All  -->
-<!-- TDD, all proven on the real 405-note vault. Track D still prospective.           -->
+<!-- STATUS: 🟢 Tracks A + B + C + D + E + F SHIPPED (A/B/C/E/F 2026-07-17, D 2026-  -->
+<!-- 07-18). A = `/lint` wiki-health scanner. B = `/file-back` deterministic filer   -->
+<!-- (a filed note passes /lint clean, never overwrites). C = `/consolidate`: a      -->
+<!-- deterministic candidate finder (stateless "fresher-than-the-page" rule) + a     -->
+<!-- fan-out/fan-in skill that writes via B. D = contradiction-flagging folded into  -->
+<!-- C's refresh pass (facts live in prose here → LLM judgment; the draft surfaces a  -->
+<!-- `### contradictions` block, the human adjudicates, nothing is silently           -->
+<!-- overwritten). E = the append-only activity ledger (vault/actions-log.md) becomes -->
+<!-- a seeded, first-class artifact, maintained by a SessionStart hook (seed-if-       -->
+<!-- absent, never overwrites). F = a SessionStart trigger fires the scans on a real  -->
+<!-- event and surfaces them in the chat (Desktop-visible), the write stays confirmed.-->
+<!-- All proven on the real 405-note vault. Remaining: cross-cutting retrieval        -->
+<!-- measurement + the formal private import (Thomas-side, see §Sequencing).          -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Action plan — give Axis 1 (wiki-health / consolidation) real mechanics
@@ -42,7 +46,7 @@
   - [x] Engine skill `engine-skills/file-back/SKILL.md` (propose → confirm → file; append path for living pages)
   - [x] Wired into `update-engine` manifest (`replace` + `scripts` 1.2.0→1.3.0); proven: filed note passes /lint clean
 - [x] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven _(2026-07-17 · deterministic candidate finder + `/consolidate` skill, TDD, proven on the real 405-note vault)_
-- [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
+- [x] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact _(2026-07-18 · folded into Track C's `/consolidate` refresh pass, skill 1.0.0→1.1.0, manifest `scripts` 1.6.0→1.7.0; flag-only, human adjudicates, never silently overwrites)_
 - [x] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect) _(2026-07-17 · e2c71f4 · seeded ledger + SessionStart maintainer hook, TDD, proven end-to-end + on the real 405-note vault)_
 - [x] **Track F — Run the Axis-1 mechanics from a deterministic trigger** (a hook/event, not only on-demand) _(2026-07-17 · b81d937 · SessionStart hook `session-wiki-health.mjs` + pure `wiki-health-nudge` core, TDD, proven on the real 405-note vault)_
   - [x] `/lint` (read-only) auto-runs on a real event and surfaces its report _(SessionStart hook; only dangling links surface here, orphans/stale stay on-demand)_
@@ -140,7 +144,34 @@ where the audit found the biggest gap (raw capture dominates; higher-order conso
 **WHAT.** When a new note asserts something that conflicts with an entity page's stated fact, the brain
 flags it for the user rather than letting the wiki hold two truths. Needs LLM judgment → later rung.
 
-- [ ] Fold into Track A's report or Track C's pass, not a standalone engine at first
+> **Shipped (2026-07-18).** Folded into Track C's `/consolidate` refresh pass exactly as this track
+> prescribed ("not a standalone engine at first"), skill `1.0.0 → 1.1.0`.
+>
+> **Why no deterministic engine (grounding, not laziness).** In this vault **facts live in prose**: the
+> living `people/` and `topics/` pages accrete *dated appended sections* (constitution §"Note format"),
+> and frontmatter is only metadata (`type/created/updated/tags`), never structured facts. So there is no
+> `field = A` vs `field = B` seam to diff deterministically, contradiction detection is irreducibly LLM
+> judgment over prose (rung 5+ of ADR 0009). Inventing a deterministic "contradiction engine" against a
+> prose corpus would be over-engineering against an unproven risk, so the detection rides the LLM merge
+> that Track C already runs, and the deterministic part is the pairing Track C *already* surfaces (a page
+> + the fresher captures citing it = the refresh candidates). No new finder was needed.
+>
+> **What changed.** The refresh drafting sub-agent now watches for a capture that CONFLICTS with a fact
+> the page states (changed role, reversed decision, different number/date/owner) and returns it under a
+> `### contradictions` block instead of folding it in as an addition. The propose step surfaces conflicts
+> FIRST and distinctly (⚠️ page says X, capture says Y); the user adjudicates (keep / adopt / dated
+> "as of" both); a contradicting claim is **never** appended without that explicit decision. Strictly
+> conservative: it can only make the human catch a conflict, it never makes the wiki worse.
+
+- [x] Fold into Track A's report or Track C's pass, not a standalone engine at first _(Track C's refresh
+      pass; see the shipped note above)_
+
+> **Optional deterministic complement (not built, needs Thomas's call).** A *structural* sibling that IS
+> deterministic and testable: flag **colliding entity pages** (two curated `person`/`topic` pages that
+> resolve to the same link key), the structural precondition for "the wiki holds two truths". That is a
+> different mechanic from semantic contradiction (it would fold into Track A's `/lint` report, TDD rung
+> 1), deliberately left out tonight to avoid substituting a deterministic proxy for the LLM feature Track
+> D actually asked for. Consider if false negatives from the LLM path prove to be a problem.
 
 ## Track E — Append-only log, first-class
 

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -1,0 +1,134 @@
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- STATUS: 🟡 PROSPECTIVE / NOT STARTED (created 2026-07-17). Nothing built yet. -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+
+# Action plan — give Axis 1 (wiki-health / consolidation) real mechanics
+
+> **Why this plan exists.** The study
+> [`llm-wiki-vs-embedding-rag-karpathy-graphify.md`](llm-wiki-vs-embedding-rag-karpathy-graphify.md)
+> (§8 audit) established that Kenjaku ships **Axis 2** (retrieval / RAG) as a full versioned, tested,
+> auto-updating engine, but ships **Axis 1** (the LLM-Wiki compile / consolidation discipline) as
+> **constitution conventions with zero enforcement**. This plan gives Axis 1 some *mechanics*. The
+> positioning / lineage rationale (we descend from Karpathy's LLM Wiki, not Graphify) lives in **ADR
+> 0033**.
+>
+> **Architectural placement.** These are **engine features**: they ship to the whole fleet via
+> `update-engine` (ADR 0012 packaging, ADR 0025 self-install of new engine skills/servers), they are
+> **generic** (never carry private content), and they honour the **determinism ladder** (ADR 0009 —
+> deterministic-first, LLM only where judgment is the point). They are **not** the import of any
+> private brain (that is a separate, private track — see §Sequencing).
+
+---
+
+## Tracking
+
+- [ ] **Track A — The brain can detect where its wiki is bleeding** (`/lint` wiki-health)
+  - [ ] Dangling `[[links]]` (target note missing)
+  - [ ] Orphan notes (zero inbound links)
+  - [ ] Stale entity pages (`updated:` old while cited in fresher notes)
+  - [ ] Frontmatter conformance (required `type` / `created` / `updated` / `tags`)
+  - [ ] Ship as an engine skill + a deterministic script, binary report
+- [ ] **Track B — The brain files a good answer back** into a durable note (semi-automatic, confirmed write)
+- [ ] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven
+- [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
+- [ ] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect)
+- [ ] **Cross-cutting — Measure the effect on retrieval** on the eval-set (better notes ⇒ better chunks)
+- [ ] **Sequencing decided** — import-before vs import-after (see §Sequencing; recommendation recorded)
+
+---
+
+## Track A — `/lint`: detect where the wiki is bleeding (start here)
+
+**WHAT.** The brain (and the user) can run one command and get an honest, binary health report of the
+vault: what links point nowhere, what notes nobody links to, what entity pages have gone stale, what
+frontmatter is malformed. This is the highest-leverage, lowest-risk Axis-1 mechanic and the most
+"Kenjaku" (deterministic, fail-loud).
+
+- [ ] A deterministic scanner (pure JS, injected fs) that, given a vault path, returns a structured
+      report: `danglingLinks[]`, `orphans[]`, `staleEntityPages[]`, `frontmatterViolations[]`
+  - [ ] TDD, rung 1 of the determinism ladder (ADR 0009): correctness in an I/O-free function, faked fs
+  - [ ] Stale rule = an entity page (`type: person|topic|…`) whose `updated:` predates the newest note
+        that `[[links]]` to it by more than a threshold (config, default e.g. 90 days)
+  - [ ] Orphan rule = a note with zero inbound `[[links]]` (excluding `daily/`, `raw-sources/`, inbox)
+- [ ] A thin CLI wrapper with a **binary exit code** (rung 2): `exit 0` clean / `exit 1` + report
+- [ ] An **engine skill** (`engine-skills/`) so the brain can run it conversationally and read the report
+- [ ] Wire into `update-engine` manifest so the fleet receives it (ADR 0012 / 0025)
+- [ ] Measure: run against a **real** vault (see §Sequencing), not the 7-note demo — the demo cannot
+      exercise orphan/stale/dangling logic meaningfully
+
+## Track B — File the good answer back
+
+**WHAT.** After a substantive exchange, the brain offers to distil the answer into a durable note
+(topic / decision / entity page) with backlinks, so hard-won synthesis stops evaporating at the end of
+a session. This is the "answers filed back" Karpathy discipline, absent today.
+
+- [ ] A convention + a light skill that proposes (never silently writes) a filed-back note, with a
+      suggested target zone and `[[links]]`
+  - [ ] Writes stay **confirmed** (brain posture) — propose, the user says yes
+  - [ ] Reuse the note taxonomy already documented in the constitution template
+
+## Track C — Consolidate raw captures into entity/topic pages
+
+**WHAT.** On demand (or scheduled), the brain reviews recent raw captures (`meetings/`, `daily/`) and
+**promotes / updates** the higher-order pages: propagate a newly-mentioned person into `people/`, merge
+topic fragments, weave backlinks. This is the heart of the compile discipline and where the audit found
+the biggest gap (raw capture dominates; higher-order consolidation lags).
+
+- [ ] A consolidation skill reusing the `sync-sources` fan-out/fan-in shape
+- [ ] Bounded, resumable, and honest about what it changed (a diff/report the user reviews)
+
+## Track D — (v2) Contradiction flagging
+
+**WHAT.** When a new note asserts something that conflicts with an entity page's stated fact, the brain
+flags it for the user rather than letting the wiki hold two truths. Needs LLM judgment → later rung.
+
+- [ ] Fold into Track A's report or Track C's pass, not a standalone engine at first
+
+## Track E — Append-only log, first-class
+
+**WHAT.** The append-only activity log becomes a seeded, maintained artifact (not a by-product of a
+`sync-sources` run), so the "what happened" ledger always exists.
+
+- [ ] Seed the artifact at install + maintain it via a hook bound to a real event (rung 3, ADR 0009)
+
+---
+
+## Sequencing — import the private brain BEFORE or AFTER building the linter?
+
+**The question (owner, 2026-07-17):** do I import my old brain first and then test the linter etc., or
+build the linter first and import after?
+
+**Key realisation that dissolves the dilemma.** These are **two different tracks on two different
+artifacts**:
+- The **linter / Axis-1 mechanics** are **engine features** (generic, ship to the fleet). Their
+  *development* needs a **real, messy, rich corpus** to be worth anything — the 7-note demo cannot
+  exercise orphan / stale / dangling logic.
+- The **import** moves **private content** into the personal brain (its own chantier:
+  [`second-brain-migration-and-engine-upstream-action.md`](second-brain-migration-and-engine-upstream-action.md)).
+- **We already have a real 733-note vault locally** (the originating private brain). So "having a real
+  corpus to build the linter against" is **available today** and does **not** block on the formal import.
+
+**Recommendation (deterministic-first, validate on real not demo — [[validate-shipped-not-test-instance]]):**
+
+- [ ] **Build Track A (`/lint`) now, using the real local vault as the dev/test corpus** (read-only
+      fixture) — it is the linter's killer use case and its only honest test bed
+- [ ] **Then run the formal import** into the generated brain — by then the linter is ready to
+      health-check the arriving notes, and the import becomes the linter's first real job (compile-on-
+      ingestion, the Karpathy discipline applied to the migration itself)
+- [ ] **Then iterate Track A + Track C against the imported vault** and measure on the eval-set
+
+> **In one line:** you don't have to choose. Build the linter **against the real vault you already
+> have** (independent of the migration's timing); run the **formal import once the linter exists** so
+> the imported notes land already health-checked. Only if the import is imminent anyway does
+> "import-first" become strictly better — the linter's *development* never has to wait for it.
+
+---
+
+## Related
+
+- Study: [`llm-wiki-vs-embedding-rag-karpathy-graphify.md`](llm-wiki-vs-embedding-rag-karpathy-graphify.md)
+- Positioning / lineage: [`../../decisions/0033-descends-from-karpathy-llm-wiki-not-graphify.md`](../../decisions/0033-descends-from-karpathy-llm-wiki-not-graphify.md)
+- Determinism ladder: [`../../decisions/0009-prefer-deterministic-mechanisms.md`](../../decisions/0009-prefer-deterministic-mechanisms.md)
+- Engine packaging / self-install: ADR 0012, ADR 0025
+- Import chantier (private content): [`second-brain-migration-and-engine-upstream-action.md`](second-brain-migration-and-engine-upstream-action.md)
+- Sibling RAG watch: [`etude-rag-local-criteres-et-veille.md`](etude-rag-local-criteres-et-veille.md)

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -220,8 +220,10 @@ never turning a silent auto-write loose.
       deterministic (`lintVault` + `consolidationCandidates`, rung 1), **surface** an `additionalContext`
       directive the agent relays in the chat (rung 6, the only Desktop-visible channel), **merge** stays
       LLM+confirmed on-demand.
-- [ ] Sibling to Track E (both are "maintain Axis 1 via a hook on a real event, not a by-product") — share
-      the wiring/lesson where they overlap _(Track E still prospective; reuse this hook's shape when built)_
+- [x] Sibling to Track E (both are "maintain Axis 1 via a hook on a real event, not a by-product"): the
+      wiring/lesson is shared _(E shipped 2026-07-17 and reused this exact shape — a SessionStart hook,
+      delivered add-if-absent by `reconcileHooks`, ordered in the settings template right after
+      `session-wiki-health`)_
 - [x] Keep the on-demand skills working unchanged; the hook is an **addition**, not a replacement
       (`/lint` and `/consolidate` skills untouched; the hook only reuses their pure cores)
 

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -41,6 +41,9 @@
 - [x] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven _(2026-07-17 · deterministic candidate finder + `/consolidate` skill, TDD, proven on the real 405-note vault)_
 - [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
 - [ ] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect)
+- [ ] **Track F — Run the Axis-1 mechanics from a deterministic trigger** (a hook/event, not only on-demand)
+  - [ ] `/lint` (read-only) auto-runs on a real event and surfaces its report
+  - [ ] `/consolidate` **scan** auto-runs and surfaces candidates — the write stays confirmed (never auto-filed)
 - [ ] **Cross-cutting — Measure the effect on retrieval** on the eval-set (better notes ⇒ better chunks)
 - [ ] **Sequencing decided** — import-before vs import-after (see §Sequencing; recommendation recorded)
 
@@ -142,6 +145,26 @@ flags it for the user rather than letting the wiki hold two truths. Needs LLM ju
 `sync-sources` run), so the "what happened" ledger always exists.
 
 - [ ] Seed the artifact at install + maintain it via a hook bound to a real event (rung 3, ADR 0009)
+
+## Track F — Run the Axis-1 mechanics from a deterministic trigger
+
+**WHAT (owner's ask, 2026-07-17).** Today `/lint` and `/consolidate` are **on-demand only** (a
+conversational trigger). The goal: let them fire **on their own**, from a **deterministic hook bound to a
+real event** (rung 3 of ADR 0009), so wiki-health stops depending on the user remembering to ask — while
+never turning a silent auto-write loose.
+
+- [ ] Pick the **event** (deterministic, verifiable): SessionStart, post-`sync-sources`, a periodic cron,
+      or a "N new captures since last pass" threshold — prefer a real event over a timer where possible
+- [ ] **`/lint` is read-only → safe to auto-run**: fire the scan on the chosen event, surface the report
+      (or stay silent when clean). No write, no confirmation needed.
+- [ ] **`/consolidate` writes → auto-run only the SCAN**: surface the candidates on the event, but the
+      merge/write **stays confirmed** (propose → the user says yes). Never auto-file. This is the load-
+      bearing guardrail — the brain's write posture must survive automation.
+- [ ] Honour the determinism ladder: the **trigger** is deterministic (hook/event), the **detection** is
+      deterministic (the pure cores already are), only the **merge** stays LLM+confirmed
+- [ ] Sibling to Track E (both are "maintain Axis 1 via a hook on a real event, not a by-product") — share
+      the wiring/lesson where they overlap
+- [ ] Keep the on-demand skills working unchanged; the hook is an **addition**, not a replacement
 
 ---
 

--- a/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
+++ b/maintainers/plans/prospective/wiki-health-axis1-mechanisms-action.md
@@ -1,7 +1,8 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🟢 Track A SHIPPED (2026-07-17). `/lint` wiki-health scanner built   -->
-<!-- in TDD, proven on the real 405-note vault, shipped as an engine skill.       -->
-<!-- Tracks B–E still prospective. -->
+<!-- STATUS: 🟢 Tracks A + B SHIPPED (2026-07-17). Track A = `/lint` wiki-health   -->
+<!-- scanner (TDD, proven on the real 405-note vault). Track B = `/file-back`      -->
+<!-- deterministic filer (TDD, proven: a filed note passes /lint clean, never      -->
+<!-- overwrites). Both are engine skills. Tracks C–E still prospective.            -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Action plan — give Axis 1 (wiki-health / consolidation) real mechanics
@@ -30,7 +31,11 @@
   - [x] Stale entity pages (`updated:` old while cited in fresher notes) _(2a509fd)_
   - [x] Frontmatter conformance (required `type` / `created` / `updated` / `tags`) _(2a509fd)_
   - [x] Ship as an engine skill + a deterministic script, binary report _(a193743, 767caad)_
-- [ ] **Track B — The brain files a good answer back** into a durable note (semi-automatic, confirmed write)
+- [x] **Track B — The brain files a good answer back** into a durable note (semi-automatic, confirmed write) _(2026-07-17 · `/file-back` engine skill + deterministic `filed-note` core, TDD)_
+  - [x] Deterministic core `scripts/lib/filed-note.mjs` (slugify, path, conformant render — 15 tests)
+  - [x] Thin CLI `scripts/file-back-note.mjs` (JSON spec on stdin, writes under vault/, never overwrites — 4 tests)
+  - [x] Engine skill `engine-skills/file-back/SKILL.md` (propose → confirm → file; append path for living pages)
+  - [x] Wired into `update-engine` manifest (`replace` + `scripts` 1.2.0→1.3.0); proven: filed note passes /lint clean
 - [ ] **Track C — The brain consolidates raw captures** into entity/topic pages, backlinks woven
 - [ ] **Track D — (v2) The brain flags contradictions** between a new note and an entity page's stated fact
 - [ ] **Track E — Append-only log is first-class** (seeded artifact + hook, not a `sync-sources` side-effect)
@@ -70,10 +75,18 @@ frontmatter is malformed. This is the highest-leverage, lowest-risk Axis-1 mecha
 (topic / decision / entity page) with backlinks, so hard-won synthesis stops evaporating at the end of
 a session. This is the "answers filed back" Karpathy discipline, absent today.
 
-- [ ] A convention + a light skill that proposes (never silently writes) a filed-back note, with a
-      suggested target zone and `[[links]]`
-  - [ ] Writes stay **confirmed** (brain posture) — propose, the user says yes
-  - [ ] Reuse the note taxonomy already documented in the constitution template
+- [x] A convention + a light skill that proposes (never silently writes) a filed-back note, with a
+      suggested target zone and `[[links]]` _(`engine-skills/file-back/SKILL.md`)_
+  - [x] Writes stay **confirmed** (brain posture) — propose, the user says yes _(SKILL step 2: propose → yes)_
+  - [x] Reuse the note taxonomy already documented in the constitution template _(`filed-note.mjs` FOLDER
+        map + dated types mirror CLAUDE.md.template §"Note format"; frontmatter conformant by construction)_
+
+> **Design note.** The deterministic kernel is the *note builder*, not the *judgment*: given a spec it
+> emits a taxonomy-conformant `{ path, content }` (right zone, complete frontmatter, woven `[[links]]`)
+> and **refuses to overwrite** — so a filed-back answer never re-introduces the defects Track A detects
+> (proven: `file-back-note.mjs` output passes `/lint` clean). Refining an *existing* living page stays a
+> confirmed conversational append (a dated section), which is the right rung of ADR 0009 for a
+> judgment-laden merge, not a risky YAML round-trip.
 
 ## Track C — Consolidate raw captures into entity/topic pages
 

--- a/scripts/consolidate-scan.mjs
+++ b/scripts/consolidate-scan.mjs
@@ -13,11 +13,16 @@
 //   node scripts/consolidate-scan.mjs            # scan ./vault
 //   node scripts/consolidate-scan.mjs <dir>      # scan another vault path
 // ─────────────────────────────────────────────────────────────────────────────
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
 import { consolidationCandidates, reportLines, hasCandidates } from "./lib/consolidation-candidates.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
+
+// The scanned vault dir is displayed (and passed to the reader) in POSIX form so
+// the output is identical across platforms — on Windows join() yields backslashes
+// and resolve() prepends a drive letter. Cf. installer toPosix / document-scanner.
+const toPosix = (p) => p.split("\\").join("/");
 
 // Real wiring — the side effects, injected so runConsolidateScan stays unit-testable.
 export const realConsolidateDeps = {
@@ -30,7 +35,7 @@ export const realConsolidateDeps = {
 // the process exit code: 0 nothing to consolidate, 1 candidates found. All side
 // effects come through `deps`.
 export function runConsolidateScan(argv, deps = realConsolidateDeps) {
-  const vaultDir = argv[0] ? resolve(argv[0]) : join(deps.cwd(), "vault");
+  const vaultDir = toPosix(argv[0] ? argv[0] : join(deps.cwd(), "vault"));
   const notes = deps.readNotes(vaultDir);
   const report = consolidationCandidates(notes);
   deps.log(`Scanned ${notes.length} notes under ${vaultDir}`);

--- a/scripts/consolidate-scan.mjs
+++ b/scripts/consolidate-scan.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// consolidate-scan.mjs — run FROM the brain folder to list what the wiki needs
+// consolidated (Axis 1, Track C): entity/person mentions in raw captures that
+// have no page yet (new-page candidates), and entity pages a fresher capture has
+// left behind (refresh candidates).
+//
+// Deterministic, fail-loud, binary (ADR 0009): it exits 0 when there is nothing
+// to consolidate / 1 when it finds candidates, so it composes in scripts. It is
+// READ-ONLY — the merge (judgment) is the `consolidate` skill's fan-out and the
+// write reuses Track B; this script only surfaces WHAT to consolidate.
+//
+//   node scripts/consolidate-scan.mjs            # scan ./vault
+//   node scripts/consolidate-scan.mjs <dir>      # scan another vault path
+// ─────────────────────────────────────────────────────────────────────────────
+import { join, resolve } from "node:path";
+
+import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
+import { consolidationCandidates, reportLines, hasCandidates } from "./lib/consolidation-candidates.mjs";
+import { isEntrypoint } from "./lib/entrypoint.mjs";
+
+// Real wiring — the side effects, injected so runConsolidateScan stays unit-testable.
+export const realConsolidateDeps = {
+  cwd: () => process.cwd(),
+  readNotes: readVaultNotes,
+  log: (...a) => console.log(...a),
+};
+
+// Scan the vault and print an honest list of consolidation candidates. Returns
+// the process exit code: 0 nothing to consolidate, 1 candidates found. All side
+// effects come through `deps`.
+export function runConsolidateScan(argv, deps = realConsolidateDeps) {
+  const vaultDir = argv[0] ? resolve(argv[0]) : join(deps.cwd(), "vault");
+  const notes = deps.readNotes(vaultDir);
+  const report = consolidationCandidates(notes);
+  deps.log(`Scanned ${notes.length} notes under ${vaultDir}`);
+  for (const line of reportLines(report)) deps.log(line);
+  return hasCandidates(report) ? 1 : 0;
+}
+
+if (isEntrypoint(import.meta.url, process.argv[1])) {
+  process.exit(runConsolidateScan(process.argv.slice(2)));
+}

--- a/scripts/consolidate-scan.test.mjs
+++ b/scripts/consolidate-scan.test.mjs
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runConsolidateScan } from "./consolidate-scan.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// consolidate-scan — the thin CLI glue over the pure Track C candidate core. It
+// reads the vault and prints an honest list of what needs consolidating, with a
+// binary exit code (0 nothing to consolidate / 1 candidates found), so it
+// composes in scripts. All side effects come through an injected `deps` port so
+// the glue itself is unit-testable (no untestable top-level side effects).
+// ═══════════════════════════════════════════════════════════════════════════
+
+function fakeDeps(overrides = {}) {
+  const logs = [];
+  const seenDirs = [];
+  const deps = {
+    cwd: () => "/brain",
+    readNotes: (dir) => {
+      seenDirs.push(dir);
+      return [];
+    },
+    log: (line) => logs.push(line),
+    ...overrides,
+  };
+  return { deps, logs, seenDirs };
+}
+
+test("runConsolidateScan — a vault with nothing to consolidate prints the count + clean line and exits 0", () => {
+  const { deps, logs, seenDirs } = fakeDeps();
+  const code = runConsolidateScan([], deps);
+  assert.equal(code, 0);
+  assert.deepEqual(seenDirs, ["/brain/vault"]);
+  assert.deepEqual(logs, ["Scanned 0 notes under /brain/vault", "✓ Nothing to consolidate"]);
+});
+
+test("runConsolidateScan — a vault with candidates prints the report and exits 1", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "[[Marie Dupont]] a tranché.",
+    },
+  ];
+  const { deps, logs } = fakeDeps({ readNotes: () => notes });
+  const code = runConsolidateScan([], deps);
+  assert.equal(code, 1);
+  assert.equal(logs[0], "Scanned 1 notes under /brain/vault");
+  assert.ok(logs.includes("✗ Consolidation candidates found"), "prints the candidates header");
+  assert.ok(
+    logs.includes("  [[Marie Dupont]] — cited by 1: meetings/2026-07-15-revue.md"),
+    "lists the new-page candidate",
+  );
+});
+
+test("runConsolidateScan — an explicit path argument overrides the default ./vault", () => {
+  const { deps, seenDirs } = fakeDeps();
+  runConsolidateScan(["/data/other-vault"], deps);
+  assert.deepEqual(seenDirs, ["/data/other-vault"]);
+});

--- a/scripts/file-back-note.mjs
+++ b/scripts/file-back-note.mjs
@@ -20,6 +20,12 @@ import { dirname, join } from "node:path";
 import { renderFiledNote } from "./lib/filed-note.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
 
+// Vault paths are displayed, compared and written in POSIX form so behaviour is
+// identical across platforms — on Windows join() yields backslashes, which would
+// break the string match against the vault path and the existence check. Cf.
+// installer toPosix / document-scanner.
+const toPosix = (p) => p.split("\\").join("/");
+
 // Real wiring — the side effects, injected so runFileBack stays unit-testable.
 export const realFileBackDeps = {
   cwd: () => process.cwd(),
@@ -53,7 +59,7 @@ export function runFileBack(argv, deps = realFileBackDeps) {
     return 1;
   }
 
-  const absPath = join(deps.cwd(), "vault", note.path);
+  const absPath = toPosix(join(deps.cwd(), "vault", note.path));
   if (deps.exists(absPath)) {
     deps.error(
       `✗ vault/${note.path} already exists — filing back never overwrites. ` +

--- a/scripts/file-back-note.mjs
+++ b/scripts/file-back-note.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// file-back-note.mjs — run FROM the brain folder to file a distilled answer back
+// into the vault as a durable, taxonomy-conformant note (Axis 1, Track B).
+//
+// Deterministic, fail-loud, binary (ADR 0009): it reads a JSON filing spec on
+// stdin, stamps today's date, and writes a note whose path + frontmatter + woven
+// [[links]] are conformant BY CONSTRUCTION (so `/lint` stays green on it). It
+// NEVER overwrites an existing note — filing back is additive; refining a living
+// page is a confirmed, conversational gesture, not a silent clobber.
+//
+//   echo '<json spec>' | node scripts/file-back-note.mjs
+//
+// Spec: { type, title, tags[], body, links?[], date? } — date required for
+// dated types (decision, meeting). Exits 0 when written, 1 when refused/error.
+// ─────────────────────────────────────────────────────────────────────────────
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { renderFiledNote } from "./lib/filed-note.mjs";
+import { isEntrypoint } from "./lib/entrypoint.mjs";
+
+// Real wiring — the side effects, injected so runFileBack stays unit-testable.
+export const realFileBackDeps = {
+  cwd: () => process.cwd(),
+  today: () => new Date().toISOString().slice(0, 10),
+  readInput: () => readFileSync(0, "utf8"),
+  exists: (p) => existsSync(p),
+  writeFile: (p, content) => {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, content);
+  },
+  log: (...a) => console.log(...a),
+  error: (...a) => console.error(...a),
+};
+
+// Read a JSON filing spec, render a conformant note, and write it under the
+// brain's vault/. Returns the process exit code: 0 written, 1 refused/error.
+export function runFileBack(argv, deps = realFileBackDeps) {
+  let spec;
+  try {
+    spec = JSON.parse(deps.readInput());
+  } catch (err) {
+    deps.error(`✗ Invalid JSON spec on stdin: ${err.message}`);
+    return 1;
+  }
+
+  let note;
+  try {
+    note = renderFiledNote({ ...spec, today: deps.today() });
+  } catch (err) {
+    deps.error(`✗ ${err.message}`);
+    return 1;
+  }
+
+  const absPath = join(deps.cwd(), "vault", note.path);
+  if (deps.exists(absPath)) {
+    deps.error(
+      `✗ vault/${note.path} already exists — filing back never overwrites. ` +
+        `Refine that living page by appending a dated section instead.`,
+    );
+    return 1;
+  }
+
+  deps.writeFile(absPath, note.content);
+  deps.log(`✓ Filed back: vault/${note.path}`);
+  return 0;
+}
+
+if (isEntrypoint(import.meta.url, process.argv[1])) {
+  process.exit(runFileBack(process.argv.slice(2)));
+}

--- a/scripts/file-back-note.test.mjs
+++ b/scripts/file-back-note.test.mjs
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runFileBack } from "./file-back-note.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// file-back-note — the thin CLI glue over the pure filed-note core (ADR 0009
+// rung 2). It reads a JSON filing spec on stdin, injects today's date, writes a
+// taxonomy-conformant note under vault/, and NEVER overwrites (fail-loud). All
+// side effects come through an injected `deps` port so the glue stays testable.
+// Binary exit: 0 written / 1 refused-or-error.
+// ═══════════════════════════════════════════════════════════════════════════
+
+function fakeDeps(overrides = {}) {
+  const logs = [];
+  const errors = [];
+  const writes = [];
+  const existing = new Set(overrides.existing ?? []);
+  const deps = {
+    cwd: () => "/brain",
+    today: () => "2026-07-17",
+    readInput: () => overrides.input ?? "{}",
+    exists: (p) => existing.has(p),
+    writeFile: (p, content) => writes.push({ path: p, content }),
+    log: (line) => logs.push(line),
+    error: (line) => errors.push(line),
+  };
+  return { deps, logs, errors, writes };
+}
+
+test("runFileBack — writes a conformant note under vault/, logs the path, exits 0", () => {
+  const spec = JSON.stringify({
+    type: "topic",
+    title: "Capacity Management",
+    tags: ["rag"],
+    body: "The distilled answer.",
+    links: ["topics/rag"],
+  });
+  const { deps, logs, writes } = fakeDeps({ input: spec });
+  const code = runFileBack([], deps);
+  assert.equal(code, 0);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].path, "/brain/vault/topics/capacity-management.md");
+  assert.match(writes[0].content, /^---\ntype: topic\ncreated: 2026-07-17\nupdated: 2026-07-17\n/);
+  assert.match(writes[0].content, /## Related\n\n- \[\[topics\/rag\]\]\n$/);
+  assert.deepEqual(logs, ["✓ Filed back: vault/topics/capacity-management.md"]);
+});
+
+test("runFileBack — refuses to overwrite an existing note, writes nothing, exits 1", () => {
+  const spec = JSON.stringify({ type: "topic", title: "RAG", tags: ["x"], body: "b" });
+  const { deps, errors, writes } = fakeDeps({
+    input: spec,
+    existing: ["/brain/vault/topics/rag.md"],
+  });
+  const code = runFileBack([], deps);
+  assert.equal(code, 1);
+  assert.equal(writes.length, 0);
+  assert.match(errors[0], /topics\/rag\.md already exists.*never overwrites/i);
+});
+
+test("runFileBack — invalid JSON on stdin is a fail-loud error, exits 1", () => {
+  const { deps, errors, writes } = fakeDeps({ input: "{not json" });
+  const code = runFileBack([], deps);
+  assert.equal(code, 1);
+  assert.equal(writes.length, 0);
+  assert.match(errors[0], /invalid json spec/i);
+});
+
+test("runFileBack — a spec the core rejects (empty tags) surfaces as exit 1, no write", () => {
+  const spec = JSON.stringify({ type: "topic", title: "X", tags: [], body: "b" });
+  const { deps, errors, writes } = fakeDeps({ input: spec });
+  const code = runFileBack([], deps);
+  assert.equal(code, 1);
+  assert.equal(writes.length, 0);
+  assert.match(errors[0], /at least one tag|non-empty/i);
+});

--- a/scripts/lib/actions-log-seed.mjs
+++ b/scripts/lib/actions-log-seed.mjs
@@ -1,0 +1,79 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// actions-log-seed.mjs — Track E: make the append-only activity ledger a SEEDED,
+// first-class artifact instead of a `sync-sources` side-effect. This is the pure
+// core (ADR 0009 rung 1): the seed CONTENT and the SessionStart hook OUTPUT, both
+// I/O-free. The fs write-if-absent seam lives below (`seedActionsLog`), mirroring
+// staged-health-note.mjs.
+//
+// The seed is /lint-conformant BY CONSTRUCTION so a freshly-seeded brain stays
+// clean (Track F "silent on day one"): it carries the required frontmatter, is a
+// non-entity `type: log` (never stale), the linter orphan-excludes it (a grep-able
+// ledger is a raw zone, like daily/), and the format example lives in a code fence
+// so `extractWikiLinks` never mistakes it for a real (dangling) link.
+// ─────────────────────────────────────────────────────────────────────────────
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+// The ledger's canonical home — the exact path `sync-sources` appends to (Step 5).
+export const ACTIONS_LOG_REL = "vault/actions-log.md";
+
+// The initial ledger: conformant frontmatter + a header that documents the
+// append-only, grep-able convention, with the entry format shown inside a code
+// fence (so it is documentation, not a linkified `[[link]]`). `today` is injected
+// (no ambient clock in the pure core) as an ISO `YYYY-MM-DD` string.
+export function initialActionsLog(today) {
+  return `---
+type: log
+created: ${today}
+updated: ${today}
+tags: [activity-log, ledger]
+---
+
+# Activity log
+
+Append-only ledger of what you did through this brain — one flat line per action,
+newest appended at the bottom, never rewritten (a grep-able file). \`sync-sources\`
+appends here automatically; you can append by hand too.
+
+Format — one \`##\` line per action:
+
+\`\`\`markdown
+## [YYYY-MM-DD] <action> — #channel [[people/recipient]]
+\`\`\`
+
+Usage: *"what did I do about X?"* → \`grep -i "X" ${ACTIONS_LOG_REL}\`.
+`;
+}
+
+// Write the initial ledger into the brain if it is not already there — the fs seam
+// (ADR 0009 rung 2). NEVER overwrites an existing ledger (it may hold real history).
+// Idempotent: safe to call at install AND on every SessionStart. Returns whether it
+// wrote this time (`seeded`) and whether the ledger is now present (`present`).
+export function seedActionsLog({ brainDir, today }) {
+  const dest = join(brainDir, ACTIONS_LOG_REL);
+  if (existsSync(dest)) return { seeded: false, present: true };
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, initialActionsLog(today));
+  return { seeded: true, present: existsSync(dest) };
+}
+
+// Wrap the seed outcome into the SessionStart hook output — or null when nothing
+// was seeded (the ledger already existed → stay SILENT, the noise guardrail Track F
+// locked). Mirrors buildWikiHealthHookOutput: the only Desktop-visible channel is
+// the chat, so the note rides `additionalContext` as a DIRECTIVE the agent relays,
+// once, when an upgrader's brain first gains the ledger. `systemMessage` is kept for
+// the CLI (dropped on Desktop, harmless).
+export function buildActionsLogHookOutput(seeded) {
+  if (!seeded) return null;
+  return {
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext:
+        `[activity-log] I just created your append-only activity ledger at ${ACTIONS_LOG_REL}. ` +
+        `Early in your next reply, briefly and in the user's language, mention it once: it is where ` +
+        `sync-sources appends one grep-able line per action taken through the brain (and where you ` +
+        `can file actions by hand). Mention it a single time, do not nag.`,
+    },
+    systemMessage: `Created the append-only activity ledger (${ACTIONS_LOG_REL}).`,
+  };
+}

--- a/scripts/lib/actions-log-seed.test.mjs
+++ b/scripts/lib/actions-log-seed.test.mjs
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  initialActionsLog,
+  seedActionsLog,
+  buildActionsLogHookOutput,
+  ACTIONS_LOG_REL,
+} from "./actions-log-seed.mjs";
+import { extractWikiLinks } from "./wiki-lint.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Track E — the append-only activity ledger becomes a seeded, first-class
+// artifact. These tests lock the two properties the seed MUST hold: it is
+// /lint-conformant (frontmatter + no dangling link from the format example) so a
+// freshly-seeded brain stays lint-clean, and it matches the sync-sources append
+// convention so appends keep working.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("initialActionsLog — carries conformant frontmatter dated with the injected day", () => {
+  const seed = initialActionsLog("2026-07-17");
+  assert.match(seed, /^---\n/);
+  assert.match(seed, /\ntype: log\n/);
+  assert.match(seed, /\ncreated: 2026-07-17\n/);
+  assert.match(seed, /\nupdated: 2026-07-17\n/);
+  assert.match(seed, /\ntags: \[[^\]]+\]\n/);
+});
+
+test("initialActionsLog — the format example is fenced, so it yields no dangling link", () => {
+  const seed = initialActionsLog("2026-07-17");
+  const body = seed.replace(/^---\n[\s\S]*?\n---\n/, "");
+  assert.deepEqual(extractWikiLinks(body), []);
+});
+
+test("seedActionsLog — writes the initial ledger when absent, reports it seeded", () => {
+  const brainDir = mkdtempSync(join(tmpdir(), "actions-log-"));
+  const result = seedActionsLog({ brainDir, today: "2026-07-17" });
+  assert.deepEqual(result, { seeded: true, present: true });
+  assert.equal(
+    readFileSync(join(brainDir, ACTIONS_LOG_REL), "utf8"),
+    initialActionsLog("2026-07-17"),
+  );
+});
+
+test("seedActionsLog — never overwrites an existing ledger, reports not seeded", () => {
+  const brainDir = mkdtempSync(join(tmpdir(), "actions-log-"));
+  const dest = join(brainDir, ACTIONS_LOG_REL);
+  mkdirSync(join(brainDir, "vault"), { recursive: true });
+  writeFileSync(dest, "## [2026-07-10] shipped Track E — #eng [[people/thomas]]\n");
+
+  const result = seedActionsLog({ brainDir, today: "2026-07-17" });
+
+  assert.deepEqual(result, { seeded: false, present: true });
+  assert.equal(readFileSync(dest, "utf8"), "## [2026-07-10] shipped Track E — #eng [[people/thomas]]\n");
+});
+
+test("buildActionsLogHookOutput — surfaces a one-time note when it just seeded the ledger", () => {
+  const output = buildActionsLogHookOutput(true);
+  assert.equal(output.hookSpecificOutput.hookEventName, "SessionStart");
+  assert.match(output.hookSpecificOutput.additionalContext, /actions-log\.md/);
+  assert.match(output.hookSpecificOutput.additionalContext, /append/i);
+  assert.match(output.systemMessage, /ledger/i);
+});
+
+test("buildActionsLogHookOutput — stays silent (null) when nothing was seeded", () => {
+  assert.equal(buildActionsLogHookOutput(false), null);
+});

--- a/scripts/lib/consolidation-candidates.mjs
+++ b/scripts/lib/consolidation-candidates.mjs
@@ -1,0 +1,116 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// consolidation-candidates.mjs — the pure, I/O-free core of the Axis-1 Track C
+// consolidation gesture (ADR 0009 rung 1: correctness lives in a function with no
+// I/O). Given already-parsed notes it surfaces WHAT needs consolidating, grouped
+// by target page, so the LLM fan-out (sync-sources shape) only has to do the
+// merge (judgment) and the write reuses Track B's deterministic builder.
+//
+// Resumability is STATELESS (no state file to seed or corrupt): a capture drives
+// consolidation purely because it is fresher than the page it feeds — or that
+// page doesn't exist yet. Once a page is refreshed its `updated:` moves past the
+// capture, so the candidate drops off on its own.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { extractWikiLinks, buildResolver } from "./wiki-lint.mjs";
+
+// Path prefixes whose notes are raw captures — the inputs consolidation promotes
+// FROM (meeting notes, daily logs, transcripts, inbox dumps).
+const DEFAULT_CAPTURE_ZONES = ["meetings/", "daily/", "raw-sources/", "inbox/"];
+
+// Frontmatter `type` values that make a note a curated entity/topic page — the
+// pages consolidation promotes INTO (and the only ones a fresher capture can
+// mark for refresh). Mirrors the stale rule's entity set in wiki-lint.
+const DEFAULT_ENTITY_TYPES = ["person", "topic", "company", "project", "concept"];
+
+function isCapture(path, captureZones) {
+  return captureZones.some((prefix) => path.startsWith(prefix));
+}
+
+// Record `source` under `key` in a group map (key → path → source), deduping by
+// source path so a capture citing the same target twice counts once.
+function addSource(groups, key, source) {
+  if (!groups.has(key)) groups.set(key, new Map());
+  groups.get(key).set(source.path, source);
+}
+
+// Materialize a group map into candidates, deterministically: groups sorted by
+// key, each group's sources sorted by path, then projected through `build`.
+function sortedCandidates(groups, build) {
+  return [...groups.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, sources]) =>
+      build(key, [...sources.values()].sort((a, b) => a.path.localeCompare(b.path))),
+    );
+}
+
+// Scan already-parsed `notes` ({ path, frontmatter, body }) and report the
+// consolidation candidates, grouped by target page. Pure: no I/O, deterministic.
+export function consolidationCandidates(notes, options = {}) {
+  const captureZones = options.captureZones ?? DEFAULT_CAPTURE_ZONES;
+  const entityTypes = options.entityTypes ?? DEFAULT_ENTITY_TYPES;
+  const resolve = buildResolver(notes);
+  const byPath = new Map(notes.map((n) => [n.path, n]));
+
+  // Group the captures' unresolved mentions by target page (new-page candidates),
+  // and the fresher-than-their-page mentions by resolved page (refresh candidates).
+  const newPageSources = new Map(); // target → Map(sourcePath → { path, updated })
+  const refreshSources = new Map(); // page path → Map(sourcePath → { path, updated })
+  for (const note of notes) {
+    if (!isCapture(note.path, captureZones)) continue;
+    const source = { path: note.path, updated: note.frontmatter.updated };
+    for (const target of extractWikiLinks(note.body)) {
+      const resolved = resolve(target);
+      if (!resolved) {
+        addSource(newPageSources, target, source); // no page yet → new-page candidate
+        continue;
+      }
+      // Resolves to an existing page: a refresh candidate when that page is a
+      // curated entity/topic left behind — the capture is fresher than its `updated:`.
+      const page = byPath.get(resolved);
+      if (!entityTypes.includes(page.frontmatter.type)) continue;
+      if (!(Date.parse(source.updated) > Date.parse(page.frontmatter.updated))) continue;
+      addSource(refreshSources, resolved, source);
+    }
+  }
+  const newPages = sortedCandidates(newPageSources, (target, sources) => ({ target, sources }));
+  const refreshes = sortedCandidates(refreshSources, (page, sources) => ({
+    page,
+    updated: byPath.get(page).frontmatter.updated,
+    sources,
+  }));
+  return { newPages, refreshes };
+}
+
+// True when the report holds at least one candidate in either category — the
+// signal the CLI turns into a binary exit code (0 nothing to consolidate / 1).
+export function hasCandidates(report) {
+  return report.newPages.length > 0 || report.refreshes.length > 0;
+}
+
+// The report as human-readable lines. Honest and binary: one reassuring line
+// when there's nothing to consolidate, one titled section per category otherwise.
+export function reportLines(report) {
+  if (!hasCandidates(report)) return ["✓ Nothing to consolidate"];
+  const lines = ["✗ Consolidation candidates found"];
+  const section = (title, items) => {
+    if (items.length === 0) return;
+    lines.push("", `${title} (${items.length}):`);
+    for (const item of items) lines.push(`  ${item}`);
+  };
+  section(
+    "New pages to create",
+    report.newPages.map(
+      (c) => `[[${c.target}]] — cited by ${c.sources.length}: ${c.sources.map((s) => s.path).join(", ")}`,
+    ),
+  );
+  section(
+    "Entity pages to refresh",
+    report.refreshes.map(
+      (r) =>
+        `${r.page} (updated ${r.updated}) — ${r.sources.length} fresher: ${r.sources
+          .map((s) => s.path)
+          .join(", ")}`,
+    ),
+  );
+  return lines;
+}

--- a/scripts/lib/consolidation-candidates.test.mjs
+++ b/scripts/lib/consolidation-candidates.test.mjs
@@ -1,0 +1,285 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { consolidationCandidates, hasCandidates, reportLines } from "./consolidation-candidates.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// consolidation-candidates — the pure, I/O-free core of Track C ("consolidate
+// raw captures into entity/topic pages", ADR 0009 rung 1). Given already-parsed
+// notes it surfaces WHAT needs consolidating, grouped by target page: entity
+// mentions that lack a page (new-page candidates) and entity pages a fresher
+// capture has left behind (refresh candidates). Resumability is STATELESS: a
+// capture is a candidate purely because it is fresher than the page it feeds
+// (or that page doesn't exist yet). The LLM fan-out does the merge; the write
+// reuses Track B. Reuses Track A's link extraction + resolver + note shape.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("consolidationCandidates — an empty vault yields no candidates", () => {
+  assert.deepEqual(consolidationCandidates([]), { newPages: [], refreshes: [] });
+});
+
+test("consolidationCandidates — only captures drive candidates; a curated page's mention is ignored", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "[[Marie Dupont]] a tranché.",
+    },
+    {
+      path: "topics/rag.md",
+      frontmatter: { type: "topic", updated: "2026-07-15" },
+      body: "See [[Some Missing Concept]].",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), {
+    newPages: [
+      { target: "Marie Dupont", sources: [{ path: "meetings/2026-07-15-revue.md", updated: "2026-07-15" }] },
+    ],
+    refreshes: [],
+  });
+});
+
+test("consolidationCandidates — the same missing target across two captures groups into one candidate, sources sorted", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-16-suivi.md",
+      frontmatter: { type: "meeting", updated: "2026-07-16" },
+      body: "Point avec [[Marie Dupont]].",
+    },
+    {
+      path: "daily/2026-07-15.md",
+      frontmatter: { type: "daily", updated: "2026-07-15" },
+      body: "Échange [[Marie Dupont]] sur le RAG.",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), {
+    newPages: [
+      {
+        target: "Marie Dupont",
+        sources: [
+          { path: "daily/2026-07-15.md", updated: "2026-07-15" },
+          { path: "meetings/2026-07-16-suivi.md", updated: "2026-07-16" },
+        ],
+      },
+    ],
+    refreshes: [],
+  });
+});
+
+test("consolidationCandidates — distinct new-page candidates come out sorted by target (deterministic)", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "[[Zoe Zeta]] then [[Alice Alpha]].",
+    },
+  ];
+  assert.deepEqual(
+    consolidationCandidates(notes).newPages.map((c) => c.target),
+    ["Alice Alpha", "Zoe Zeta"],
+  );
+});
+
+test("consolidationCandidates — a mention resolving to an existing (not-stale) page is not a new-page candidate", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "[[people/marie-dupont]] a tranché.",
+    },
+    {
+      path: "people/marie-dupont.md",
+      frontmatter: { type: "person", updated: "2026-07-15" },
+      body: "Head of Platform.",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), { newPages: [], refreshes: [] });
+});
+
+// ── refresh candidates: an entity page a fresher capture has left behind ───────
+
+test("consolidationCandidates — an entity page older than a capture citing it is a refresh candidate", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "On a reparlé de [[topics/rag]] en profondeur.",
+    },
+    {
+      path: "topics/rag.md",
+      frontmatter: { type: "topic", updated: "2026-04-01" },
+      body: "Retrieval-augmented generation.",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), {
+    newPages: [],
+    refreshes: [
+      {
+        page: "topics/rag.md",
+        updated: "2026-04-01",
+        sources: [{ path: "meetings/2026-07-15-revue.md", updated: "2026-07-15" }],
+      },
+    ],
+  });
+});
+
+test("consolidationCandidates — refreshes group multiple fresher captures per page and come out sorted", () => {
+  const notes = [
+    { path: "topics/rag.md", frontmatter: { type: "topic", updated: "2026-04-01" }, body: "RAG." },
+    { path: "people/alice.md", frontmatter: { type: "person", updated: "2026-03-01" }, body: "Alice." },
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "Reparlé de [[topics/rag]].",
+    },
+    {
+      path: "daily/2026-07-16.md",
+      frontmatter: { type: "daily", updated: "2026-07-16" },
+      body: "[[topics/rag]] et [[people/alice]].",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), {
+    newPages: [],
+    refreshes: [
+      {
+        page: "people/alice.md",
+        updated: "2026-03-01",
+        sources: [{ path: "daily/2026-07-16.md", updated: "2026-07-16" }],
+      },
+      {
+        page: "topics/rag.md",
+        updated: "2026-04-01",
+        sources: [
+          { path: "daily/2026-07-16.md", updated: "2026-07-16" },
+          { path: "meetings/2026-07-15-revue.md", updated: "2026-07-15" },
+        ],
+      },
+    ],
+  });
+});
+
+test("consolidationCandidates — a capture with no updated date can't be proven fresher, so it's no refresh (fail-safe)", () => {
+  const notes = [
+    {
+      path: "daily/2026-07-15.md",
+      frontmatter: { type: "daily" }, // no `updated` → freshness unknown
+      body: "[[topics/rag]] encore.",
+    },
+    { path: "topics/rag.md", frontmatter: { type: "topic", updated: "2026-01-01" }, body: "RAG." },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), { newPages: [], refreshes: [] });
+});
+
+test("consolidationCandidates — captureZones is configurable: a bespoke zone drives candidates, defaults don't", () => {
+  const notes = [
+    {
+      path: "journal/2026-07-15.md",
+      frontmatter: { type: "journal", updated: "2026-07-15" },
+      body: "[[Marie Dupont]].",
+    },
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "[[Someone Else]].",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes, { captureZones: ["journal/"] }), {
+    newPages: [
+      { target: "Marie Dupont", sources: [{ path: "journal/2026-07-15.md", updated: "2026-07-15" }] },
+    ],
+    refreshes: [],
+  });
+});
+
+test("consolidationCandidates — an entity page fresher than the capture citing it is not a refresh candidate", () => {
+  const notes = [
+    {
+      path: "meetings/2026-04-01-vieux.md",
+      frontmatter: { type: "meeting", updated: "2026-04-01" },
+      body: "Première mention de [[topics/rag]].",
+    },
+    {
+      path: "topics/rag.md",
+      frontmatter: { type: "topic", updated: "2026-07-15" },
+      body: "Retrieval-augmented generation, à jour.",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), { newPages: [], refreshes: [] });
+});
+
+test("consolidationCandidates — a capture citing a resolved NON-entity note (another capture) is not a refresh", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-16-suivi.md",
+      frontmatter: { type: "meeting", updated: "2026-07-16" },
+      body: "Fait suite à [[meetings/2026-07-15-revue]].",
+    },
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "Revue archi.",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), { newPages: [], refreshes: [] });
+});
+
+// ── new-page candidates: an entity mentioned in a capture but with no page ─────
+
+test("consolidationCandidates — a capture's unresolved mention is a new-page candidate", () => {
+  const notes = [
+    {
+      path: "meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "[[Marie Dupont]] a tranché : on part sur du RAG local.",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), {
+    newPages: [
+      { target: "Marie Dupont", sources: [{ path: "meetings/2026-07-15-revue.md", updated: "2026-07-15" }] },
+    ],
+    refreshes: [],
+  });
+});
+
+// ── hasCandidates: the binary signal the CLI turns into an exit code ───────────
+
+test("hasCandidates — an empty report is false (nothing to consolidate)", () => {
+  assert.equal(hasCandidates({ newPages: [], refreshes: [] }), false);
+});
+
+test("hasCandidates — true when only new-page candidates exist", () => {
+  assert.equal(hasCandidates({ newPages: [{ target: "X", sources: [] }], refreshes: [] }), true);
+});
+
+test("hasCandidates — true when only refresh candidates exist", () => {
+  assert.equal(hasCandidates({ newPages: [], refreshes: [{ page: "topics/x.md", updated: "2026-01-01", sources: [] }] }), true);
+});
+
+// ── reportLines: an honest, human-readable rendering of the candidates ─────────
+
+test("reportLines — a clean report is one reassuring line (nothing to consolidate)", () => {
+  assert.deepEqual(reportLines({ newPages: [], refreshes: [] }), ["✓ Nothing to consolidate"]);
+});
+
+test("reportLines — renders both sections with counts, sources, and a titled header", () => {
+  const report = {
+    newPages: [
+      {
+        target: "Marie Dupont",
+        sources: [{ path: "daily/2026-07-15.md" }, { path: "meetings/2026-07-16.md" }],
+      },
+    ],
+    refreshes: [
+      { page: "topics/rag.md", updated: "2026-04-01", sources: [{ path: "meetings/2026-07-15-revue.md" }] },
+    ],
+  };
+  assert.deepEqual(reportLines(report), [
+    "✗ Consolidation candidates found",
+    "",
+    "New pages to create (1):",
+    "  [[Marie Dupont]] — cited by 2: daily/2026-07-15.md, meetings/2026-07-16.md",
+    "",
+    "Entity pages to refresh (1):",
+    "  topics/rag.md (updated 2026-04-01) — 1 fresher: meetings/2026-07-15-revue.md",
+  ]);
+});

--- a/scripts/lib/filed-note.mjs
+++ b/scripts/lib/filed-note.mjs
@@ -1,0 +1,75 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// filed-note.mjs — the pure, I/O-free core of Track B ("file the good answer
+// back", ADR 0009 rung 1: correctness in a function with no I/O). Given a filing
+// spec it builds a note that is conformant to the vault taxonomy BY CONSTRUCTION:
+// the right path, complete frontmatter (type/created/updated/tags), and woven
+// [[links]] — so a filed-back answer never re-introduces the defects the `/lint`
+// scanner (Track A) reports. A thin CLI (rung 2) injects the date and the fs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Turn a human title into a filename-safe slug: lowercased, accent-stripped,
+// kebab-case (e.g. "Jane Doe" → "jane-doe").
+export function slugify(title) {
+  const slug = title
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // strip combining accent marks
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-") // any run of non-alphanumerics → one hyphen
+    .replace(/^-+|-+$/g, ""); // trim leading/trailing hyphens
+  if (slug === "") throw new Error(`empty slug: title "${title}" has no slug-able characters`);
+  return slug;
+}
+
+// The vault folder each note type lives in (mirrors the constitution taxonomy).
+const FOLDER = {
+  person: "people",
+  topic: "topics",
+  decision: "decisions",
+  meeting: "meetings",
+};
+
+// Dated types carry a YYYY-MM-DD prefix in their filename (constitution taxonomy);
+// living pages (person/topic) do not.
+const DATED = new Set(["decision", "meeting"]);
+
+// The vault-relative path a filed-back note must live at, derived from its type
+// (and title, and — for dated types — its date). Pure: no clock, no fs.
+export function filedNotePath(spec) {
+  const folder = FOLDER[spec.type];
+  if (!folder) {
+    throw new Error(
+      `unknown type "${spec.type}": supported types are ${Object.keys(FOLDER).join(", ")}`,
+    );
+  }
+  if (DATED.has(spec.type) && !spec.date) {
+    throw new Error(`type "${spec.type}" requires a date (YYYY-MM-DD) for its filename`);
+  }
+  const stem = DATED.has(spec.type) ? `${spec.date}-${slugify(spec.title)}` : slugify(spec.title);
+  return `${folder}/${stem}.md`;
+}
+
+// Build a filed-back note as { path, content }. The content is conformant to the
+// vault taxonomy BY CONSTRUCTION: complete frontmatter (type/created/updated/tags
+// all present), an H1 title, the distilled body, and — when links are given — a
+// "Related" section weaving them in as [[wikilinks]]. Pure: `today` is injected,
+// never read from a clock.
+export function renderFiledNote(spec) {
+  if (!spec.today) throw new Error("today (YYYY-MM-DD) is required to stamp created/updated");
+  if (!spec.tags || spec.tags.length === 0) {
+    throw new Error("at least one tag is required (frontmatter conformance: tags must be non-empty)");
+  }
+  const links = spec.links ?? [];
+  const path = filedNotePath(spec);
+  const frontmatter = [
+    "---",
+    `type: ${spec.type}`,
+    `created: ${spec.today}`,
+    `updated: ${spec.today}`,
+    `tags: [${spec.tags.join(", ")}]`,
+    "---",
+  ].join("\n");
+  const related =
+    links.length > 0 ? `\n## Related\n\n${links.map((l) => `- [[${l}]]`).join("\n")}\n` : "";
+  const content = `${frontmatter}\n\n# ${spec.title}\n\n${spec.body}\n${related}`;
+  return { path, content };
+}

--- a/scripts/lib/filed-note.test.mjs
+++ b/scripts/lib/filed-note.test.mjs
@@ -1,0 +1,156 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { slugify, filedNotePath, renderFiledNote } from "./filed-note.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// filed-note — the pure, I/O-free core of Track B ("file the good answer back").
+// Given a filing spec it builds a note that is conformant to the vault taxonomy
+// BY CONSTRUCTION (ADR 0009 rung 1): correct path, complete frontmatter, woven
+// [[links]] — so a filed-back answer never re-introduces the very defects /lint
+// (Track A) detects. This block covers slugify (title → filename-safe slug).
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("slugify — a two-word title becomes kebab-case, lowercased", () => {
+  assert.equal(slugify("Jane Doe"), "jane-doe");
+});
+
+test("slugify — strips accents to plain ASCII (no accents in filenames)", () => {
+  assert.equal(slugify("Café Résumé"), "cafe-resume");
+});
+
+test("slugify — collapses punctuation and repeated spaces to single hyphens, trimmed", () => {
+  assert.equal(slugify("  RAG & Embeddings!  "), "rag-embeddings");
+});
+
+test("slugify — a title with no slug-able characters throws (fail-loud, not empty)", () => {
+  assert.throws(() => slugify("!?…"), /empty slug|no slug-able/i);
+});
+
+// ── filedNotePath: the vault-relative path implied by type + title (+ date) ────
+
+test("filedNotePath — a living page (topic) is <folder>/<slug>.md, no date", () => {
+  assert.equal(
+    filedNotePath({ type: "topic", title: "Capacity Management" }),
+    "topics/capacity-management.md",
+  );
+});
+
+test("filedNotePath — a person page lives under people/ (folder is not a naive plural)", () => {
+  assert.equal(
+    filedNotePath({ type: "person", title: "Jane Doe" }),
+    "people/jane-doe.md",
+  );
+});
+
+test("filedNotePath — a dated type (decision) is <folder>/<date>-<slug>.md", () => {
+  assert.equal(
+    filedNotePath({ type: "decision", title: "Adopt The Hive", date: "2026-07-17" }),
+    "decisions/2026-07-17-adopt-the-hive.md",
+  );
+});
+
+test("filedNotePath — a meeting is dated too, distinct from an undated topic", () => {
+  assert.equal(
+    filedNotePath({ type: "meeting", title: "Q3 Review", date: "2026-07-17" }),
+    "meetings/2026-07-17-q3-review.md",
+  );
+});
+
+test("filedNotePath — an unknown type throws, naming the supported types", () => {
+  assert.throws(
+    () => filedNotePath({ type: "recipe", title: "Whatever" }),
+    /unknown type "recipe".*person.*topic.*decision.*meeting/is,
+  );
+});
+
+test("filedNotePath — a dated type without a date throws (fail-loud)", () => {
+  assert.throws(
+    () => filedNotePath({ type: "decision", title: "Adopt The Hive" }),
+    /decision.*requires a date/i,
+  );
+});
+
+// ── renderFiledNote: a taxonomy-conformant { path, content } by construction ───
+
+test("renderFiledNote — throws when today is missing (created/updated would be blank)", () => {
+  assert.throws(
+    () => renderFiledNote({ type: "topic", title: "X", tags: ["a"], body: "b", links: [] }),
+    /today.*required/i,
+  );
+});
+
+test("renderFiledNote — throws on empty tags (frontmatter conformance would break)", () => {
+  assert.throws(
+    () =>
+      renderFiledNote({ type: "topic", title: "X", tags: [], body: "b", links: [], today: "2026-07-17" }),
+    /at least one tag|tags.*required|non-empty/i,
+  );
+});
+
+test("renderFiledNote — omitted links default to no Related section (not a crash)", () => {
+  const note = renderFiledNote({
+    type: "topic",
+    title: "X",
+    tags: ["a"],
+    body: "b",
+    today: "2026-07-17",
+  });
+  assert.equal(note.content.includes("## Related"), false);
+});
+
+test("renderFiledNote — with no links, omits the Related section entirely", () => {
+  const note = renderFiledNote({
+    type: "decision",
+    title: "Adopt The Hive",
+    tags: ["architecture"],
+    body: "We go modular monolith.",
+    links: [],
+    date: "2026-07-17",
+    today: "2026-07-17",
+  });
+  assert.deepEqual(note, {
+    path: "decisions/2026-07-17-adopt-the-hive.md",
+    content: `---
+type: decision
+created: 2026-07-17
+updated: 2026-07-17
+tags: [architecture]
+---
+
+# Adopt The Hive
+
+We go modular monolith.
+`,
+  });
+});
+
+test("renderFiledNote — builds path + conformant frontmatter, body, and woven [[links]]", () => {
+  const note = renderFiledNote({
+    type: "topic",
+    title: "Capacity Management",
+    tags: ["rag", "retrieval"],
+    body: "The distilled answer.",
+    links: ["people/jane-doe", "topics/rag"],
+    today: "2026-07-17",
+  });
+  assert.deepEqual(note, {
+    path: "topics/capacity-management.md",
+    content: `---
+type: topic
+created: 2026-07-17
+updated: 2026-07-17
+tags: [rag, retrieval]
+---
+
+# Capacity Management
+
+The distilled answer.
+
+## Related
+
+- [[people/jane-doe]]
+- [[topics/rag]]
+`,
+  });
+});

--- a/scripts/lib/wiki-health-nudge.mjs
+++ b/scripts/lib/wiki-health-nudge.mjs
@@ -1,0 +1,47 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// wiki-health-nudge.mjs — the pure, I/O-free core of Track F (ADR 0009 rung 1).
+// Given the two STRUCTURED reports (lintVault's + consolidationCandidates'), it
+// builds the compact SessionStart chat nudge — or null when nothing actionable.
+//
+// It surfaces ONLY the self-clearing / true-regression signals: consolidation
+// candidates (stateless — they drop off once the page is refreshed) and dangling
+// links (real breakage, always worth fixing). Orphans/stale/frontmatter are a
+// standing backlog on a real vault → they stay in the on-demand /lint, never at
+// session start (the noise guardrail).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Build the Track-F nudge from the two structured reports, or null when there is
+// nothing actionable to surface. Pure: no I/O, deterministic.
+export function wikiHealthNudge({ lintReport, consolidationReport }) {
+  const dangling = lintReport.danglingLinks.length;
+  const candidates = consolidationReport.newPages.length + consolidationReport.refreshes.length;
+  if (dangling === 0 && candidates === 0) return null;
+
+  const parts = [];
+  if (candidates > 0) parts.push(`${candidates} consolidation candidates (offer /consolidate)`);
+  if (dangling > 0) parts.push(`${dangling} dangling links (offer /lint)`);
+  return parts.join(" and ");
+}
+
+// Wrap the nudge into the SessionStart hook output, or null when there's nothing
+// to emit. Mirrors buildSelfHealHookOutput (session-self-heal.mjs): the ONLY
+// Desktop-visible channel is the CHAT, and a SessionStart hook's
+// `hookSpecificOutput.additionalContext` is injected into the agent's context, so
+// the agent relays it into the chat. So the nudge rides additionalContext, phrased
+// as a DIRECTIVE the agent surfaces to the user. `systemMessage` is kept too —
+// dropped on Desktop (harmless), shown on the CLI.
+export function buildWikiHealthHookOutput(nudge) {
+  if (!nudge) return null;
+  return {
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext:
+        `[wiki-health] The vault has pending housekeeping: ${nudge}. Early in your next reply, ` +
+        `briefly and in the user's language, tell the user and offer to run the relevant command ` +
+        `(/consolidate to promote raw captures into entity/topic pages, /lint for the full health ` +
+        `report). This is OPTIONAL housekeeping — mention it once, do not nag, and NEVER auto-file: ` +
+        `any consolidation write stays confirmed (propose → the user says yes).`,
+    },
+    systemMessage: nudge,
+  };
+}

--- a/scripts/lib/wiki-health-nudge.test.mjs
+++ b/scripts/lib/wiki-health-nudge.test.mjs
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { wikiHealthNudge, buildWikiHealthHookOutput } from "./wiki-health-nudge.mjs";
+
+// wikiHealthNudge is the pure Track-F core (ADR 0009 rung 1): given the two
+// STRUCTURED reports (lintVault's + consolidationCandidates'), it builds the
+// compact SessionStart chat nudge — or null when nothing actionable. It surfaces
+// ONLY the self-clearing / true-regression signals (dangling links + consolidation
+// candidates); orphans/stale/frontmatter stay in the on-demand /lint.
+
+const emptyLint = { danglingLinks: [], orphans: [], staleEntityPages: [], frontmatterViolations: [] };
+const emptyConsolidation = { newPages: [], refreshes: [] };
+
+test("wikiHealthNudge — both reports empty → null (quiet, no session-start noise)", () => {
+  const nudge = wikiHealthNudge({ lintReport: emptyLint, consolidationReport: emptyConsolidation });
+  assert.equal(nudge, null);
+});
+
+test("wikiHealthNudge — dangling links only → names the count and offers /lint", () => {
+  const lintReport = {
+    ...emptyLint,
+    danglingLinks: [
+      { from: "meetings/2026-07-10.md", target: "Acme Corp" },
+      { from: "daily/2026-07-11.md", target: "Widget X" },
+    ],
+  };
+  const nudge = wikiHealthNudge({ lintReport, consolidationReport: emptyConsolidation });
+  assert.match(nudge, /2 dangling/);
+  assert.match(nudge, /\/lint/);
+});
+
+test("wikiHealthNudge — consolidation candidates only → names the count and offers /consolidate", () => {
+  const consolidationReport = {
+    newPages: [{ target: "Acme Corp", sources: [{ path: "meetings/2026-07-10.md" }] }],
+    refreshes: [
+      { page: "people/jane.md", updated: "2026-01-01", sources: [{ path: "meetings/2026-07-10.md" }] },
+      { page: "topics/widget.md", updated: "2026-02-01", sources: [{ path: "daily/2026-07-11.md" }] },
+    ],
+  };
+  const nudge = wikiHealthNudge({ lintReport: emptyLint, consolidationReport });
+  assert.match(nudge, /3 consolidation/);
+  assert.match(nudge, /\/consolidate/);
+});
+
+test("wikiHealthNudge — both signals present → names both, offers both", () => {
+  const lintReport = { ...emptyLint, danglingLinks: [{ from: "daily/x.md", target: "Nowhere" }] };
+  const consolidationReport = {
+    newPages: [{ target: "Acme Corp", sources: [{ path: "meetings/2026-07-10.md" }] }],
+    refreshes: [],
+  };
+  const nudge = wikiHealthNudge({ lintReport, consolidationReport });
+  assert.match(nudge, /1 consolidation candidates/);
+  assert.match(nudge, /1 dangling links/);
+  assert.match(nudge, /\/consolidate/);
+  assert.match(nudge, /\/lint/);
+});
+
+test("wikiHealthNudge — orphans/stale/frontmatter but no dangling & no candidates → null (noise guardrail)", () => {
+  const lintReport = {
+    danglingLinks: [],
+    orphans: ["notes/lonely.md", "notes/unlinked.md"],
+    staleEntityPages: [{ path: "people/bob.md", updated: "2025-01-01", freshestReference: "2026-07-01" }],
+    frontmatterViolations: [{ path: "notes/bad.md", missing: ["tags"] }],
+  };
+  const nudge = wikiHealthNudge({ lintReport, consolidationReport: emptyConsolidation });
+  assert.equal(nudge, null);
+});
+
+test("buildWikiHealthHookOutput — null nudge → null (nothing to emit)", () => {
+  assert.equal(buildWikiHealthHookOutput(null), null);
+});
+
+test("buildWikiHealthHookOutput — non-null → SessionStart directive on the Desktop-visible chat channel", () => {
+  const nudge = "3 consolidation candidates (offer /consolidate) and 1 dangling links (offer /lint)";
+  const out = buildWikiHealthHookOutput(nudge);
+
+  assert.equal(out.hookSpecificOutput.hookEventName, "SessionStart");
+  const ctx = out.hookSpecificOutput.additionalContext;
+  // The directive must DIRECT the agent to tell the USER in the chat (additionalContext is agent-facing).
+  assert.match(ctx, /tell the user/i);
+  // It must carry the concrete facts, so the agent surfaces the real numbers.
+  assert.match(ctx, /3 consolidation candidates/);
+  assert.match(ctx, /1 dangling links/);
+  // It must frame the write posture: optional housekeeping, never auto-file.
+  assert.match(ctx, /optional/i);
+  assert.match(ctx, /never (auto-file|write)|confirm/i);
+  // systemMessage carries the raw nudge (dropped on Desktop, shown on CLI).
+  assert.equal(out.systemMessage, nudge);
+});

--- a/scripts/lib/wiki-lint-io.mjs
+++ b/scripts/lib/wiki-lint-io.mjs
@@ -1,0 +1,40 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// wiki-lint-io.mjs — the fs adapter (ADR 0009 rung 2) for the `/lint` wiki-health
+// scanner. It reads a real vault into the parsed-note shape { path, frontmatter,
+// body } that the pure core in wiki-lint.mjs consumes.
+//
+// parseNote is a dependency-free frontmatter reader: the launcher ships no
+// gray-matter, and we only need the handful of keys the lint rules care about
+// (type / created / updated / tags), so a small YAML subset is enough.
+// ─────────────────────────────────────────────────────────────────────────────
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { listFilesRelPosix } from "./fs-walk.mjs";
+
+// Parse one Markdown file's raw text into { frontmatter, body }. Supports scalar
+// values and an inline `key: [a, b]` list. A file with no frontmatter yields {}.
+export function parseNote(raw) {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, body: raw };
+  const frontmatter = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!kv) continue;
+    const [, key, rawValue] = kv;
+    const inlineList = rawValue.match(/^\[(.*)\]$/);
+    frontmatter[key] = inlineList
+      ? inlineList[1].split(",").map((v) => v.trim()).filter((v) => v !== "")
+      : rawValue.trim();
+  }
+  return { frontmatter, body: match[2] };
+}
+
+// Read every .md file under `vaultDir` into the parsed-note shape, path relative
+// to the vault and POSIX-separated (so the pure core's basename/prefix logic is
+// platform-independent).
+export function readVaultNotes(vaultDir) {
+  return listFilesRelPosix(vaultDir)
+    .filter((rel) => rel.endsWith(".md"))
+    .map((rel) => ({ path: rel, ...parseNote(readFileSync(join(vaultDir, rel), "utf8")) }));
+}

--- a/scripts/lib/wiki-lint-io.test.mjs
+++ b/scripts/lib/wiki-lint-io.test.mjs
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseNote, readVaultNotes } from "./wiki-lint-io.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// wiki-lint-io — the fs adapter (ADR 0009 rung 2) that reads a real vault into
+// the parsed-note shape { path, frontmatter, body } the pure lint core consumes.
+// parseNote is a dependency-free frontmatter reader (the launcher ships no
+// gray-matter); readVaultNotes walks the vault and parses every .md file.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("parseNote — reads scalar frontmatter, an inline tags list, and the body", () => {
+  const raw = "---\ntype: person\ncreated: 2026-01-01\nupdated: 2026-02-02\ntags: [a, b]\n---\nBody with [[Link]]";
+  assert.deepEqual(parseNote(raw), {
+    frontmatter: { type: "person", created: "2026-01-01", updated: "2026-02-02", tags: ["a", "b"] },
+    body: "Body with [[Link]]",
+  });
+});
+
+test("parseNote — a note without frontmatter yields empty frontmatter and the raw body", () => {
+  assert.deepEqual(parseNote("# Just a title\n[[Link]]"), {
+    frontmatter: {},
+    body: "# Just a title\n[[Link]]",
+  });
+});
+
+function vaultFixture(tree) {
+  const dir = mkdtempSync(join(tmpdir(), "sbg-lint-"));
+  for (const [rel, content] of Object.entries(tree)) {
+    const abs = join(dir, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return dir;
+}
+
+test("readVaultNotes — parses every .md note with a relative POSIX path, skips non-md", (t) => {
+  const dir = vaultFixture({
+    "people/alice.md": "---\ntype: person\n---\nhi [[bob]]",
+    "notes/b.md": "no frontmatter here",
+    "attachments/pic.png": "binary",
+  });
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  assert.deepEqual(readVaultNotes(dir).sort((a, b) => a.path.localeCompare(b.path)), [
+    { path: "notes/b.md", frontmatter: {}, body: "no frontmatter here" },
+    { path: "people/alice.md", frontmatter: { type: "person" }, body: "hi [[bob]]" },
+  ]);
+});

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -23,23 +23,75 @@ function basename(path) {
 // dump), so they are excluded from the orphan rule by default.
 const DEFAULT_ORPHAN_EXCLUDE = ["daily/", "raw-sources/", "inbox/"];
 
+// Frontmatter `type` values that make a note a curated "entity page" (subject to
+// the stale rule). Configurable via options.entityTypes.
+const DEFAULT_ENTITY_TYPES = ["person", "topic", "company", "project", "concept"];
+
+// A note goes stale when the freshest note linking to it is this many days newer.
+const DEFAULT_STALE_DAYS = 90;
+
+// Frontmatter keys every note is expected to carry. Configurable via options.
+const DEFAULT_REQUIRED_FRONTMATTER = ["type", "created", "updated", "tags"];
+
+// A required key counts as present only if it holds a non-empty value.
+function isPresent(value) {
+  if (value == null || value === "") return false;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+const DAY_MS = 86_400_000;
+function daysBetween(laterIso, earlierIso) {
+  return (Date.parse(laterIso) - Date.parse(earlierIso)) / DAY_MS;
+}
+
 // Scan already-parsed `notes` ({ path, frontmatter, body }) and report where the
 // wiki bleeds. Pure: no I/O, order-preserving, deterministic. `options`:
 //   orphanExclude — path prefixes whose notes are never flagged as orphans.
+//   entityTypes  — frontmatter `type` values treated as entity pages.
+//   staleDays    — how many days behind its freshest reference makes an entity stale.
 export function lintVault(notes, options = {}) {
   const orphanExclude = options.orphanExclude ?? DEFAULT_ORPHAN_EXCLUDE;
+  const entityTypes = options.entityTypes ?? DEFAULT_ENTITY_TYPES;
+  const staleDays = options.staleDays ?? DEFAULT_STALE_DAYS;
+  const requiredFrontmatter = options.requiredFrontmatter ?? DEFAULT_REQUIRED_FRONTMATTER;
+
   const known = new Set(notes.map((n) => basename(n.path)));
   const danglingLinks = [];
   const inbound = new Set();
+  const freshestReference = new Map(); // target basename → newest linking note's `updated`
   for (const note of notes) {
     for (const target of extractWikiLinks(note.body)) {
-      if (known.has(target)) inbound.add(target);
-      else danglingLinks.push({ from: note.path, target });
+      if (!known.has(target)) {
+        danglingLinks.push({ from: note.path, target });
+        continue;
+      }
+      inbound.add(target);
+      const when = note.frontmatter.updated;
+      const seen = freshestReference.get(target);
+      if (when && (!seen || Date.parse(when) > Date.parse(seen))) {
+        freshestReference.set(target, when);
+      }
     }
   }
   const orphans = notes
     .filter((n) => !inbound.has(basename(n.path)))
     .filter((n) => !orphanExclude.some((prefix) => n.path.startsWith(prefix)))
     .map((n) => n.path);
-  return { danglingLinks, orphans };
+
+  const staleEntityPages = [];
+  for (const note of notes) {
+    if (!entityTypes.includes(note.frontmatter.type)) continue;
+    const freshest = freshestReference.get(basename(note.path));
+    const updated = note.frontmatter.updated;
+    if (freshest && updated && daysBetween(freshest, updated) > staleDays) {
+      staleEntityPages.push({ path: note.path, updated, freshestReference: freshest });
+    }
+  }
+  const frontmatterViolations = [];
+  for (const note of notes) {
+    const missing = requiredFrontmatter.filter((key) => !isPresent(note.frontmatter[key]));
+    if (missing.length > 0) frontmatterViolations.push({ path: note.path, missing });
+  }
+  return { danglingLinks, orphans, staleEntityPages, frontmatterViolations };
 }

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -14,9 +14,28 @@ export function extractWikiLinks(body) {
   );
 }
 
-// A note's basename (filename without extension) — how Obsidian resolves a link.
+// A note's basename (filename without extension) — the short Obsidian link form.
 function basename(path) {
   return path.split("/").pop().replace(/\.md$/, "");
+}
+
+// Build a resolver mapping every accepted link spelling to a note's canonical
+// path. Obsidian resolves a `[[Target]]` by basename, and a `[[folder/note]]` (or
+// `[[folder/note.md]]`) by path. Path spellings are registered even when a
+// basename collides, so the longer form always disambiguates.
+function buildResolver(notes) {
+  const byKey = new Map();
+  const register = (key, path) => {
+    if (!byKey.has(key)) byKey.set(key, path);
+  };
+  for (const note of notes) {
+    const noExt = note.path.replace(/\.md$/, "");
+    register(note.path, note.path); // folder/note.md
+    register(noExt, note.path); //     folder/note
+    register(basename(note.path), note.path); // note
+  }
+  // Resolve a raw link target to a canonical note path, or null if it points nowhere.
+  return (target) => byKey.get(target) ?? byKey.get(target.replace(/\.md$/, "")) ?? null;
 }
 
 // Raw-capture zones: notes here are legitimately unlinked (a daily log, an inbox
@@ -56,33 +75,39 @@ export function lintVault(notes, options = {}) {
   const staleDays = options.staleDays ?? DEFAULT_STALE_DAYS;
   const requiredFrontmatter = options.requiredFrontmatter ?? DEFAULT_REQUIRED_FRONTMATTER;
 
-  const known = new Set(notes.map((n) => basename(n.path)));
+  const resolve = buildResolver(notes);
   const danglingLinks = [];
-  const inbound = new Set();
-  const freshestReference = new Map(); // target basename → newest linking note's `updated`
+  const danglingSeen = new Set(); // "from\0target" already recorded — report each once
+  const inbound = new Set(); // canonical paths that receive at least one link
+  const freshestReference = new Map(); // canonical path → newest linking note's `updated`
   for (const note of notes) {
     for (const target of extractWikiLinks(note.body)) {
-      if (!known.has(target)) {
-        danglingLinks.push({ from: note.path, target });
+      const resolved = resolve(target);
+      if (!resolved) {
+        const key = `${note.path}\0${target}`;
+        if (!danglingSeen.has(key)) {
+          danglingSeen.add(key);
+          danglingLinks.push({ from: note.path, target });
+        }
         continue;
       }
-      inbound.add(target);
+      inbound.add(resolved);
       const when = note.frontmatter.updated;
-      const seen = freshestReference.get(target);
+      const seen = freshestReference.get(resolved);
       if (when && (!seen || Date.parse(when) > Date.parse(seen))) {
-        freshestReference.set(target, when);
+        freshestReference.set(resolved, when);
       }
     }
   }
   const orphans = notes
-    .filter((n) => !inbound.has(basename(n.path)))
+    .filter((n) => !inbound.has(n.path))
     .filter((n) => !orphanExclude.some((prefix) => n.path.startsWith(prefix)))
     .map((n) => n.path);
 
   const staleEntityPages = [];
   for (const note of notes) {
     if (!entityTypes.includes(note.frontmatter.type)) continue;
-    const freshest = freshestReference.get(basename(note.path));
+    const freshest = freshestReference.get(note.path);
     const updated = note.frontmatter.updated;
     if (freshest && updated && daysBetween(freshest, updated) > staleDays) {
       staleEntityPages.push({ path: note.path, updated, freshestReference: freshest });

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -23,7 +23,7 @@ function basename(path) {
 // path. Obsidian resolves a `[[Target]]` by basename, and a `[[folder/note]]` (or
 // `[[folder/note.md]]`) by path. Path spellings are registered even when a
 // basename collides, so the longer form always disambiguates.
-function buildResolver(notes) {
+export function buildResolver(notes) {
   const byKey = new Map();
   const register = (key, path) => {
     if (!byKey.has(key)) byKey.set(key, path);

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -1,0 +1,45 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// wiki-lint.mjs — the pure, I/O-free core of the Axis-1 `/lint` wiki-health
+// scanner (ADR 0009 rung 1: correctness lives in a function with no I/O). Given
+// already-parsed notes, it reports where the wiki bleeds: dangling links, orphan
+// notes, stale entity pages, frontmatter violations. A separate fs adapter (rung
+// 2) reads the vault into the parsed-note shape this core consumes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Every `[[Target]]` wikilink found in `body`, in order of appearance. Obsidian's
+// `[[Target|alias]]` and `[[Target#heading]]` forms resolve to the bare target.
+export function extractWikiLinks(body) {
+  return [...body.matchAll(/\[\[([^\]]+)\]\]/g)].map((m) =>
+    m[1].split(/[|#]/)[0].trim(),
+  );
+}
+
+// A note's basename (filename without extension) — how Obsidian resolves a link.
+function basename(path) {
+  return path.split("/").pop().replace(/\.md$/, "");
+}
+
+// Raw-capture zones: notes here are legitimately unlinked (a daily log, an inbox
+// dump), so they are excluded from the orphan rule by default.
+const DEFAULT_ORPHAN_EXCLUDE = ["daily/", "raw-sources/", "inbox/"];
+
+// Scan already-parsed `notes` ({ path, frontmatter, body }) and report where the
+// wiki bleeds. Pure: no I/O, order-preserving, deterministic. `options`:
+//   orphanExclude — path prefixes whose notes are never flagged as orphans.
+export function lintVault(notes, options = {}) {
+  const orphanExclude = options.orphanExclude ?? DEFAULT_ORPHAN_EXCLUDE;
+  const known = new Set(notes.map((n) => basename(n.path)));
+  const danglingLinks = [];
+  const inbound = new Set();
+  for (const note of notes) {
+    for (const target of extractWikiLinks(note.body)) {
+      if (known.has(target)) inbound.add(target);
+      else danglingLinks.push({ from: note.path, target });
+    }
+  }
+  const orphans = notes
+    .filter((n) => !inbound.has(basename(n.path)))
+    .filter((n) => !orphanExclude.some((prefix) => n.path.startsWith(prefix)))
+    .map((n) => n.path);
+  return { danglingLinks, orphans };
+}

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -52,8 +52,10 @@ export function buildResolver(notes) {
 }
 
 // Raw-capture zones: notes here are legitimately unlinked (a daily log, an inbox
-// dump), so they are excluded from the orphan rule by default.
-const DEFAULT_ORPHAN_EXCLUDE = ["daily/", "raw-sources/", "inbox/"];
+// dump, the append-only activity ledger), so they are excluded from the orphan rule
+// by default. `actions-log.md` is a grep-able ledger, not a wiki node — nobody links
+// TO it, so flagging it orphan is a permanent false positive.
+const DEFAULT_ORPHAN_EXCLUDE = ["daily/", "raw-sources/", "inbox/", "actions-log.md"];
 
 // Frontmatter `type` values that make a note a curated "entity page" (subject to
 // the stale rule). Configurable via options.entityTypes.

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -120,3 +120,40 @@ export function lintVault(notes, options = {}) {
   }
   return { danglingLinks, orphans, staleEntityPages, frontmatterViolations };
 }
+
+// The report as human-readable lines (joined by formatReport). Honest and
+// binary: one reassuring line when clean, one titled section per bleeding
+// category otherwise.
+export function reportLines(report) {
+  if (!hasFindings(report)) return ["✓ Wiki health: clean"];
+  const lines = ["✗ Wiki health: issues found"];
+  const section = (title, items) => {
+    if (items.length === 0) return;
+    lines.push("", `${title} (${items.length}):`);
+    for (const item of items) lines.push(`  ${item}`);
+  };
+  section("Dangling links", report.danglingLinks.map((d) => `${d.from} → [[${d.target}]]`));
+  section("Orphans", report.orphans);
+  section(
+    "Stale entity pages",
+    report.staleEntityPages.map(
+      (s) => `${s.path} (updated ${s.updated}, cited as fresh as ${s.freshestReference})`,
+    ),
+  );
+  section(
+    "Frontmatter issues",
+    report.frontmatterViolations.map((v) => `${v.path} (missing: ${v.missing.join(", ")})`),
+  );
+  return lines;
+}
+
+// True when the report holds at least one finding in any category — the signal
+// the CLI turns into a binary exit code (0 clean / 1 bleeding).
+export function hasFindings(report) {
+  return (
+    report.danglingLinks.length > 0 ||
+    report.orphans.length > 0 ||
+    report.staleEntityPages.length > 0 ||
+    report.frontmatterViolations.length > 0
+  );
+}

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -6,10 +6,23 @@
 // 2) reads the vault into the parsed-note shape this core consumes.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Blank out fenced code blocks (```…```) and inline code spans (`…`) so their
+// contents can't be mistaken for prose. Obsidian does not linkify `[[…]]` written
+// inside code, so neither do we — a link example in a code span is documentation,
+// not a real link. Replacing with spaces preserves offsets (nothing else needs them,
+// but it keeps the transform trivially non-reordering).
+function stripCode(body) {
+  return body
+    .replace(/```[\s\S]*?```/g, (m) => " ".repeat(m.length))
+    .replace(/`[^`\n]*`/g, (m) => " ".repeat(m.length));
+}
+
 // Every `[[Target]]` wikilink found in `body`, in order of appearance. Obsidian's
 // `[[Target|alias]]` and `[[Target#heading]]` forms resolve to the bare target.
+// Links inside code (fenced blocks or inline spans) are ignored — Obsidian doesn't
+// linkify code, so a `[[link]]` example there is syntax documentation, not a link.
 export function extractWikiLinks(body) {
-  return [...body.matchAll(/\[\[([^\]]+)\]\]/g)].map((m) =>
+  return [...stripCode(body).matchAll(/\[\[([^\]]+)\]\]/g)].map((m) =>
     m[1].split(/[|#]/)[0].trim(),
   );
 }

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -89,6 +89,14 @@ test("lintVault — raw-capture zones (daily/, raw-sources/, inbox/) are never o
   assert.deepEqual(report.orphans, ["topic.md"]);
 });
 
+test("lintVault — the append-only ledger (actions-log.md) is a raw zone, never an orphan", () => {
+  const report = lintVault([
+    { path: "actions-log.md", frontmatter: { type: "log" }, body: "" },
+    { path: "topic.md", frontmatter: {}, body: "" },
+  ]);
+  assert.deepEqual(report.orphans, ["topic.md"]);
+});
+
 // ── stale entity pages: an entity note left behind by fresher notes citing it ──
 
 test("lintVault — flags an entity page older than the freshest note linking to it", () => {

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -30,6 +30,18 @@ test("extractWikiLinks — resolves the target, dropping |alias and #heading", (
   );
 });
 
+test("extractWikiLinks — ignores [[links]] inside an inline `code` span (Obsidian doesn't linkify code)", () => {
+  assert.deepEqual(
+    extractWikiLinks("a real [[Foo]] but `[[Bar]]` is just syntax"),
+    ["Foo"],
+  );
+});
+
+test("extractWikiLinks — ignores [[links]] inside a fenced ``` code block, keeps links after it", () => {
+  const body = "before [[Keep]]\n```\nexample: [[InCode]]\n```\nafter [[AlsoKeep]]";
+  assert.deepEqual(extractWikiLinks(body), ["Keep", "AlsoKeep"]);
+});
+
 // ── dangling links: a [[link]] whose target basename matches no note ──────────
 
 test("lintVault — flags a link whose target note is absent, keeps resolved ones", () => {

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -1,7 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { extractWikiLinks, lintVault } from "./wiki-lint.mjs";
+import { extractWikiLinks, lintVault, hasFindings, reportLines } from "./wiki-lint.mjs";
+
+const CLEAN = { danglingLinks: [], orphans: [], staleEntityPages: [], frontmatterViolations: [] };
 
 // ═══════════════════════════════════════════════════════════════════════════
 // wiki-lint — the pure, I/O-free core of the Axis-1 `/lint` wiki-health scanner
@@ -121,5 +123,71 @@ test("lintVault — an empty string or empty array counts as a missing required 
   ]);
   assert.deepEqual(report.frontmatterViolations, [
     { path: "empties.md", missing: ["updated", "tags"] },
+  ]);
+});
+
+// ── hasFindings: drives the CLI's binary exit code ────────────────────────────
+
+test("hasFindings — false when every category is empty", () => {
+  assert.equal(hasFindings(CLEAN), false);
+});
+
+test("hasFindings — true when any single category is non-empty", () => {
+  assert.equal(hasFindings({ ...CLEAN, danglingLinks: [{ from: "a", target: "b" }] }), true);
+  assert.equal(hasFindings({ ...CLEAN, orphans: ["a.md"] }), true);
+  assert.equal(hasFindings({ ...CLEAN, staleEntityPages: [{ path: "e.md" }] }), true);
+  assert.equal(hasFindings({ ...CLEAN, frontmatterViolations: [{ path: "f.md", missing: ["type"] }] }), true);
+});
+
+// ── reportLines: the human-readable, honest health report ─────────────────────
+
+test("reportLines — a clean vault reports a single reassuring line", () => {
+  assert.deepEqual(reportLines(CLEAN), ["✓ Wiki health: clean"]);
+});
+
+test("reportLines — a dangling-only report shows just the dangling section", () => {
+  const report = { ...CLEAN, danglingLinks: [{ from: "notes/a.md", target: "Missing" }] };
+  assert.deepEqual(reportLines(report), [
+    "✗ Wiki health: issues found",
+    "",
+    "Dangling links (1):",
+    "  notes/a.md → [[Missing]]",
+  ]);
+});
+
+test("reportLines — orphans render one path per line", () => {
+  const report = { ...CLEAN, orphans: ["c.md", "d.md"] };
+  assert.deepEqual(reportLines(report), [
+    "✗ Wiki health: issues found",
+    "",
+    "Orphans (2):",
+    "  c.md",
+    "  d.md",
+  ]);
+});
+
+test("reportLines — a stale entity page shows its date and its freshest citation", () => {
+  const report = {
+    ...CLEAN,
+    staleEntityPages: [{ path: "people/alice.md", updated: "2026-01-01", freshestReference: "2026-06-01" }],
+  };
+  assert.deepEqual(reportLines(report), [
+    "✗ Wiki health: issues found",
+    "",
+    "Stale entity pages (1):",
+    "  people/alice.md (updated 2026-01-01, cited as fresh as 2026-06-01)",
+  ]);
+});
+
+test("reportLines — a frontmatter violation lists the note and its missing keys", () => {
+  const report = {
+    ...CLEAN,
+    frontmatterViolations: [{ path: "bad.md", missing: ["created", "updated", "tags"] }],
+  };
+  assert.deepEqual(reportLines(report), [
+    "✗ Wiki health: issues found",
+    "",
+    "Frontmatter issues (1):",
+    "  bad.md (missing: created, updated, tags)",
   ]);
 });

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -58,3 +58,52 @@ test("lintVault — raw-capture zones (daily/, raw-sources/, inbox/) are never o
   ]);
   assert.deepEqual(report.orphans, ["topic.md"]);
 });
+
+// ── stale entity pages: an entity note left behind by fresher notes citing it ──
+
+test("lintVault — flags an entity page older than the freshest note linking to it", () => {
+  const report = lintVault([
+    { path: "people/alice.md", frontmatter: { type: "person", updated: "2026-01-01" }, body: "" },
+    { path: "notes/meeting.md", frontmatter: { updated: "2026-06-01" }, body: "met [[alice]]" },
+  ]);
+  assert.deepEqual(report.staleEntityPages, [
+    { path: "people/alice.md", updated: "2026-01-01", freshestReference: "2026-06-01" },
+  ]);
+});
+
+test("lintVault — exactly at the threshold is not stale, and non-entities never are", () => {
+  const report = lintVault([
+    // entity, freshest reference exactly 90 days later (Jan1→Apr1) — on the border, not past it
+    { path: "people/bob.md", frontmatter: { type: "person", updated: "2026-01-01" }, body: "" },
+    { path: "notes/a.md", frontmatter: { updated: "2026-04-01" }, body: "[[bob]]" },
+    // plain note far behind its reference, but no entity type → never stale
+    { path: "notes/plain.md", frontmatter: { updated: "2026-01-01" }, body: "" },
+    { path: "notes/b.md", frontmatter: { updated: "2026-12-01" }, body: "[[plain]]" },
+  ]);
+  assert.deepEqual(report.staleEntityPages, []);
+});
+
+// ── frontmatter conformance: required keys present ────────────────────────────
+
+test("lintVault — lists the required frontmatter keys a note is missing", () => {
+  const report = lintVault([
+    { path: "bad.md", frontmatter: { type: "person" }, body: "" },
+    {
+      path: "good.md",
+      frontmatter: { type: "topic", created: "2026-01-01", updated: "2026-01-02", tags: ["x"] },
+      body: "",
+    },
+  ]);
+  assert.deepEqual(report.frontmatterViolations, [
+    { path: "bad.md", missing: ["created", "updated", "tags"] },
+  ]);
+});
+
+test("lintVault — an empty string or empty array counts as a missing required key", () => {
+  const report = lintVault([
+    { path: "empties.md", frontmatter: { type: "topic", created: "2026-01-01", updated: "", tags: [] }, body: "" },
+  ]);
+  assert.deepEqual(report.frontmatterViolations, [
+    { path: "empties.md", missing: ["updated", "tags"] },
+  ]);
+});

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractWikiLinks, lintVault } from "./wiki-lint.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// wiki-lint — the pure, I/O-free core of the Axis-1 `/lint` wiki-health scanner
+// (ADR 0009 rung 1: correctness in a function with no I/O). Given already-parsed
+// notes it reports where the wiki bleeds: dangling links, orphans, stale entity
+// pages, frontmatter violations. This block covers wikilink extraction.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("extractWikiLinks — pulls a single [[Target]] out of body text", () => {
+  assert.deepEqual(extractWikiLinks("see [[Foo]] for details"), ["Foo"]);
+});
+
+test("extractWikiLinks — pulls every link in order, ignoring single [brackets]", () => {
+  assert.deepEqual(
+    extractWikiLinks("[[Zeta]] then a [decoy] and [[Alpha]]"),
+    ["Zeta", "Alpha"],
+  );
+});
+
+test("extractWikiLinks — resolves the target, dropping |alias and #heading", () => {
+  assert.deepEqual(
+    extractWikiLinks("[[Real Note|shown text]] and [[Page#Section]]"),
+    ["Real Note", "Page"],
+  );
+});
+
+// ── dangling links: a [[link]] whose target basename matches no note ──────────
+
+test("lintVault — flags a link whose target note is absent, keeps resolved ones", () => {
+  const report = lintVault([
+    { path: "notes/a.md", frontmatter: {}, body: "[[Missing]] but [[Alice]] exists" },
+    { path: "people/Alice.md", frontmatter: {}, body: "" },
+  ]);
+  assert.deepEqual(report.danglingLinks, [{ from: "notes/a.md", target: "Missing" }]);
+});
+
+// ── orphans: a note nobody links to ───────────────────────────────────────────
+
+test("lintVault — flags the note with zero inbound links, not the linked ones", () => {
+  const report = lintVault([
+    { path: "a.md", frontmatter: {}, body: "[[b]]" },
+    { path: "b.md", frontmatter: {}, body: "[[a]]" },
+    { path: "c.md", frontmatter: {}, body: "nobody links here" },
+  ]);
+  assert.deepEqual(report.orphans, ["c.md"]);
+});
+
+test("lintVault — raw-capture zones (daily/, raw-sources/, inbox/) are never orphans", () => {
+  const report = lintVault([
+    { path: "daily/2026-07-17.md", frontmatter: {}, body: "" },
+    { path: "raw-sources/dump.md", frontmatter: {}, body: "" },
+    { path: "inbox/scratch.md", frontmatter: {}, body: "" },
+    { path: "topic.md", frontmatter: {}, body: "" },
+  ]);
+  assert.deepEqual(report.orphans, ["topic.md"]);
+});

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -38,6 +38,22 @@ test("lintVault — flags a link whose target note is absent, keeps resolved one
   assert.deepEqual(report.danglingLinks, [{ from: "notes/a.md", target: "Missing" }]);
 });
 
+test("lintVault — the same broken link repeated in one note is reported once", () => {
+  const report = lintVault([
+    { path: "a.md", frontmatter: {}, body: "[[Missing]] and again [[Missing]]" },
+  ]);
+  assert.deepEqual(report.danglingLinks, [{ from: "a.md", target: "Missing" }]);
+});
+
+test("lintVault — resolves path-form links [[folder/note]] and [[folder/note.md]]", () => {
+  const report = lintVault([
+    { path: "topics/rag.md", frontmatter: {}, body: "" },
+    { path: "notes/x.md", frontmatter: {}, body: "see [[topics/rag]] and [[topics/rag.md]]" },
+  ]);
+  assert.deepEqual(report.danglingLinks, []);
+  assert.deepEqual(report.orphans, ["notes/x.md"]); // topics/rag has an inbound link now
+});
+
 // ── orphans: a note nobody links to ───────────────────────────────────────────
 
 test("lintVault — flags the note with zero inbound links, not the linked ones", () => {

--- a/scripts/lint-vault.mjs
+++ b/scripts/lint-vault.mjs
@@ -9,11 +9,16 @@
 //   node scripts/lint-vault.mjs            # health-check ./vault
 //   node scripts/lint-vault.mjs <dir>      # health-check another vault path
 // ─────────────────────────────────────────────────────────────────────────────
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
 import { lintVault, reportLines, hasFindings } from "./lib/wiki-lint.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
+
+// The scanned vault dir is displayed (and passed to the reader) in POSIX form so
+// the output is identical across platforms — on Windows join() yields backslashes
+// and resolve() prepends a drive letter. Cf. installer toPosix / document-scanner.
+const toPosix = (p) => p.split("\\").join("/");
 
 // Real wiring — the side effects, injected so runLint stays unit-testable.
 export const realLintDeps = {
@@ -26,7 +31,7 @@ export const realLintDeps = {
 // Scan the vault and print an honest health report. Returns the process exit
 // code: 0 clean, 1 issues found. All side effects come through `deps`.
 export function runLint(argv, deps = realLintDeps) {
-  const vaultDir = argv[0] ? resolve(argv[0]) : join(deps.cwd(), "vault");
+  const vaultDir = toPosix(argv[0] ? argv[0] : join(deps.cwd(), "vault"));
   const notes = deps.readNotes(vaultDir);
   const report = lintVault(notes);
   deps.log(`Scanned ${notes.length} notes under ${vaultDir}`);

--- a/scripts/lint-vault.mjs
+++ b/scripts/lint-vault.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// lint-vault.mjs — run FROM the brain folder to health-check the wiki (Axis 1).
+//
+// Deterministic, fail-loud, binary (ADR 0009): it reports where the wiki bleeds
+// — dangling [[links]], orphan notes, stale entity pages, malformed frontmatter —
+// and exits 0 when clean / 1 when it finds issues, so it composes in scripts.
+//
+//   node scripts/lint-vault.mjs            # health-check ./vault
+//   node scripts/lint-vault.mjs <dir>      # health-check another vault path
+// ─────────────────────────────────────────────────────────────────────────────
+import { join, resolve } from "node:path";
+
+import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
+import { lintVault, reportLines, hasFindings } from "./lib/wiki-lint.mjs";
+import { isEntrypoint } from "./lib/entrypoint.mjs";
+
+// Real wiring — the side effects, injected so runLint stays unit-testable.
+export const realLintDeps = {
+  cwd: () => process.cwd(),
+  readNotes: readVaultNotes,
+  log: (...a) => console.log(...a),
+  error: (...a) => console.error(...a),
+};
+
+// Scan the vault and print an honest health report. Returns the process exit
+// code: 0 clean, 1 issues found. All side effects come through `deps`.
+export function runLint(argv, deps = realLintDeps) {
+  const vaultDir = argv[0] ? resolve(argv[0]) : join(deps.cwd(), "vault");
+  const notes = deps.readNotes(vaultDir);
+  const report = lintVault(notes);
+  deps.log(`Scanned ${notes.length} notes under ${vaultDir}`);
+  for (const line of reportLines(report)) deps.log(line);
+  return hasFindings(report) ? 1 : 0;
+}
+
+if (isEntrypoint(import.meta.url, process.argv[1])) {
+  process.exit(runLint(process.argv.slice(2)));
+}

--- a/scripts/lint-vault.test.mjs
+++ b/scripts/lint-vault.test.mjs
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runLint } from "./lint-vault.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// lint-vault — the thin CLI glue over the pure wiki-health core. Binary exit
+// code (0 clean / 1 bleeding / 2 usage error). All side effects come through an
+// injected `deps` port so the glue itself is unit-testable (no untestable
+// top-level side effects — TDD mutation lesson #6).
+// ═══════════════════════════════════════════════════════════════════════════
+
+function fakeDeps(overrides = {}) {
+  const logs = [];
+  const errors = [];
+  const seenDirs = [];
+  const deps = {
+    cwd: () => "/brain",
+    readNotes: (dir) => {
+      seenDirs.push(dir);
+      return [];
+    },
+    log: (line) => logs.push(line),
+    error: (line) => errors.push(line),
+    ...overrides,
+  };
+  return { deps, logs, errors, seenDirs };
+}
+
+test("runLint — a clean vault prints the scan count + clean line and exits 0", () => {
+  const { deps, logs, seenDirs } = fakeDeps();
+  const code = runLint([], deps);
+  assert.equal(code, 0);
+  assert.deepEqual(seenDirs, ["/brain/vault"]);
+  assert.deepEqual(logs, ["Scanned 0 notes under /brain/vault", "✓ Wiki health: clean"]);
+});
+
+test("runLint — a bleeding vault prints the report and exits 1", () => {
+  const notes = [{ path: "a.md", frontmatter: { type: "topic", created: "d", updated: "d", tags: ["t"] }, body: "[[Missing]]" }];
+  const { deps, logs } = fakeDeps({ readNotes: () => notes });
+  const code = runLint([], deps);
+  assert.equal(code, 1);
+  assert.equal(logs[0], "Scanned 1 notes under /brain/vault");
+  assert.ok(logs.includes("✗ Wiki health: issues found"), "prints the bleeding header");
+  assert.ok(logs.includes("  a.md → [[Missing]]"), "lists the dangling link");
+});
+
+test("runLint — an explicit path argument overrides the default ./vault", () => {
+  const { deps, seenDirs } = fakeDeps();
+  runLint(["/data/other-vault"], deps);
+  assert.deepEqual(seenDirs, ["/data/other-vault"]);
+});

--- a/scripts/session-actions-log.mjs
+++ b/scripts/session-actions-log.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// session-actions-log.mjs — SessionStart hook that makes the append-only activity
+// ledger FIRST-CLASS (Track E). The installer seeds it for new brains; this hook is
+// the ongoing maintainer bound to a real event (rung 3 of the determinism ladder,
+// ADR 0009): it seeds-if-absent on every SessionStart, so an UPGRADER that never
+// re-runs the installer still gains the ledger at its next session — and a brain
+// whose ledger was deleted quietly regains it.
+//
+// Determinism ladder: the TRIGGER is a deterministic hook (this), the SEED is a pure
+// write-if-absent (rung 2, `seedActionsLog` — never overwrites real history), and
+// the SURFACE is an additionalContext note the agent relays in the chat (the only
+// Desktop-visible channel), ONCE, on the session that first created the ledger.
+//
+// Contract: quiet unless it just seeded, fail-open (never throws, ALWAYS exits 0).
+// Wired as a SessionStart hook AFTER session-wiki-health.mjs (cf. .claude/settings.json).
+// Cross-OS: pure Node.
+// ─────────────────────────────────────────────────────────────────────────────
+import { dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { seedActionsLog, buildActionsLogHookOutput } from "./lib/actions-log-seed.mjs";
+
+// Testable core: seed the ledger (injected), and signal the seeding outcome only
+// when it actually wrote this session. Fail-open — a seed hiccup (odd fs, races)
+// must never disturb session start.
+export function sessionActionsLog({ seedLog, emit }) {
+  try {
+    const { seeded } = seedLog();
+    if (seeded) {
+      emit(true);
+      return { seeded: true };
+    }
+  } catch {
+    // swallow — fail-open; a seed hiccup must never break session start.
+  }
+  return { seeded: false };
+}
+
+// ── main: wire the real fs seams (deterministic glue, not unit-tested) ──
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const brainDir = resolve(__dirname, "..");
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC), same as sync-sources
+  let seeded = false;
+
+  sessionActionsLog({
+    seedLog: () => seedActionsLog({ brainDir, today }),
+    emit: (v) => (seeded = v),
+  });
+
+  const output = buildActionsLogHookOutput(seeded);
+  if (output) {
+    // additionalContext is the ONLY Desktop-visible channel (chat) — see buildActionsLogHookOutput.
+    process.stdout.write(JSON.stringify(output) + "\n");
+  }
+  process.exit(0); // fail-open: ALWAYS exit 0, never block session start
+}

--- a/scripts/session-actions-log.test.mjs
+++ b/scripts/session-actions-log.test.mjs
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { sessionActionsLog } from "./session-actions-log.mjs";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Track E — SessionStart hook that makes the activity ledger first-class: it
+// seeds-if-absent on a real event (rung 3, ADR 0009) so every brain — including
+// upgraders that never re-run the installer — gains the ledger, and surfaces a
+// one-time note only when it just seeded (quiet otherwise). Fail-open.
+// ═══════════════════════════════════════════════════════════════════════════
+
+function seams(overrides = {}) {
+  const calls = { emitted: [] };
+  const base = {
+    seedLog: () => ({ seeded: true, present: true }),
+    emit: (v) => calls.emitted.push(v),
+  };
+  return { args: { ...base, ...overrides }, calls };
+}
+
+test("sessionActionsLog — emits once when it just seeded the ledger", () => {
+  const { args, calls } = seams();
+  const result = sessionActionsLog(args);
+  assert.deepEqual(result, { seeded: true });
+  assert.deepEqual(calls.emitted, [true]);
+});
+
+test("sessionActionsLog — stays silent when the ledger already existed", () => {
+  const { args, calls } = seams({ seedLog: () => ({ seeded: false, present: true }) });
+  const result = sessionActionsLog(args);
+  assert.deepEqual(result, { seeded: false });
+  assert.deepEqual(calls.emitted, []);
+});
+
+test("sessionActionsLog — fail-open: a seed hiccup never throws nor emits", () => {
+  const { args, calls } = seams({
+    seedLog: () => {
+      throw new Error("odd fs");
+    },
+  });
+  const result = sessionActionsLog(args);
+  assert.deepEqual(result, { seeded: false });
+  assert.deepEqual(calls.emitted, []);
+});
+
+test("settings.json.template wires session-actions-log as a SessionStart hook, AFTER session-wiki-health", () => {
+  const settings = JSON.parse(
+    readFileSync(join(REPO_ROOT, ".claude", "settings.json.template"), "utf8"),
+  );
+  const commands = settings.hooks.SessionStart.flatMap((entry) => entry.hooks.map((h) => h.command));
+  const actionsIdx = commands.findIndex((c) => c.includes("session-actions-log.mjs"));
+  const wikiIdx = commands.findIndex((c) => c.includes("session-wiki-health.mjs"));
+  assert.ok(actionsIdx >= 0, "session-actions-log.mjs must be wired on SessionStart");
+  assert.ok(wikiIdx >= 0, "session-wiki-health.mjs must stay wired on SessionStart");
+  assert.ok(wikiIdx < actionsIdx, "actions-log must run after wiki-health");
+});
+
+test("engine-manifest carries session-actions-log in the replace regime", () => {
+  const manifest = JSON.parse(readFileSync(join(REPO_ROOT, "engine-manifest.json"), "utf8"));
+  assert.ok(
+    manifest.regimes.replace.includes("scripts/session-actions-log.mjs"),
+    "the hook must ship to the fleet via the replace regime",
+  );
+});

--- a/scripts/session-wiki-health.mjs
+++ b/scripts/session-wiki-health.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// session-wiki-health.mjs — SessionStart Axis-1 nudge (Track F). Runs the wiki's
+// deterministic health scans on a real event (rung 3 of the determinism ladder,
+// ADR 0009) so consolidation / dangling-link maintenance stops depending on the
+// user remembering to ask — WITHOUT ever turning a silent auto-write loose.
+//
+// Determinism ladder: the TRIGGER is a deterministic hook (this), the DETECTION is
+// the pure lint + consolidation cores (rung 1), the SURFACE is an additionalContext
+// DIRECTIVE the agent relays in the chat (the only Desktop-visible channel), and the
+// WRITE stays fully confirmed on-demand (/consolidate = propose → yes), never here.
+//
+// It surfaces ONLY the self-clearing / true-regression signals (consolidation
+// candidates + dangling links); orphans/stale/frontmatter stay in the on-demand
+// /lint (a standing backlog would spam every session). See wiki-health-nudge.mjs.
+//
+// Contract: quiet unless actionable, fail-open (never throws, the hook ALWAYS exits 0).
+// Wired as a SessionStart hook AFTER session-self-heal.mjs (cf. .claude/settings.json).
+// Cross-OS: pure Node.
+// ─────────────────────────────────────────────────────────────────────────────
+import { dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
+import { lintVault } from "./lib/wiki-lint.mjs";
+import { consolidationCandidates } from "./lib/consolidation-candidates.mjs";
+import { wikiHealthNudge, buildWikiHealthHookOutput } from "./lib/wiki-health-nudge.mjs";
+
+// Testable core: read the vault (injected), run the two deterministic scans, emit
+// the nudge only when there's something actionable. Fail-open — a missing/odd vault
+// must never disturb session start.
+export function sessionWikiHealth({ readNotes, vaultDir, emit }) {
+  try {
+    const notes = readNotes(vaultDir);
+    const nudge = wikiHealthNudge({
+      lintReport: lintVault(notes),
+      consolidationReport: consolidationCandidates(notes),
+    });
+    if (nudge) {
+      emit(nudge);
+      return { reported: true };
+    }
+  } catch {
+    // swallow — fail-open; a scan hiccup must never break session start.
+  }
+  return { reported: false };
+}
+
+// ── main: wire the real read-only seams (deterministic glue, not unit-tested) ──
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const brainDir = resolve(__dirname, "..");
+  const vaultDir = join(brainDir, "vault");
+  let nudge = null;
+
+  sessionWikiHealth({
+    readNotes: readVaultNotes,
+    vaultDir,
+    emit: (msg) => (nudge = msg),
+  });
+
+  const output = buildWikiHealthHookOutput(nudge);
+  if (output) {
+    // additionalContext is the ONLY Desktop-visible channel (chat) — see buildWikiHealthHookOutput.
+    process.stdout.write(JSON.stringify(output) + "\n");
+  }
+  process.exit(0); // fail-open: ALWAYS exit 0, never block session start
+}

--- a/scripts/session-wiki-health.test.mjs
+++ b/scripts/session-wiki-health.test.mjs
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { sessionWikiHealth } from "./session-wiki-health.mjs";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// sessionWikiHealth is the Track-F SessionStart core: it reads the vault (injected),
+// runs the deterministic lint + consolidation scans, and emits the chat nudge ONLY
+// when there is something actionable (dangling links or consolidation candidates).
+// Fail-open: it never throws, so it can never disturb session start.
+
+// A capture note under a capture zone, citing a target that has no page yet — a
+// new-page consolidation candidate that makes the nudge fire.
+const captureCitingMissingPage = {
+  path: "meetings/2026-07-10.md",
+  frontmatter: { type: "meeting", created: "2026-07-10", updated: "2026-07-10", tags: ["m"] },
+  body: "Met with [[Acme Corp]] about the roadmap.",
+};
+
+function seams(overrides = {}) {
+  const calls = { emitted: [] };
+  const base = {
+    vaultDir: "/brain/vault",
+    readNotes: () => [captureCitingMissingPage],
+    emit: (msg) => calls.emitted.push(msg),
+  };
+  return { args: { ...base, ...overrides }, calls };
+}
+
+test("sessionWikiHealth — empty vault → emits nothing (quiet)", () => {
+  const { args, calls } = seams({ readNotes: () => [] });
+  sessionWikiHealth(args);
+  assert.deepEqual(calls.emitted, []);
+});
+
+test("sessionWikiHealth — a capture citing a page-less entity → emits the consolidation nudge", () => {
+  const { args, calls } = seams();
+  sessionWikiHealth(args);
+  assert.equal(calls.emitted.length, 1);
+  assert.match(calls.emitted[0], /1 consolidation candidates/);
+  assert.match(calls.emitted[0], /\/consolidate/);
+});
+
+test("sessionWikiHealth — reads FROM the given vaultDir", () => {
+  const seen = [];
+  const { args } = seams({ readNotes: (dir) => (seen.push(dir), []) });
+  sessionWikiHealth(args);
+  assert.deepEqual(seen, ["/brain/vault"]);
+});
+
+test("sessionWikiHealth — fail-open: a throwing readNotes never propagates, emits nothing", () => {
+  const { args, calls } = seams({
+    readNotes: () => {
+      throw new Error("vault unreadable");
+    },
+  });
+  sessionWikiHealth(args); // must NOT throw
+  assert.deepEqual(calls.emitted, []);
+});
+
+test("settings.json.template wires session-wiki-health as a SessionStart hook, AFTER session-self-heal", () => {
+  const settings = JSON.parse(
+    readFileSync(join(REPO_ROOT, ".claude", "settings.json.template"), "utf8"),
+  );
+  const commands = settings.hooks.SessionStart.flatMap((entry) => entry.hooks.map((h) => h.command));
+  const wikiIdx = commands.findIndex((c) => c.includes("session-wiki-health.mjs"));
+  const selfHealIdx = commands.findIndex((c) => c.includes("session-self-heal.mjs"));
+  assert.ok(wikiIdx >= 0, "session-wiki-health.mjs must be wired on SessionStart");
+  assert.ok(selfHealIdx >= 0, "session-self-heal.mjs must stay wired on SessionStart");
+  assert.ok(selfHealIdx < wikiIdx, "wiki-health must run after self-heal (the restart nudge keeps priority)");
+});

--- a/templates/fr/.claude/skills/sync-sources/SKILL.md
+++ b/templates/fr/.claude/skills/sync-sources/SKILL.md
@@ -241,15 +241,18 @@ Pas de section vide — l'omettre. Chaque signal cite sa source (crochets ou bac
 
 ### Étape 5 — Append dans `vault/actions-log.md`
 
-**Appender** (créer le fichier s'il n'existe pas) une ligne plate par action, préfixée de la date —
-pas de frontmatter, fichier *grep-able* :
+Le ledger est un **artefact de première classe, initialisé (seedé)** : il est créé à l'installation
+et re-seedé (s'il venait à manquer) au démarrage de session par le hook `session-actions-log`, donc
+il existe normalement déjà - il suffit d'**appender** une ligne plate et *grep-able* par action sous
+son en-tête (le créer quand même s'il est absent) :
 
 ```markdown
 ## [YYYY-MM-DD] <action> — #canal [[people/destinataire]]
 ```
 
-**Append-only** : ne jamais réécrire les lignes existantes. Usage : « qu'est-ce que j'ai fait sur
-X ? » → `grep -i "X" vault/actions-log.md` puis enrichissement via les briefings référencés.
+**Append-only** : ne jamais réécrire les lignes existantes ni l'en-tête seedé. Usage : « qu'est-ce
+que j'ai fait sur X ? » → `grep -i "X" vault/actions-log.md` puis enrichissement via les briefings
+référencés.
 
 ## Mode re-exécution (même jour)
 


### PR DESCRIPTION
## Why

The study `llm-wiki-vs-embedding-rag-karpathy-graphify.md` (§8 audit) established that Kenjaku ships **Axis 2** (retrieval / RAG) as a full versioned, tested, auto-updating engine, but shipped **Axis 1** (the LLM-Wiki compile / consolidation discipline) as **constitution conventions with zero enforcement**. This PR gives Axis 1 real *mechanics*: deterministic where it can be, LLM only where judgment is the point, writes always confirmed.

Positioning / lineage lives in **ADR 0033** (we descend from Karpathy's LLM Wiki, sibling of Graphify, no false anteriority).

## What ships (Tracks A to F, all TDD, all proven on the real 405-note vault)

- [x] **A. `/lint`** wiki-health scanner: a pure I/O-free core (`wiki-lint.mjs`) reports dangling `[[links]]`, orphans, stale entity pages, frontmatter violations; thin CLI with a binary exit; engine skill. The real vault immediately paid off (exposed the path-form link-resolution bug: dangling 795 to 47).
- [x] **B. `/file-back`**: a deterministic note builder (`filed-note.mjs`, conformant by construction, refuses to overwrite) + a thin CLI + an engine skill. A filed note passes `/lint` clean.
- [x] **C. `/consolidate`**: a deterministic candidate finder (`consolidation-candidates.mjs`, stateless "fresher-than-the-page" rule) + a fan-out/fan-in skill (`sync-sources` shape) that proposes each merge and writes via B (never overwrites).
- [x] **D. Contradiction-flagging**: folded into C's refresh pass (facts live in prose here, so detection is irreducibly LLM). The refresh sub-agent surfaces a `### contradictions` block, the human adjudicates, a stated fact is never silently overwritten. Strictly conservative: it can only help catch a conflict.
- [x] **E. Append-only ledger first-class**: `vault/actions-log.md` becomes a seeded artifact maintained by a SessionStart hook (seed-if-absent, never overwrites), not a `sync-sources` by-product.
- [x] **F. Deterministic trigger**: a SessionStart hook (`session-wiki-health.mjs`) fires the scans on a real event and surfaces them via `additionalContext` (the only Desktop-visible channel); the write stays confirmed.

## Design spine (ADR 0009 determinism ladder)

Every track has the same three-rung shape: **detection is deterministic** (a pure, faked-fs core, unit-tested), **the merge is LLM judgment** (read-only sub-agents, no context rot), **the write is deterministic and confirmed** (reuse B's builder, refuses to overwrite). Nothing auto-writes unattended.

## Delivery

These are **engine features** (generic, never carry private content). They ship fleet-wide via `update-engine` (manifest `replace` buckets for `scripts/**`, `scripts/lib/**`, `engine-skills/**`; `engineVersion.scripts` walked 1.1.0 to 1.7.0 across the tracks) and self-install via `reconcileHooks` (add-if-absent). The installer seeds fresh brains.

## Tests

Full suite **654/654 green**. Strict TDD on every deterministic core (Track D is a prompt-level judgment change, so no engine test to add there).

## Out of scope (Thomas-side, need the running vault / private content)

- [ ] Cross-cutting: measure the effect on retrieval on the eval-set (needs the RAG running on a real indexed vault).
- [ ] The formal import of the private brain, then iterate A + C against it (private content, separate chantier).

An optional deterministic complement to D (flag *colliding entity pages* into `/lint`) is noted in the plan but deliberately left out, to avoid substituting a deterministic proxy for the LLM feature D actually asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
