### PR TITLE
docs: log post-v3.6.1 backlog — /lint follow-ups + graduated-autonomy affordance north-star

### DIFF
--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -177,8 +177,8 @@ never patch it inside a deployed brain** (a local patch is clobbered by the mani
 - [x] **Audited `/file-back` (2026-07-19) — NOT bitten by this regression.** `file-back-note.mjs` +
   `filed-note.mjs` only **write** a conformant note (path derived from the type taxonomy); they use
   neither `buildResolver` nor a zone `startsWith`, so the resolver/zone universe blind spot doesn't
-  touch them. Its universe **placement** (writing under `vault/<universe>/…`) is a separate concern —
-  the import-stamping item above (universes plan Step 6), not this linter fix.
+  touch them. Its universe **placement** (writing under `vault/<universe>/…`) is a separate concern,
+  now tracked as **Follow-up 3 below** (found in the field 2026-07-20), not this linter fix.
 - [ ] **Not part of this regression:** the frontmatter findings the linter reports (~163: missing
   `updated`/`tags`) are **universe-independent** and genuinely actionable — don't discount them once the
   false positives are removed. That triage is **brain-side content work**, not launcher work.
@@ -239,5 +239,28 @@ the same category error as calling it an orphan.
       conform) — this only silences the **raw** zones, cf. the "Not part of this regression" note above.
 - [ ] **TDD** on `wiki-lint.mjs`; harness only, no reindex; same patch-release path.
 
+### Follow-up 3 — the file-back builder is not universe-aware (files new notes at the vault root)
+
+**WHAT (found in the field 2026-07-20, during a `/consolidate` write).** `file-back-note.mjs` +
+`filed-note.mjs` (the deterministic builder that Track B and `/consolidate` reuse to write **new** notes)
+derive the path straight from the type taxonomy (`vault/people/x.md`) with **no notion of the active
+universe** and **no `universe:` frontmatter key**. On a universe brain a filed-back person lands at the
+**vault root**, not under `<universe>/…` — so it is off-scope for that universe's retrieval and needs a
+manual placement (the field brain worked around it with a direct `Write` under the universe, and logged
+the gap). This is **distinct** from import stamping (Step 6, done — that stamps *imported* notes, via
+`stamp-universe.mjs`); here it's the *file-back* write path.
+
+- [ ] **Make `renderFiledNote` / `filedNotePath` universe-aware:** prefix the path with the **active
+      universe** (`vault/<universe>/<folder>/…`) and stamp the `universe:` key, when a universe is active
+      — reusing the same active-universe source the reader anchors on (registry / `.vault-rag/`, cf. the
+      universes plan). A default/root brain (no universe) keeps today's behaviour exactly.
+- [ ] **Decision (deferred):** does the builder **read** the active universe itself, or does the caller
+      (`file-back-note.mjs` CLI / the skill) pass it into the spec? Lean: pass it in (keep the pure core
+      I/O-free; the thin CLI resolves the active universe), so `filed-note.mjs` stays a pure builder.
+- [ ] **TDD** on `filed-note.mjs` (pure core, already 15 tests) + the CLI; harness only, no reindex.
+- [ ] Corrects the audit note above (the file-back universe **placement** was flagged as "a separate
+      concern" — this is that concern, now a tracked item, not the import-stamping one).
+
 > Links: the axis-1 wiki-health plan (`wiki-health-axis1-mechanisms-action.md`, Tracks A/C own these
-> pure cores), ADR 0009 (deterministic rung-1 cores), [[validate-shipped-not-test-instance]].
+> pure cores), ADR 0009 (deterministic rung-1 cores), ADR 0034 (universes),
+> [[validate-shipped-not-test-instance]].

--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -188,3 +188,56 @@ never patch it inside a deployed brain** (a local patch is clobbered by the mani
 > [[cross-platform-ci-is-the-arbiter]] (POSIX-at-the-source), [[validate-shipped-not-test-instance]]
 > (fix the engine source, not the deployed brain), the axis-1 wiki-health plan
 > (`wiki-health-axis1-mechanisms-action.md`).
+
+## 🧹 Make `/lint` stop crying wolf on normal work-notes and raw dumps (2 engine follow-ups)
+
+> **Origin (2026-07-19, field-verify of v3.6.1 on a real single-universe vault ~410 notes).** With the
+> universe-aware fix live, the report is trustworthy — but it still flags two categories that are
+> **structural noise, not rot**. Two engine improvements were logged from the field (deferred here on
+> purpose: **no code yet**, owner picks the approach when picked up). The reflex is the same as the
+> regression above: **fix the generic engine source so every brain benefits**, never hand-patch or
+> hard-code one brain's personal taxonomy ([[validate-shipped-not-test-instance]]).
+
+### Follow-up 1 — a note nobody links to is not always an orphan: exclude the engine's own work-zones
+
+**WHAT:** `/lint` flags a note as an orphan when no other note links to it, but several **work-zone**
+folders are legitimately unlinked by design (nobody links back to a meeting write-up or a 1-1 prep).
+On the field vault ~110 of 178 reported orphans were exactly this false positive. The orphan-exclude
+default (`daily/`, `raw-sources/`, `inbox/`, `actions-log.md`) predates those zones.
+
+- [ ] **Extend `DEFAULT_ORPHAN_EXCLUDE`** (`scripts/lib/wiki-lint.mjs`) to the folders **the engine's
+      own shipped skills write** and that are never linked to: `meetings/`, `briefings/` (sync-sources),
+      `prep-1-1/` (prepare-1-1), `coaching/` (coach). These are generic — every brain has them.
+  - [ ] Keep it **universe-prefix-insensitive** by reusing the existing `isUnderZone` helper (already
+        in place from v3.6.1) — no new path logic.
+  - [ ] **Do NOT bake in brain-specific folders** (e.g. `prep-day/`, `rapport-etonnement/`): those stay
+        per-brain, added through `options.orphanExclude` (a brain-side lint config is a separate item).
+  - [ ] Fixes a latent **inconsistency** en passant: `meetings/` is already a `/consolidate` capture
+        zone (`DEFAULT_CAPTURE_ZONES`) but was missing from the lint orphan-exclude.
+- [ ] **Decision (deferred — owner to pick when built):** path-prefix list (above, smallest change) **vs**
+      a cleaner **type-based** exemption (exclude any note whose `type` is a capture/work type —
+      meeting/briefing/prep/coaching/daily — symmetric to `entityTypes`). Default recommendation: the
+      path-prefix list, consistent with the current design; the type-based refactor is a nice-to-have.
+- [ ] **TDD** on `wiki-lint.mjs` (baby-steps, fail-first); harness only, no reindex; carry via a patch
+      release tag (ADR 0017).
+
+### Follow-up 2 — a raw dump is not a curated node: don't demand full frontmatter on raw-capture zones
+
+**WHAT:** every note is expected to carry frontmatter (`type/created/updated/tags`), but imported **raw
+transcripts** (`raw-sources/transcripts/*`) arrive without it — 43 of them showed as frontmatter
+violations on the field vault. A raw dump is not a curated wiki node; holding it to the full taxonomy is
+the same category error as calling it an orphan.
+
+- [ ] **Exempt raw-capture zones from the required-frontmatter rule** in `lintVault`
+      (`scripts/lib/wiki-lint.mjs`) — parallel to the orphan exemption, reusing `isUnderZone`. Kills the
+      false frontmatter findings **without inventing any dates**.
+- [ ] **Decision (deferred — owner to pick when built):** lint-side exemption (above, recommended, zero
+      fabricated metadata) **vs** stamping minimal frontmatter at **import** time (importer fabricates
+      `created`) **vs** both (exempt in lint + have `sync-sources` write frontmatter for *new*
+      transcripts so future ones are clean). Default recommendation: the lint-side exemption.
+- [ ] Keep the genuinely-actionable frontmatter findings intact (living curated notes still expected to
+      conform) — this only silences the **raw** zones, cf. the "Not part of this regression" note above.
+- [ ] **TDD** on `wiki-lint.mjs`; harness only, no reindex; same patch-release path.
+
+> Links: the axis-1 wiki-health plan (`wiki-health-axis1-mechanisms-action.md`, Tracks A/C own these
+> pure cores), ADR 0009 (deterministic rung-1 cores), [[validate-shipped-not-test-instance]].

--- a/maintainers/plans/prospective/restore-affordance-graduated-autonomy-action.md
+++ b/maintainers/plans/prospective/restore-affordance-graduated-autonomy-action.md
@@ -1,0 +1,71 @@
+# Restore the second brain's affordance — graduated autonomy + plain language
+
+> **Origin (2026-07-19, owner).** Since `/lint` and `/consolidate` landed (axis-1 wiki-health), the
+> generated brain's original strength — "things happen on their own" — degraded: it now **interrogates**
+> the user (a wall of decision-prompts) in **tool-jargon** a non-technical person can't parse. In one
+> session the owner had to relay ~5 subset-picker prompts and said "I don't understand the subject or
+> the options". We traded the magic for a dashboard. This plan restores the affordance without losing
+> the self-maintenance mechanics.
+>
+> North-star, always-loaded pointer: memory `brain-graduated-autonomy-affordance`. Siblings: ADR 0009
+> (deterministic-first = the 🟢 tier), the axis-1 wiki-health plan (`wiki-health-axis1-mechanisms-action.md`).
+
+## Tracking
+
+- [ ] **1. Agree the model (ADR).** The current "read-only auto / writes confirmed" posture is too
+      binary; ratify the 3-tier graduated-autonomy model as an ADR so it governs all skill design.
+- [ ] **2. Audit today's interaction points** against the 3 tiers (which prompts should become 🟢/🟡).
+- [ ] **3. Reclassify + implement**, skill by skill, TDD, generic-only (no brain-specific taxonomy).
+- [ ] **4. Kill the jargon** in every user-facing string the brain emits.
+
+---
+
+## The model — graduated autonomy (gate: reversibility + confidence)
+
+Everything the brain writes is **auto-committed → always git-revertible**; that safety net is what makes
+autonomous action acceptable.
+
+- **🟢 Silent auto** — safe, deterministic, reversible gestures. Just do them, don't ask.
+  Examples: fix an unambiguous dead-link typo where the target clearly exists (the `dora-sprints →
+  dora-latest` rename was deterministic), stamp a missing date read from the note's own content, exclude
+  structural noise from a health report.
+- **🟡 Announce-then-do (batched, plain-language)** — one summary "here are the N things I'll do, say
+  stop if one bothers you", then act unless vetoed. Replaces N separate multi-select prompts.
+- **🔴 Genuinely ask** — only a real judgment call: merge two maybe-different people, create a page that
+  shapes the taxonomy, resolve a contradiction between a page and a fresh capture, RH-sensitive content.
+  Always **plain language + "why it matters"** for a non-technical person.
+
+> Note: a **good** 🔴 was field-observed 2026-07-19 — a `/consolidate` run that autonomously ran 4
+> read-only agents, **caught a duplicate page** and **flagged genuine contradictions**, then asked only
+> about those. That IS the target behaviour for 🔴; the residual issue is presentation length + jargon,
+> not the decision to ask.
+
+## Detail
+
+### 1. ADR — ratify the 3-tier model
+- [ ] Write the ADR (crux up top, prior-art named per `CONVENTIONS.md`): supersede/refine the binary
+      "read-only auto / writes confirmed" stance with the tier gate (reversibility + confidence).
+- [ ] Add `Scope: Second brain (runtime)` (the skills + hooks that ship to the brain).
+
+### 2. Audit current interaction points
+- [ ] Inventory every place a shipped skill/hook **asks** the user: `/lint` report + follow-up prompts,
+      `/consolidate` scope + per-candidate prompts, `sync-sources`, the SessionStart wiki-health hook.
+- [ ] For each, tag the target tier and note what blocks it from 🟢/🟡 today (usually: no safe-class
+      detection, or no batched-summary surface).
+
+### 3. Reclassify + implement (TDD, generic-only)
+- [ ] **🟢 candidates first** (highest affordance win): deterministic dead-link repairs where the target
+      is unambiguous; auto-exclude structural noise (dovetails with the 2 logged `/lint` follow-ups in
+      `post-v3.1.0-ux-backlog.md` — a first 🟢 step).
+- [ ] **🟡 batched summary** surface: replace multi-select cascades with one "will do X, Y, Z — veto?"
+      message.
+- [ ] Keep every default **generic**; brain-specific choices stay configurable, never hard-coded
+      ([[validate-shipped-not-test-instance]]).
+
+### 4. Plain-language pass
+- [ ] Scrub user-facing strings of tool-jargon (`orphan-exclude`, `fan-out`, `frontmatter`…) → human
+      wording; when the brain must ask, it explains the "why it matters" for a non-dev.
+
+> **Not now, logged so it isn't lost.** No code yet; this is the design driver. The 2 `/lint` follow-ups
+> already logged (work-zone orphans + raw-dump frontmatter) are the first concrete 🟢 steps and can land
+> before the ADR.


### PR DESCRIPTION
## Why

Field-verify of **v3.6.1** on a real single-universe vault (~410 notes) confirmed the universe-aware `/lint` now reports true. Two residual categories are **structural noise, not rot** — logged here as **deferred engine follow-ups** (no code yet; the owner picks the approach when picked up). Same reflex as the regression fix: fix the generic engine source so every brain benefits, never hard-code one brain's personal taxonomy.

## What is logged (backlog only)

**Follow-up 1 — a note nobody links to is not always an orphan.** Extend the orphan-exclude default to the work-zones the engine's own shipped skills write (`meetings/`, `briefings/`, `prep-1-1/`, `coaching/`), which are legitimately unlinked. ~110 of 178 reported orphans on the field vault were this false positive. Brain-specific folders (`prep-day/`, …) stay per-brain via `options.orphanExclude`. Fixes en passant the latent inconsistency where `meetings/` is already a `/consolidate` capture zone but was missing from the lint orphan-exclude.

**Follow-up 2 — a raw dump is not a curated node.** Exempt raw-capture zones from the required-frontmatter rule so an imported raw transcript isn't held to the full taxonomy (43 findings on the field vault), **without inventing any dates**.

Each item records a deferred **decision** (path-prefix vs type-based; lint-exemption vs import-stamping) with a recommended default. Both would be TDD on `wiki-lint.mjs`, harness only, no reindex, carried via a patch tag (ADR 0017).

Docs-only — no code, no behaviour change. Section added to `maintainers/plans/prospective/post-v3.1.0-ux-backlog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)