### PR TITLE
docs(plans): fleet-upgrade sequencing decision + ROADMAP ordering authority

### DIFF
--- a/maintainers/plans/ROADMAP.md
+++ b/maintainers/plans/ROADMAP.md
@@ -1,0 +1,91 @@
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- STATUS: 🧭 LIVING — ordering authority across the active plans.               -->
+<!-- This file owns the CROSS-PLAN ORDER only. It never duplicates a plan's         -->
+<!-- content (checkboxes, done/remains, commits): each plan stays the single        -->
+<!-- source of truth for its own state; this is the map that says which goes first. -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+
+# 🧭 ROADMAP — cross-plan ordering authority
+
+**What this is.** A single place that answers *"which plan moves next, and what must ship before
+what?"* when several plans are in flight at once. It is a **map + a gate-list**, deliberately thin:
+pointers, not copies. Each plan below remains the **canonical** owner of its own steps, commits and
+remaining work; do not restate that here (anti-context-rot). Open a plan to work it; open this file
+to know the **order**.
+
+> Sibling conventions: `maintainers/CONVENTIONS.md` (checkboxes on every step; one canonical plan =
+> the repo's; plan-done = archived). Memory pointer: `fleet-upgrade-sequencing`.
+
+---
+
+## The invariant (the one order not to re-invert)
+
+Decided with Thomas 2026-07-18. When juggling plans, keep this sequence:
+
+1. 🟢 **Green** — legacy-**safe** fresh-install layering of the constitution (new engine-owned
+   `CLAUDE.engine.md` in the `replace` regime; `CLAUDE.md` **stays** in `SACRED_FILES`, so deployed
+   monolithic brains are never clobbered). **Must ship BEFORE the migration's *generate* step**, so
+   the regenerated personal brain is born two-layer.
+2. 🧠 **Migration generate** — Track D of the migration plan (generate → import 405 notes → layer the
+   private capabilities). Depends on green.
+3. 🔴 **Fleet re-layering + big-jump upgrade experience** — retro-fit already-deployed monolithic
+   brains (~v3.2.x) and build the broader upgrade UX: **(A)** completeness across a big jump,
+   **(B)** "what you gained" notes (reuse the *The One With…* codenames), **(C)** pre-flight reindex
+   preview said *before* upgrading. Heavy QA on fixtures reproduced from the release tag(s).
+   **Deferred to AFTER the migration.**
+
+**Why deferring 🔴 is safe:** the constitution is `sacred`, `constitutionTemplate` is frozen at
+`1.0.0`, and `indexSchemaVersion` has been `1` continuously since before v3.2.1 → a **v3.2.x →
+current jump triggers NO reindex**, and `update-engine` is state-convergent (one jump converges).
+Nothing forces the fleet's upgrade in the interim.
+
+---
+
+## Tracking (the gates, in order)
+
+- [ ] **Gate 1 — 🟢 Green: legacy-safe fresh-install layering.**
+  - [ ] Add engine-owned `CLAUDE.engine.md` (`replace`), keep `CLAUDE.md` in `SACRED_FILES`
+        (`scripts/lib/engine-apply-plan.mjs`); thin sacred `CLAUDE.md` `@import`s it.
+  - [ ] Do-no-harm QA: a reproduced legacy brain updating past green is untouched (no `CLAUDE.md`
+        clobber, no reindex, no behaviour change).
+  - [ ] **Canonical plan:** `prospective/engine-managed-file-merge-strategy.md` → §"Sequencing decision".
+- [ ] **Gate 2 — 🧠 Migration generate (depends on Gate 1).**
+  - [ ] Track D: generate brain → `/import` ~405 notes → layer private capabilities.
+  - [ ] **Canonical plan:** `prospective/second-brain-migration-and-engine-upstream-action.md` → Track D.
+- [ ] **Gate 3 — 🔴 Fleet re-layering + big-jump upgrade experience (deferred until after Gate 2).**
+  - [ ] (A) Completeness across a big jump (frozen files: constitution + shipped user-skills).
+  - [ ] (B) Benefit-framed changelog spanning the jump (*The One With…* substrate).
+  - [ ] (C) Pre-flight preview: apply plan **and** reindex decision, shown before applying.
+  - [ ] QA fixtures reproduced from the release **tag(s)** + synthetic personal edits; first enumerate
+        the versions actually deployed.
+  - [ ] Likely graduates to its own plan ("engine upgrade experience for the deployed fleet");
+        F-B7e (constitution re-layering) becomes one component of it.
+  - [ ] **Canonical plan:** `prospective/engine-managed-file-merge-strategy.md` → §"Sequencing decision" (deferred half).
+
+> Determinism note (once green exists): consider a lightweight guard that fails loud if a release
+> bumps `constitutionTemplate` before green has shipped — turning this ordering invariant into an
+> enforced gate rather than a written one (ADR 0009 spirit).
+
+---
+
+## The map — active plans
+
+| Plan (canonical) | What it delivers | Gate | Status |
+| --- | --- | --- | --- |
+| `prospective/engine-managed-file-merge-strategy.md` | Propagate engine improvements into user-editable provided files (constitution + shipped skills) without clobbering edits. | 1 & 3 | 🔭 Prospective / analysis; sequencing decided. |
+| `prospective/second-brain-migration-and-engine-upstream-action.md` | Migrate the pre-existing personal brain (~405 notes) + upstream the generic delta. | 2 | In progress: Tracks A/B/C DONE (PR #29/#30/#32); **Track D next**; F post-migration. |
+
+> Other in-flight plans on their own branches (e.g. wiki-health axis 1, marketing page) are **not
+> part of this fleet-upgrade ordering** and are tracked by their own plans + memory pointers; they
+> are listed here only if/when they gain a cross-plan dependency.
+
+---
+
+## How to use this file
+
+- **Picking up work after a `/clear`:** read the invariant, find the **first unchecked gate**, open
+  its canonical plan, and resume at that plan's first `- [ ]`.
+- **Finishing a gate:** check it here **and** in its canonical plan, with _(date · commit)_. Keep the
+  two in sync; if they ever disagree, the **canonical plan wins** (this file is only the order).
+- **Adding a plan to the fleet order:** add one row to the map + one gate, both as pointers. Never
+  paste the plan's internal steps here.

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -88,6 +88,10 @@ bump). Until then, the current install-if-absent / sacred behavior is the correc
 
 ## Sequencing decision (2026-07-18) — after the personal-brain migration; broaden to the fleet's upgrade experience
 
+> **Cross-plan order:** this section is Gate 1 (green) and Gate 3 (fleet re-layering) of
+> [`../ROADMAP.md`](../ROADMAP.md), the ordering authority. This plan owns the *how*; the ROADMAP owns
+> the *order relative to the migration*.
+
 **Decision.** Build the *legacy re-layering* (retro-fitting existing monolithic brains) **after** the personal
 second-brain migration (`second-brain-migration-and-engine-upstream-action.md`, Track D). Ship **only** the
 *legacy-safe fresh-install layering* **before** that migration's generate step, so the regenerated personal

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -2,6 +2,11 @@
 <!-- STATUS: 🔭 PROSPECTIVE / ANALYSIS (2026-06-21) — design captured, not yet an  -->
 <!-- ADR, NOT implemented. Provisional direction agreed; decide + write the ADR     -->
 <!-- when a release actually changes the constitution (see "Why this is non-blocking"). -->
+<!-- SEQUENCING DECIDED (2026-07-18): fresh-install "green" (legacy-safe) ships       -->
+<!-- BEFORE the personal-brain migration; the deployed fleet's re-layering + the      -->
+<!-- broader big-jump upgrade experience (completeness, what-you-gained notes,        -->
+<!-- pre-flight reindex preview) + heavy QA are deferred AFTER it. See "Sequencing    -->
+<!-- decision" below.                                                                 -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # Propagating engine improvements into user-editable provided files (constitution + shipped skills)
@@ -54,6 +59,9 @@ install-if-absent behavior for shipped skills.
   edits scattered anywhere — the `ENGINE:BEGIN/END` boundary cannot be inferred retroactively without risk
   of capturing a personal edit inside the engine block. Option 3 needs a migration story (likely lean on the
   2/1 net for the first jump, or introduce the boundary only on fresh installs + a guided one-time migration).
+  _(Sequencing + safety framing decided 2026-07-18, see "Sequencing decision": fresh installs get the
+  boundary; deployed monoliths stay sacred/untouched and are re-layered later via an opt-in, QA'd upgrade,
+  never inferred blindly. The retro-fit split algorithm itself still to design.)_
 - [ ] **Editing an engine *instruction*** (not just adding one's own) — prose doesn't override like CSS;
   decide whether that's supported (probably via the personal zone / overrides, or accepted as out-of-scope).
 - [ ] **Where the base lives** for option 2 (store the rendered base, or the template version + params to
@@ -77,6 +85,51 @@ independent reasons — so this enhancement is not required to ship any current 
 
 This enhancement becomes relevant only the day a release *does* change the constitution (a `constitutionTemplate`
 bump). Until then, the current install-if-absent / sacred behavior is the correct, safe default.
+
+## Sequencing decision (2026-07-18) — after the personal-brain migration; broaden to the fleet's upgrade experience
+
+**Decision.** Build the *legacy re-layering* (retro-fitting existing monolithic brains) **after** the personal
+second-brain migration (`second-brain-migration-and-engine-upstream-action.md`, Track D). Ship **only** the
+*legacy-safe fresh-install layering* **before** that migration's generate step, so the regenerated personal
+brain is born two-layer. This surfaced while realising the concern is broader than the constitution merge: it
+is the **whole upgrade experience for the brains already deployed in the field** from an earlier Kenjaku
+release (the pre-layering, monolithic-constitution line, ~v3.2.x).
+
+- [ ] **Fresh-install layering ("green") is a prerequisite of the migration's generate step, and must be
+      legacy-SAFE by construction.** Do **not** remove `CLAUDE.md` from `SACRED_FILES`
+      (`scripts/lib/engine-apply-plan.mjs:32`): that would expose every deployed monolithic brain to a clobber
+      on its next update. Instead **add a new engine-owned constitution layer file** (e.g. `CLAUDE.engine.md`,
+      in `replace`, absent from `SACRED_FILES`) that a fresh, thin, sacred `CLAUDE.md` `@import`s. Deployed
+      monolithic brains keep their sacred `CLAUDE.md` untouched (they simply lack the new file).
+  - [ ] **Green-time "do-no-harm" QA (required before releasing green):** prove a reproduced legacy brain
+        updating past green is untouched — no clobber of its `CLAUDE.md`, no reindex, no behaviour change.
+- [ ] **The heavy re-layering QA is safely deferred to AFTER the migration.** The deployed fleet is safe in the
+      interim, for the reasons in "Why this is non-blocking": sacred `CLAUDE.md`, `constitutionTemplate` frozen
+      at `1.0.0`, a stale constitution cannot break the engine. Nothing forces their upgrade.
+- [ ] **The deferred chantier is the fleet's UPGRADE EXPERIENCE, not only the constitution merge.** Scope:
+  - [ ] **(A) Completeness across a big jump.** `update-engine` is **state-convergent** (fetch the latest ref,
+        apply the current manifest's regimes → one jump converges to target; the manifest + reconciler are
+        present since before v3.2.1), so no intermediate versions are replayed. The remaining completeness gap
+        is exactly the **frozen** files: the constitution (this plan) and the shipped user-skills under
+        `.claude/skills/` (`coach`, `prepare-1-1`, … install-if-absent). Close them the same way.
+  - [ ] **(B) Tell the user what they gained.** A human, benefit-framed changelog spanning the jump (from the
+        brain's recorded ref to target), surfaced at upgrade. Reuse the "The One With…" release codenames as the
+        substrate; suited to non-technical owners.
+  - [ ] **(C) Pre-flight preview (say it BEFORE upgrading).** A dry-run that computes the apply plan **and the
+        reindex decision** (recorded vs target `indexSchemaVersion`) and shows it before applying: what lands,
+        and whether notes will be re-encoded + the rough cost. Today `update-engine` reports reindex only
+        *after* (`scripts/update-engine.mjs:15`, `runReindex` IFF the schema moved); expose it *ahead*.
+  - [ ] **Grounded reindex fact:** `indexSchemaVersion` has been **`1` continuously** since before v3.2.1
+        (introduced 2026-06-14, never changed) through today → a **v3.2.x → current jump triggers NO reindex**.
+        A reindex only ever fires if the index format changes in the future — exactly when (C) earns its keep.
+  - [ ] **QA fixtures:** reproduce legacy brains from the release **tag(s)** (checkout the deployed version, run
+        the installer) + **synthetic** personal edits to exercise the nasty boundary cases. Never use real
+        deployed brains' private content. First step: **enumerate the versions actually deployed** so QA covers
+        the real span.
+- [ ] **This deferred chantier likely graduates to its own plan** ("engine upgrade experience for the deployed
+      fleet") when picked up; F-B7e (constitution re-layering) becomes one component of it.
+
+> Cross-ref: the reciprocal prerequisite note lives in the migration plan's Track D.
 
 ## Next steps (post-demo)
 

--- a/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
+++ b/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
@@ -207,11 +207,23 @@ names/IDs, org/account emails, product-team names, and any private-project refer
 
 - [ ] Generate a fresh brain from the launcher (after Track A + generic bits of B/C have landed
       upstream), choosing the embedder consciously (privacy trade-off).
+  - [ ] **Prerequisite (engine):** the *legacy-safe fresh-install constitution layering* ("green") must land
+        in the launcher FIRST, so the regenerated brain is **born two-layer** and future constitution
+        improvements keep flowing to it. See the "Sequencing decision" in
+        `engine-managed-file-merge-strategy.md`. Skipping it would make this brand-new brain a future
+        monolithic-legacy case.
 - [ ] From the **new** brain, run `/import` pointing at the source vault → 405 notes + attachments
       (demo skipped, no overwrite).
 - [ ] Reindex; verify with a canary query (`node scripts/verify-rag.mjs` → exit 0).
 - [ ] Layer the **private** skills (Track B) and the **merged** constitution (Track C) into the new
       brain (these are the parts that never go through the launcher).
+
+> **Not a fleet fixture.** The source brain is **not** a Kenjaku brain (it only supplies the notes to
+> `/import`), so it is **not** a legacy-upgrade fixture. Re-layering the brains already deployed from an
+> earlier Kenjaku release, and its substantial QA (completeness across a big jump, a "what you gained"
+> changelog, a pre-flight reindex preview), is a **separate, deferred** chantier: see
+> `engine-managed-file-merge-strategy.md` §"Sequencing decision". Deferring it is safe: those brains are
+> sacred/working today and a v3.2.x → current jump triggers no reindex (`indexSchemaVersion` unchanged).
 
 ---
 

--- a/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
+++ b/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
@@ -205,6 +205,9 @@ names/IDs, org/account emails, product-team names, and any private-project refer
 
 ## Track D — Corpus migration (personal brain)
 
+> **Cross-plan order:** this is Gate 2 of [`../ROADMAP.md`](../ROADMAP.md) — it depends on Gate 1
+> (green) landing first (see the prerequisite below).
+
 - [ ] Generate a fresh brain from the launcher (after Track A + generic bits of B/C have landed
       upstream), choosing the embedder consciously (privacy trade-off).
   - [ ] **Prerequisite (engine):** the *legacy-safe fresh-install constitution layering* ("green") must land


### PR DESCRIPTION
## What

Record the **cross-plan ordering** for the fleet-upgrade work and give it a single home.

- **`maintainers/plans/ROADMAP.md`** (new) — a thin **map + checkable gate-list** that owns the
  cross-plan *order* only, pointing at each canonical plan instead of duplicating its state
  (anti-context-rot). The invariant it encodes:
  1. 🟢 **Green** — legacy-safe fresh-install constitution layering (new engine-owned
     `CLAUDE.engine.md` in `replace`; `CLAUDE.md` stays `SACRED` → deployed monoliths never clobbered).
     Ships **before** the migration's *generate* step.
  2. 🧠 **Migration generate** (Track D) — depends on green, so the regenerated brain is born two-layer.
  3. 🔴 **Fleet re-layering + big-jump upgrade experience** (completeness, "what you gained" notes,
     pre-flight reindex preview) — deferred **after** the migration.
- **Sequencing decision** captured in `engine-managed-file-merge-strategy.md` (§"Sequencing decision").
- **Reciprocal back-pointers** added so each plan points at the ROADMAP: the merge-strategy plan
  (Gate 1 & 3) and the migration plan's Track D (Gate 2, depends on Gate 1).

## Why

Several plans are in flight at once; the order between them (green → migrate → re-layer) is easy to
re-invert when juggling. This makes the order explicit and checkable, without copying plan content.

## Why deferring the 🔴 fleet re-layering is safe

Constitution is `sacred`, `constitutionTemplate` is frozen at `1.0.0`, and `indexSchemaVersion` has
been `1` continuously since before v3.2.1 → a v3.2.x → current jump triggers **no reindex**, and
`update-engine` is state-convergent. Nothing forces the fleet's upgrade in the interim.

## Scope

Docs-only. 3 files, +163 lines. No code, no engine or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)