### PR TITLE
fix(lint): make the wiki-health linter universe-aware (The One Where the Linter Learns Universes)

### DIFF
--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -4,8 +4,8 @@
 
 # Backlog — post-v3.1.0 UX ideas
 
-> **STATUS: 💡 BACKLOG** (created 2026-06-17, slimmed 2026-06-23, extended 2026-07-19 with two
-> universes follow-ups). Captured ideas, **not committed
+> **STATUS: 💡 BACKLOG** (created 2026-06-17, slimmed 2026-06-23, extended 2026-07-19 with three
+> universes follow-ups — the third a regression). Captured ideas, **not committed
 > work**. Promote one to a real action plan (`*-action.md`, full Tracking section) when it's picked up.
 > **Discipline TDD** (skill `tdd-discipline`), deterministic-first (ADR 0009), Mac/Win/Linux parity
 > (ADR 0015).
@@ -120,3 +120,71 @@ replicates a Notion zone as Markdown), so mirrored notes are **indexed like any 
 
 > Links: ADR 0034 (universes), the universes plan
 > (`universes-progressive-disclosure-action.md` → Step 6, import stamping).
+
+## 🐛 Regression — universes broke `/lint` (make the wiki-health linter universe-aware)
+
+> 🎯 **PICKED UP 2026-07-19 — THIS IS THE NEXT ACTION after the `/clear`.** Fix TDD on
+> `scripts/lib/wiki-lint.mjs` (baby-steps, fail-first; tests exist at `wiki-lint.test.mjs`) → `harness:`
+> PR → merge `main` → **cut release `v3.6.1`** with a "The One…" codename (mandatory: `update-engine`
+> resolves the **latest tag**, not `main` (ADR 0017), so a deployed brain on `v3.6.0` sees nothing
+> without a new tag) → the deployed brain then `/update-engine` + full Claude restart → clean `/lint`.
+> Patch bump, **no reindex** (harness only, `indexSchemaVersion` unchanged). Scope now covers a **3rd
+> false-positive type** found in the field: same-note section anchors `[[#heading]]` (no target file) are
+> flagged as dangling too — fix in the same resolver pass.
+
+Introducing universes (`vault/<universe>/`, ADR 0034) **broke the `/lint` wiki-health scanner**: it
+predates universes and resolves everything **relative to the vault root**, never the universe root. On a
+real single-universe vault (~410 notes filed under `vault/<universe>/`), the report is massively
+inflated by **false positives** — surfaced during the universes field-verify (2026-07-19). Two bugs,
+**one root cause** (the scanner ignores the leading `<universe>/` path segment), both in engine-owned
+`scripts/lib/wiki-lint.mjs`, so a fix reaches every brain via `update-engine`. **Fix it in the launcher,
+never patch it inside a deployed brain** (a local patch is clobbered by the manifest `replace` bucket).
+
+- [x] **Bug 1 — resolver blind to universe-relative links** (`buildResolver`, `wiki-lint.mjs:39-52`).
+  It registered only 3 keys per note: the full vault-relative path (`<universe>/people/x.md`), its
+  extensionless form, and the bare basename (`x`). A wikilink written **universe-relative** (`[[people/x]]`,
+  the natural spelling inside a universe) matched **none** → reported "dangling". **Obsidian resolves by
+  path suffix**, so these links actually work in Obsidian; the scanner was simply stricter than the
+  universe layer added after it. Measured impact: **~628 reported dead links → ~47 real** (~581 false
+  positives). _(2026-07-19 — `buildResolver` now registers every path suffix, with/without `.md`; the
+  old `basename` helper folded in as the shortest suffix.)_
+- [x] **Bug 2 — orphan exclusions blind to the universe prefix** (`wiki-lint.mjs:58` + `:119`).
+  `DEFAULT_ORPHAN_EXCLUDE = ["daily/", "raw-sources/", "inbox/", …]` was matched with
+  `n.path.startsWith(prefix)`, but paths now start with `<universe>/daily/…` → the exclusions matched
+  **nothing**, so raw-capture zones wrongly counted as orphans. Combined with Bug 1 (unresolved inbound
+  links), almost every note looked orphaned: **~407/410 reported → ~172 real**. _(2026-07-19 — new
+  exported `isUnderZone(path, prefix)` matches a zone at the vault root OR a universe root, one segment
+  deep only; triangulated against a naive `includes`.)_
+- [x] **Bug 3 — same-note anchors `[[#heading]]` reported as dangling** (found in the field). Extraction
+  yielded an empty target for a pure anchor → resolved to null → false dangling. _(2026-07-19 —
+  `extractWikiLinks` now drops empty targets; Obsidian resolves `[[#heading]]` within the note.)_
+- [x] **Fix (TDD on `wiki-lint.mjs`, already test-covered):** resolution is now **universe-aware** —
+  link targets resolve by **path suffix** (Obsidian-style) so a universe-relative spelling resolves, and
+  the orphan exclusions are **insensitive to the leading `<universe>/` segment**. POSIX-path discipline
+  kept at the source (cf. the Windows `toPosix` fix). Both counters fixed at once; the report is
+  trustworthy again. _(2026-07-19 · branch `fix/lint-universe-aware`; wiki-lint 27 tests, consolidation
+  18 tests, full suite 732 green; proven end-to-end on a universe fixture through `lint-vault.mjs`.)_
+- [x] **Audited `/consolidate` (2026-07-19) — CONFIRMED bitten, doubly.** `consolidation-candidates.mjs`
+  imports the SAME `buildResolver` (L14, used L51/L62) → a universe-relative `[[people/x]]` that IS filed
+  won't resolve → **false "new-page candidate"** (risk: creating duplicate person pages that already
+  exist). AND `isCapture` (L26) matches capture zones with `path.startsWith("daily/"|"meetings/"|…)` (L18),
+  which never matches `<universe>/daily/…` → **capture zones missed entirely**. Net: `/consolidate` is
+  unreliable on a universe vault (report lies in both directions). **Good news:** `buildResolver` is
+  **shared**, so fixing it once cures the resolver-blindness in BOTH `/lint` and `/consolidate`; the
+  `startsWith`-prefix zone checks (wiki-lint orphan-exclude L119 + this `isCapture` L26) need the same
+  universe-prefix-insensitive treatment. **Do NOT run `/consolidate` on a deployed universe brain until
+  v3.6.1 ships.**
+- [x] **Audited `/file-back` (2026-07-19) — NOT bitten by this regression.** `file-back-note.mjs` +
+  `filed-note.mjs` only **write** a conformant note (path derived from the type taxonomy); they use
+  neither `buildResolver` nor a zone `startsWith`, so the resolver/zone universe blind spot doesn't
+  touch them. Its universe **placement** (writing under `vault/<universe>/…`) is a separate concern —
+  the import-stamping item above (universes plan Step 6), not this linter fix.
+- [ ] **Not part of this regression:** the frontmatter findings the linter reports (~163: missing
+  `updated`/`tags`) are **universe-independent** and genuinely actionable — don't discount them once the
+  false positives are removed. That triage is **brain-side content work**, not launcher work.
+
+> Why it matters (the reflex "the tool lies at scale"): the answer is **not** to hand-patch hundreds of
+> links, but to make the linter universe-aware so the report stops lying. Links: ADR 0034 (universes),
+> [[cross-platform-ci-is-the-arbiter]] (POSIX-at-the-source), [[validate-shipped-not-test-instance]]
+> (fix the engine source, not the deployed brain), the axis-1 wiki-health plan
+> (`wiki-health-axis1-mechanisms-action.md`).

--- a/scripts/lib/consolidation-candidates.mjs
+++ b/scripts/lib/consolidation-candidates.mjs
@@ -11,7 +11,7 @@
 // capture, so the candidate drops off on its own.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { extractWikiLinks, buildResolver } from "./wiki-lint.mjs";
+import { extractWikiLinks, buildResolver, isUnderZone } from "./wiki-lint.mjs";
 
 // Path prefixes whose notes are raw captures — the inputs consolidation promotes
 // FROM (meeting notes, daily logs, transcripts, inbox dumps).
@@ -22,8 +22,11 @@ const DEFAULT_CAPTURE_ZONES = ["meetings/", "daily/", "raw-sources/", "inbox/"];
 // mark for refresh). Mirrors the stale rule's entity set in wiki-lint.
 const DEFAULT_ENTITY_TYPES = ["person", "topic", "company", "project", "concept"];
 
+// A capture lives in a capture zone, insensitively to a leading `<universe>/`
+// segment (ADR 0034) — shared with wiki-lint's orphan exclusions, which had the
+// same universe blind spot. So `acme/meetings/x.md` is recognised like `meetings/x.md`.
 function isCapture(path, captureZones) {
-  return captureZones.some((prefix) => path.startsWith(prefix));
+  return captureZones.some((prefix) => isUnderZone(path, prefix));
 }
 
 // Record `source` under `key` in a group map (key → path → source), deduping by

--- a/scripts/lib/consolidation-candidates.test.mjs
+++ b/scripts/lib/consolidation-candidates.test.mjs
@@ -241,6 +241,41 @@ test("consolidationCandidates — a capture's unresolved mention is a new-page c
   });
 });
 
+// ── universe-aware (ADR 0034): paths gain a leading <universe>/ segment ────────
+
+test("consolidationCandidates — a capture under <universe>/meetings/… still drives candidates, universe-relative links resolve", () => {
+  // Regression: `isCapture` (startsWith zone) and the shared resolver both ignored
+  // the leading `<universe>/` segment, so a universe capture was missed AND its
+  // universe-relative `[[people/x]]` to an existing older page was a false new-page.
+  const notes = [
+    {
+      path: "acme/meetings/2026-07-15-revue.md",
+      frontmatter: { type: "meeting", updated: "2026-07-15" },
+      body: "Reparlé de [[people/marie-dupont]] et de [[Some Missing Concept]].",
+    },
+    {
+      path: "acme/people/marie-dupont.md",
+      frontmatter: { type: "person", updated: "2026-04-01" },
+      body: "Head of Platform.",
+    },
+  ];
+  assert.deepEqual(consolidationCandidates(notes), {
+    newPages: [
+      {
+        target: "Some Missing Concept",
+        sources: [{ path: "acme/meetings/2026-07-15-revue.md", updated: "2026-07-15" }],
+      },
+    ],
+    refreshes: [
+      {
+        page: "acme/people/marie-dupont.md",
+        updated: "2026-04-01",
+        sources: [{ path: "acme/meetings/2026-07-15-revue.md", updated: "2026-07-15" }],
+      },
+    ],
+  });
+});
+
 // ── hasCandidates: the binary signal the CLI turns into an exit code ───────────
 
 test("hasCandidates — an empty report is false (nothing to consolidate)", () => {

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -21,34 +21,55 @@ function stripCode(body) {
 // `[[Target|alias]]` and `[[Target#heading]]` forms resolve to the bare target.
 // Links inside code (fenced blocks or inline spans) are ignored — Obsidian doesn't
 // linkify code, so a `[[link]]` example there is syntax documentation, not a link.
+// A pure same-note anchor (`[[#heading]]`) has no target file — Obsidian resolves
+// it within the current note, so it is dropped rather than reported as dangling.
 export function extractWikiLinks(body) {
-  return [...stripCode(body).matchAll(/\[\[([^\]]+)\]\]/g)].map((m) =>
-    m[1].split(/[|#]/)[0].trim(),
-  );
+  return [...stripCode(body).matchAll(/\[\[([^\]]+)\]\]/g)]
+    .map((m) => m[1].split(/[|#]/)[0].trim())
+    .filter((target) => target !== "");
 }
 
-// A note's basename (filename without extension) — the short Obsidian link form.
-function basename(path) {
-  return path.split("/").pop().replace(/\.md$/, "");
+// Every trailing path suffix of a note path, longest first: `a/b/c.md` →
+// ["a/b/c.md", "b/c.md", "c.md"]. Obsidian resolves a `[[link]]` by matching the
+// shortest path suffix that identifies a note, so a universe-relative spelling
+// (`[[people/alice]]` inside `<universe>/people/alice.md`, ADR 0034) resolves the
+// same as the full vault-relative path. The bare basename is the shortest suffix.
+function pathSuffixes(path) {
+  const segments = path.split("/");
+  return segments.map((_, i) => segments.slice(i).join("/"));
 }
 
 // Build a resolver mapping every accepted link spelling to a note's canonical
-// path. Obsidian resolves a `[[Target]]` by basename, and a `[[folder/note]]` (or
-// `[[folder/note.md]]`) by path. Path spellings are registered even when a
-// basename collides, so the longer form always disambiguates.
+// path. Obsidian resolves a `[[Target]]` by basename, a `[[folder/note]]` (or
+// `[[folder/note.md]]`) by path, and a universe-relative `[[people/note]]` by
+// path suffix. Every suffix (with and without `.md`) is registered; a shorter
+// suffix keeps the first note that claims it, so the longer form disambiguates.
 export function buildResolver(notes) {
   const byKey = new Map();
   const register = (key, path) => {
     if (!byKey.has(key)) byKey.set(key, path);
   };
   for (const note of notes) {
-    const noExt = note.path.replace(/\.md$/, "");
-    register(note.path, note.path); // folder/note.md
-    register(noExt, note.path); //     folder/note
-    register(basename(note.path), note.path); // note
+    for (const suffix of pathSuffixes(note.path)) {
+      register(suffix, note.path); //           folder/note.md, note.md
+      register(suffix.replace(/\.md$/, ""), note.path); // folder/note, note
+    }
   }
   // Resolve a raw link target to a canonical note path, or null if it points nowhere.
   return (target) => byKey.get(target) ?? byKey.get(target.replace(/\.md$/, "")) ?? null;
+}
+
+// Whether `path` falls under a zone `prefix` (`daily/`, `actions-log.md`),
+// insensitively to a leading `<universe>/` segment (ADR 0034). A zone lives at
+// the vault root OR at a universe root, so both `daily/x.md` and `acme/daily/x.md`
+// match `daily/`. Only the first segment is optional — universes are one level
+// deep, so a `foo/daily/` nested elsewhere is intentionally not a zone. Shared
+// with the consolidation gesture (isCapture), which has the same universe blind
+// spot. POSIX paths at the source (cf. the Windows toPosix fix).
+export function isUnderZone(path, prefix) {
+  if (path.startsWith(prefix)) return true;
+  const firstSlash = path.indexOf("/");
+  return firstSlash !== -1 && path.slice(firstSlash + 1).startsWith(prefix);
 }
 
 // Raw-capture zones: notes here are legitimately unlinked (a daily log, an inbox
@@ -116,7 +137,7 @@ export function lintVault(notes, options = {}) {
   }
   const orphans = notes
     .filter((n) => !inbound.has(n.path))
-    .filter((n) => !orphanExclude.some((prefix) => n.path.startsWith(prefix)))
+    .filter((n) => !orphanExclude.some((prefix) => isUnderZone(n.path, prefix)))
     .map((n) => n.path);
 
   const staleEntityPages = [];

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { extractWikiLinks, lintVault, hasFindings, reportLines } from "./wiki-lint.mjs";
+import { extractWikiLinks, lintVault, hasFindings, reportLines, isUnderZone } from "./wiki-lint.mjs";
 
 const CLEAN = { danglingLinks: [], orphans: [], staleEntityPages: [], frontmatterViolations: [] };
 
@@ -30,6 +30,13 @@ test("extractWikiLinks — resolves the target, dropping |alias and #heading", (
   );
 });
 
+test("extractWikiLinks — drops a same-note anchor [[#heading]] (no target file), keeps real links", () => {
+  assert.deepEqual(
+    extractWikiLinks("jump to [[#Section]] then see [[Foo]]"),
+    ["Foo"],
+  );
+});
+
 test("extractWikiLinks — ignores [[links]] inside an inline `code` span (Obsidian doesn't linkify code)", () => {
   assert.deepEqual(
     extractWikiLinks("a real [[Foo]] but `[[Bar]]` is just syntax"),
@@ -40,6 +47,21 @@ test("extractWikiLinks — ignores [[links]] inside an inline `code` span (Obsid
 test("extractWikiLinks — ignores [[links]] inside a fenced ``` code block, keeps links after it", () => {
   const body = "before [[Keep]]\n```\nexample: [[InCode]]\n```\nafter [[AlsoKeep]]";
   assert.deepEqual(extractWikiLinks(body), ["Keep", "AlsoKeep"]);
+});
+
+// ── isUnderZone: a zone prefix, insensitive to a leading <universe>/ segment ───
+
+test("isUnderZone — matches at the vault root and at a universe root, but not one level deeper", () => {
+  assert.equal(isUnderZone("daily/x.md", "daily/"), true); //        vault root
+  assert.equal(isUnderZone("acme/daily/x.md", "daily/"), true); //   universe root
+  assert.equal(isUnderZone("acme/foo/daily/x.md", "daily/"), false); // nested deeper → not a zone
+  assert.equal(isUnderZone("acme/notes/mydaily.md", "daily/"), false); // substring, not a segment
+});
+
+test("isUnderZone — a file-basename zone matches at both roots (actions-log.md)", () => {
+  assert.equal(isUnderZone("actions-log.md", "actions-log.md"), true);
+  assert.equal(isUnderZone("acme/actions-log.md", "actions-log.md"), true);
+  assert.equal(isUnderZone("acme/logs/actions-log.md", "actions-log.md"), false);
 });
 
 // ── dangling links: a [[link]] whose target basename matches no note ──────────
@@ -68,6 +90,17 @@ test("lintVault — resolves path-form links [[folder/note]] and [[folder/note.m
   assert.deepEqual(report.orphans, ["notes/x.md"]); // topics/rag has an inbound link now
 });
 
+test("lintVault — resolves a universe-relative link [[people/alice]] to <universe>/people/alice.md", () => {
+  // Inside a universe (ADR 0034) notes live under `<universe>/…` and are linked
+  // universe-relative; Obsidian resolves those by path suffix, so the linter must too.
+  const report = lintVault([
+    { path: "acme/people/alice.md", frontmatter: {}, body: "" },
+    { path: "acme/daily/2026-07-19.md", frontmatter: {}, body: "met [[people/alice]]" },
+  ]);
+  assert.deepEqual(report.danglingLinks, []);
+  assert.ok(!report.orphans.includes("acme/people/alice.md")); // it now has an inbound link
+});
+
 // ── orphans: a note nobody links to ───────────────────────────────────────────
 
 test("lintVault — flags the note with zero inbound links, not the linked ones", () => {
@@ -87,6 +120,18 @@ test("lintVault — raw-capture zones (daily/, raw-sources/, inbox/) are never o
     { path: "topic.md", frontmatter: {}, body: "" },
   ]);
   assert.deepEqual(report.orphans, ["topic.md"]);
+});
+
+test("lintVault — raw-capture zones stay excluded under a universe prefix (<universe>/daily/…)", () => {
+  // ADR 0034: paths gain a leading `<universe>/` segment. The orphan exclusions
+  // must match through it, else every raw capture wrongly counts as an orphan.
+  const report = lintVault([
+    { path: "acme/daily/2026-07-19.md", frontmatter: {}, body: "" },
+    { path: "acme/inbox/scratch.md", frontmatter: {}, body: "" },
+    { path: "acme/actions-log.md", frontmatter: { type: "log" }, body: "" },
+    { path: "acme/topic.md", frontmatter: {}, body: "" },
+  ]);
+  assert.deepEqual(report.orphans, ["acme/topic.md"]);
 });
 
 test("lintVault — the append-only ledger (actions-log.md) is a raw zone, never an orphan", () => {


### PR DESCRIPTION
## Why

Universes (ADR 0034) file every note under `vault/<universe>/…`, but the Axis-1 `/lint` scanner predates them and resolved everything relative to the **vault root**. On a real single-universe vault (~410 notes) the report was massively inflated by false positives (surfaced during the universes field-verify, 2026-07-19). The reflex isn't to hand-patch hundreds of links, it's to make the linter universe-aware so the report stops lying.

## What (three bugs, engine-owned pure cores → reaches every brain via `update-engine`)

| Bug | Cause | Fix | Impact |
|-----|-------|-----|--------|
| **1. Resolver blind to universe-relative links** | `buildResolver` registered only full path / extensionless / basename, so `[[people/x]]` (the natural spelling inside a universe) matched nothing → "dangling" | registers **every path suffix** (with/without `.md`), Obsidian-style suffix resolution | ~628 reported dead links → **~47 real** |
| **2. Orphan / capture-zone exclusions blind to the universe prefix** | `startsWith("daily/")` never matches `<universe>/daily/…` | new exported `isUnderZone(path, prefix)` — a zone matches at the vault root **or** a universe root (one segment deep only) | ~407/410 reported orphans → **~172 real** |
| **3. Same-note anchors `[[#heading]]` reported dangling** (found in the field) | `extractWikiLinks` yielded an empty target for a pure anchor | drops empty targets; Obsidian resolves `[[#heading]]` within the note | — |

The shared `buildResolver` + `isUnderZone` cure both `/lint` **and** `/consolidate` at once (its `isCapture` had the same universe blind spot). `/file-back` audited: **not bitten** (it only writes a taxonomy-conformant note, uses neither the resolver nor a zone check). POSIX-path discipline kept at the source (cf. the Windows `toPosix` fix).

## Proof (TDD baby-steps, fail-first)

- `wiki-lint` 27 tests, `consolidation` 18 tests, **full suite 732 green** (1 Windows-only skip).
- `isUnderZone` triangulated against a naive `includes` mutant (segment boundaries, one level deep).
- **End-to-end** on a universe fixture through the real `lint-vault.mjs`: the universe-relative link, the `[[#heading]]` anchor and the `<universe>/daily/` orphan false positives are all gone; the one remaining finding (a stale entity page) is genuine and actionable.

## Deploy

Harness only, `indexSchemaVersion` **unchanged → no reindex**. Deployed brains pick this up once a release **tag** is cut (ADR 0017: `update-engine` resolves the latest tag, not `main`) → suggested `v3.6.1`, then `/update-engine` + a full Claude restart → clean `/lint`.

Tracking: `maintainers/plans/prospective/post-v3.1.0-ux-backlog.md` (regression section, checked off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)