### PR TITLE
fix(import): register the universe so imported notes become /switch-able

### DIFF
--- a/.claude/skills/import/SKILL.md
+++ b/.claude/skills/import/SKILL.md
@@ -78,22 +78,35 @@ node scripts/import-brain.mjs "<source>" --apply
 ```
 It copies the planned files into `vault/`, preserving subfolders, **never overwriting** a collision.
 
-### Optional — import INTO a universe (`--universe <name>`, advanced)
+### Import INTO a universe: ask once on a whole-brain migration (`--universe <name>`)
 
-If the user wants the imported notes to land in a **specific universe** (ADR 0034 — e.g. re-homing a
-*previous employer's* notes as their own retrieval scope, distinct from the owner's cross-cutting
-notes), pass `--universe <name>` on **both** the plan and the apply commands:
+Re-homing a **whole previous brain** (a distinct sphere: a *past employer's* notes, a client, a bounded
+context) is the textbook case for a **universe** (ADR 0034). So, before showing the plan, **proactively
+ask one light question**:
+
+> *"Do these notes belong to a **universe** of their own (for instance a past employer or a client, kept
+> as a separate retrieval scope), or to your general / default notes?"*
+
+- **A separate sphere → pass `--universe <name>`** on **both** the plan and the apply commands.
+- **General / default → no flag** (today's behaviour). Don't ask this on a small ad-hoc import of a few
+  loose notes: only when a whole brain / a clearly distinct sphere is in play (keep the feature
+  invisible-until-needed).
+
 ```bash
 node scripts/import-brain.mjs "<source>" --universe "<name>"          # plan
 node scripts/import-brain.mjs "<source>" --universe "<name>" --apply  # apply
 ```
-The core then **routes** every imported file under `vault/<name>/…` (self-contained subtree) and
-**stamps** each note's frontmatter with `universe: <name>` (additive: an existing `universe:` key is
-never clobbered). The name is normalized to a safe slug; attachments travel byte-for-byte.
 
-> 🧭 **Only offer this if it fits.** Most imports go to the default (no flag) — a single-universe
-> brain never needs it. Surface it when the user is clearly bringing in a **separate sphere** they
-> want scoped on its own. Importing into a universe does **not** auto-`/switch` to it.
+With a universe, the core:
+- **routes** every imported file under `vault/<name>/…` (self-contained subtree) and **stamps** each
+  note's frontmatter with `universe: <name>` (additive: an existing `universe:` key is never clobbered;
+  attachments travel byte-for-byte, never stamped). The name is normalized to a safe slug.
+- **registers** `<name>` in the brain's universe registry, so it becomes a real, **`/switch`-able**
+  scope right away and the brain crosses into multi-universe mode (the progressive-disclosure reminder +
+  `/switch` onboarding start to surface).
+
+> 🧭 **It does NOT auto-`/switch` to the imported universe.** After the import, tell the user they can
+> **`/switch <name>`** to work inside it (their default / cross-cutting notes stay visible there too).
 
 ### Step 4 — Reindex (so the imported notes are searchable)
 The new notes must be indexed before the RAG can find them. Incremental indexing is enough — we only

--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ The infra, the storage, the concurrency, the guardrails: that's **its** job — 
 > updates quietly in the background if it finds something new — a bit like a web page that displays
 > instantly then refreshes on its own. The details are in [under the hood](#under-the-hood).
 
+## 🌌 One brain, several universes (optional)
+
+Life comes in chapters: a past employer then a new one, several clients, your work sphere and your
+personal one. Your second brain can hold all of them in one place while still knowing which is which.
+Each of these worlds is called a **universe**. When you're working inside one, your brain answers from
+*that* universe's notes (plus the handful you keep as **cross-cutting**, valid everywhere, like your own
+methods, habits or preferences), so a question about your current job doesn't drag in years of
+unrelated history. You stay in charge: a plain *"switch to my Acme universe"* changes the scope, and a
+rare *"search across all my universes"* looks everywhere at once. Best of all, it stays **invisible
+until you actually need it**: as long as you have a single universe, nothing shows up (no new folder, no
+extra step, no reminder), and your brain behaves exactly as it does today. Universes only surface the
+day you create a second one.
+
 ## Not sure what to ask it? Start here
 
 A few opening lines to get going — just talk to it the way you'd brief an assistant. Bonus: each one
@@ -471,6 +484,13 @@ The hands-on steps (and how to run it yourself, if you're technical) are in
 **It's safe by construction:** it copies your notes (and their attachments, with subfolders preserved)
 **only** — never the old engine — and it **never overwrites** an existing note (a name collision is
 *skipped* and reported). Demo notes don't travel.
+
+> 🌌 **Landing your old notes in a universe (optional).** If you organise your brain into
+> [universes](#one-brain-several-universes-optional), you can tell the import which one your old notes
+> belong to, for instance *"import my old notes from `<path>` into my Acme universe"*. They all arrive
+> **stamped into that universe**, so switching to it later brings them back cleanly, without mixing them
+> into the rest. Say nothing about universes and everything imports the normal way, into your default
+> scope, exactly as before.
 
 > ⚠️ **The one footgun, said plainly:** point it at your **old brain folder** — don't try to copy the
 > *whole* folder by hand into the new one (that's what used to clobber the new engine). The import

--- a/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
+++ b/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
@@ -196,10 +196,12 @@ names/IDs, org/account emails, product-team names, and any private-project refer
 > (EN in English, FR in French, no em-dash). The 564 harness tests stay green (incl. the
 > constitution-mirror-citations parity test).
 >
-> **Discovered drift (out of Track C scope, follow-up):** the FR overlay is still missing the EN base's
-> §4 **"Local mirrors"** routing section (the `mcp__local-mirror__*` tool table + routing rule) — a
-> localization gap for `fr` brains, unrelated to the source-brain merge. Track separately: a FR↔EN
-> constitution parity pass.
+> **Discovered drift (out of Track C scope, follow-up): RESOLVED 2026-07-19.** The note flagged the FR
+> overlay as missing the EN base's §4 "Local mirrors" routing section (the `mcp__local-mirror__*` tool
+> table + routing rule). The two-layer restructure (PR #37, 2026-07-18) closed it: the detailed routing
+> now lives in the engine layer, and both `CLAUDE.engine.md` (EN) and `templates/fr/CLAUDE.engine.md`
+> (FR) carry a structurally 1:1 body (25 headings each, incl. "Local mirrors" + the local-mirror
+> citation pattern). Verified read-only 2026-07-19; no parity pass needed.
 
 ---
 

--- a/scripts/lib/import-vault.mjs
+++ b/scripts/lib/import-vault.mjs
@@ -6,8 +6,18 @@ import { existsSync, statSync, readFileSync, writeFileSync, mkdirSync, copyFileS
 import { join, dirname } from "node:path";
 import { listFilesRelPosix } from "./fs-walk.mjs";
 import { isExampleNote } from "./example-notes.mjs";
-import { normalizeUniverseName, DEFAULT_UNIVERSE } from "./universes.mjs";
+import {
+  normalizeUniverseName,
+  DEFAULT_UNIVERSE,
+  vaultRagDir,
+  readRegistry,
+  writeRegistry,
+  addToRegistry,
+} from "./universes.mjs";
 import { stampUniverse } from "./stamp-universe.mjs";
+
+// Real-fs io for the registry helpers (they take an injected fs, ADR 0009).
+const registryIo = { existsSync, readFileSync, mkdirSync, writeFileSync };
 
 // Resolves `source` to its vault dir: a brain root resolves to <source>/vault;
 // a dir that is already a vault is used as-is.
@@ -95,6 +105,13 @@ export function applyImport(plan, { dest }) {
       copyFileSync(source, target);
     }
     copied.push(relpath);
+  }
+  // A universe-scoped import must REGISTER the universe, else the notes are
+  // stamped but the universe stays orphan: `/switch` refuses an unknown name and
+  // the progressive-disclosure gate never flips. Registering makes it switchable.
+  if (uni) {
+    const dir = vaultRagDir(dest);
+    writeRegistry(registryIo, dir, addToRegistry(readRegistry(registryIo, dir), uni));
   }
   // Collisions are never overwritten — they are reported, untouched.
   return { copied, skipped: [...plan.collisions] };

--- a/scripts/lib/import-vault.test.mjs
+++ b/scripts/lib/import-vault.test.mjs
@@ -4,6 +4,10 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { planImport, applyImport, formatPlan, formatApplyResult } from "./import-vault.mjs";
+import { readRegistry, registryPath, vaultRagDir } from "./universes.mjs";
+
+// A real-fs io for the registry helpers (they take an injected fs).
+const realIo = { existsSync, readFileSync, mkdirSync, writeFileSync };
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 function tmp(prefix) {
@@ -224,6 +228,35 @@ test("import --universe stamps every .md note and routes files under vault/<univ
     // Nothing at the root — the universe scopes the whole import.
     assert.equal(existsSync(join(destVault, "daily", "2026-04-16.md")), false);
     assert.deepEqual(result.copied.sort(), ["daily/2026-04-16.md", "photo.png"]);
+  });
+});
+
+test("import --universe registers the universe in the registry (so it becomes switchable)", () => {
+  withBrains(({ source, dest, srcVault }) => {
+    writeFileSync(join(srcVault, "note.md"), "# N\n");
+    const plan = planImport({ source, dest, universe: "Acme Corp" });
+    applyImport(plan, { dest });
+    assert.deepEqual(readRegistry(realIo, vaultRagDir(dest)), ["acme-corp"]);
+  });
+});
+
+test("import WITHOUT a universe leaves the registry untouched (no orphan entry, gate stays shut)", () => {
+  withBrains(({ source, dest, srcVault }) => {
+    writeFileSync(join(srcVault, "note.md"), "# N\n");
+    applyImport(planImport({ source, dest }), { dest });
+    assert.deepEqual(readRegistry(realIo, vaultRagDir(dest)), []);
+    // No universe → the registry file is never even created (the gate stays shut).
+    assert.equal(existsSync(registryPath(vaultRagDir(dest))), false);
+  });
+});
+
+test("import --universe is idempotent and accretes: re-importing dedups, a second universe coexists (sorted)", () => {
+  withBrains(({ source, dest, srcVault }) => {
+    writeFileSync(join(srcVault, "n.md"), "# N\n");
+    applyImport(planImport({ source, dest, universe: "Zeta" }), { dest }); // register "zeta"
+    applyImport(planImport({ source, dest, universe: "Zeta" }), { dest }); // re-import → no duplicate
+    applyImport(planImport({ source, dest, universe: "Acme" }), { dest }); // a different one accretes
+    assert.deepEqual(readRegistry(realIo, vaultRagDir(dest)), ["acme", "zeta"]);
   });
 });
 

--- a/templates/fr/.claude/skills/import/SKILL.md
+++ b/templates/fr/.claude/skills/import/SKILL.md
@@ -81,6 +81,39 @@ node scripts/import-brain.mjs "<source>" --apply
 Copie les fichiers planifiés dans `vault/`, en préservant les sous-dossiers, **sans jamais écraser**
 une collision.
 
+### Importer DANS un univers : poser la question une fois lors d'une migration de cerveau entier (`--universe <nom>`)
+
+Rapatrier un **cerveau entier précédent** (une sphère distincte : les notes d'un *employeur précédent*,
+un client, un contexte borné) est le cas d'école d'un **univers** (ADR 0034). Donc, avant de montrer le
+plan, **pose proactivement une question légère** :
+
+> *« Ces notes appartiennent-elles à un **univers** qui leur est propre (par exemple un employeur
+> précédent ou un client, gardé comme périmètre de recherche séparé), ou à tes notes générales / par
+> défaut ? »*
+
+- **Une sphère séparée → passe `--universe <nom>`** sur **les deux** commandes (plan ET apply).
+- **Général / par défaut → aucun flag** (le comportement d'aujourd'hui). Ne pose pas la question pour un
+  petit import ponctuel de quelques notes éparses : seulement quand un cerveau entier, ou une sphère
+  clairement distincte, est en jeu (garder la fonctionnalité invisible-tant-qu'on-n'en-a-pas-besoin).
+
+```bash
+node scripts/import-brain.mjs "<source>" --universe "<nom>"          # plan
+node scripts/import-brain.mjs "<source>" --universe "<nom>" --apply  # apply
+```
+
+Avec un univers, le cœur :
+- **route** chaque fichier importé sous `vault/<nom>/…` (sous-arbre autonome) et **estampille** le
+  frontmatter de chaque note avec `universe: <nom>` (additif : une clé `universe:` existante n'est jamais
+  écrasée ; les pièces jointes voyagent à l'octet près, jamais estampillées). Le nom est normalisé en
+  slug sûr.
+- **enregistre** `<nom>` dans le registre des univers du cerveau : il devient aussitôt un périmètre réel,
+  **commutable via `/switch`**, et le cerveau bascule en mode multi-univers (le rappel de divulgation
+  progressive + l'onboarding `/switch` commencent à apparaître).
+
+> 🧭 **Il ne fait PAS de `/switch` automatique vers l'univers importé.** Après l'import, indique qu'on
+> peut **`/switch <nom>`** pour travailler dedans (les notes par défaut / transverses y restent visibles
+> aussi).
+
 ### Étape 4 — Réindexer (pour que les notes importées soient cherchables)
 Les nouvelles notes doivent être indexées avant que le RAG ne les trouve. Une indexation incrémentale
 suffit — on n'a fait qu'**ajouter** des fichiers :


### PR DESCRIPTION
## Why

`import --universe <name>` stamped notes and routed them under `vault/<name>/`, but **never registered the universe** in `universes.json`. The scope was left orphan:

- `switchToUniverse` refuses a name absent from the registry → the user could **not** `/switch <name>` after importing into it.
- `isMultiverse` never flipped → the progressive-disclosure reminder + `/switch` onboarding never surfaced.

So one could import a whole previous brain "into acme" and then be unable to reach it, defeating the migration use-case (ROADMAP Gate 3).

## What

- **Core (`import-vault.mjs`)**: `applyImport` now **registers** a non-default universe (idempotent, deduped, sorted via `addToRegistry`). A no-universe import stays untouched: the registry file is not even created, so the gate stays shut for single-universe brains.
- **Skill (`import`, EN + FR parity)**: proactively ask one light question on a whole-brain migration ("do these notes belong to a universe of their own?"), and document that the import now registers the universe (real, `/switch`-able) **without** auto-switching. The FR overlay had **no** universe section at all — parity restored.
- **README**: a general-public "One brain, several universes (optional)" section + a universe-scoped import note.
- **Plan hygiene**: mark the FR/EN local-mirror parity drift resolved (closed by the two-layer split, PR #37).

## Tests

TDD baby-steps (fail-first). The absent-case guard is **mutation-proven** (removing the `if (uni)` guard turns it red). Full harness suite green (727, 0 fail, 1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
