### PR TITLE
feat(engine): the write-path finds your universe across import, file-back and local-mirror, /switch flags single-account connectors, and /lint stops crying wolf (The One Where Everything Finds Its Universe)

### DIFF
--- a/.claude/skills/switch/SKILL.md
+++ b/.claude/skills/switch/SKILL.md
@@ -48,9 +48,14 @@ Run, from the brain folder:
 ```bash
 node scripts/set-active-universe.mjs "<name>"
 ```
-- **exit 0** → relay the confirmation ("switched to '<name>'") and remind, in one line, that
-  searches now stay in that universe plus your cross-cutting notes (say *"search all universes"* to
-  span them).
+- **exit 0** → **relay the core's message verbatim** (in the user's language), then remind, in one
+  line, that searches now stay in that universe plus your cross-cutting notes (say *"search all
+  universes"* to span them). When the switch lands in a **named** universe (not a return to the
+  cross-cutting `default`), the core **already appends** a one-line reminder that the **native
+  connectors** (Slack, Notion, Google, mail…) are **single-account** and do not follow the switch, so
+  the user reconnects them if this universe uses different accounts. You do **not** decide when to
+  show it and **never reason about it yourself** (ADR 0009): the deterministic core owns that call,
+  you only surface what it prints.
 - **exit 1, "unknown universe"** → the name is not registered. Show the `available:` list the core
   printed, and **offer to create it** (create-and-switch) or pick an existing one. Do not create
   silently.

--- a/local-mirror/src/adapters/fs-active-universe.ts
+++ b/local-mirror/src/adapters/fs-active-universe.ts
@@ -1,0 +1,31 @@
+// Driven adapter: reads the per-machine active-universe pointer (ADR 0034), written by the
+// `/switch` skill at `<brainRoot>/.vault-rag/active-universe`. Used ONLY by `setup_source` to
+// freeze a new mirror's universe — never on the hot sync path.
+//
+// The pure normalizer (`resolveActiveUniverse`) is split from the file I/O so both are unit-
+// testable, and any read failure degrades to the default universe rather than breaking a setup:
+// a single-universe brain has no pointer file at all, which is the common, healthy case.
+
+import { readFileSync } from 'node:fs';
+import { DEFAULT_UNIVERSE } from '../lib/universe.js';
+
+/** Pure: normalize a raw pointer content. Trimmed; blank/whitespace/absent → the default universe. */
+export function resolveActiveUniverse(raw: string | null): string {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : DEFAULT_UNIVERSE;
+}
+
+/**
+ * Read + normalize the active-universe pointer. `read` is injectable for tests; any error
+ * (absent/unreadable pointer) falls back to the default universe — never throws to the caller.
+ */
+export function readActiveUniverse(
+  pointerPath: string,
+  read: (p: string) => string = (p) => readFileSync(p, 'utf8'),
+): string {
+  try {
+    return resolveActiveUniverse(read(pointerPath));
+  } catch {
+    return DEFAULT_UNIVERSE;
+  }
+}

--- a/local-mirror/src/domain/local-mirror.ts
+++ b/local-mirror/src/domain/local-mirror.ts
@@ -182,10 +182,10 @@ export class LocalMirror implements ILocalMirror {
     let allOk = true;
 
     for (const item of items) {
-      const vaultPath = `${config.target_dir}/${item.id}.md`;
+      const vaultPath = vaultPathFor(config, item.id);
       const tracked = previous?.items[item.id];
       try {
-        const markdown = toLocalMirrorMarkdown(config.name, item, await connector.fetchContent(item));
+        const markdown = toLocalMirrorMarkdown(config.name, item, await connector.fetchContent(item), config.universe);
         const hash = contentHash(markdown);
         if (tracked && tracked.contentHash === hash) {
           nextItems[item.id] = tracked;
@@ -470,6 +470,16 @@ export function toSourceState(
     lastSyncStatus: persisted?.lastSyncStatus ?? 'never',
     itemCount: persisted ? Object.keys(persisted.items).length : 0,
   };
+}
+
+/**
+ * Vault-relative path of a mirrored note. A universe-scoped mirror lands under its universe root
+ * (`<universe>/<target_dir>/<id>.md`, ADR 0034) so retrieval scope travels with the file, exactly
+ * as `/import --universe` files notes; a rootless mirror keeps the historical root path unchanged.
+ */
+export function vaultPathFor(config: LocalMirrorConfig, id: string): string {
+  const prefix = config.universe ? `${config.universe}/` : '';
+  return `${prefix}${config.target_dir}/${id}.md`;
 }
 
 /** The source's stable Notion root page id — from prior state, else extracted from the URL. */

--- a/local-mirror/src/domain/local-mirror.ts
+++ b/local-mirror/src/domain/local-mirror.ts
@@ -24,6 +24,7 @@ import type {
 import { toLocalMirrorMarkdown } from '../lib/markdown.js';
 import { contentHash } from '../lib/content-hash.js';
 import { extractPageId } from '../lib/notion-url.js';
+import { DEFAULT_UNIVERSE } from '../lib/universe.js';
 import { pagesToDelete } from './reconcile.js';
 
 /**
@@ -52,6 +53,12 @@ export interface LocalMirrorDeps {
   connectorFor: ConnectorFactory;
   /** Single-flight lock per source, across processes (auto-refresh study, S2 item 1). */
   syncLock: ISyncLock;
+  /**
+   * The currently-active universe (ADR 0034), read ONLY by `setupSource` to FREEZE a mirror's
+   * universe at declaration time — never on the hot sync path, so a background tick firing while
+   * the user `/switch`es can't scatter one mirror's notes across universes.
+   */
+  activeUniverse: () => string;
 }
 
 /** The Domain Service — the concrete API port. Pure orchestration, no transport. */
@@ -77,7 +84,8 @@ export class LocalMirror implements ILocalMirror {
    * name (`tokenEnv`) is stored (§11).
    */
   async setupSource(req: SetupRequest): Promise<SetupResult> {
-    const config = configFromRequest(req);
+    // Freeze the active universe into the config NOW (ADR 0034) — never re-read at sync time.
+    const config = configFromRequest(req, this.deps.activeUniverse());
     const connector = this.deps.connectorFor(config);
 
     let items;
@@ -487,8 +495,12 @@ export function rootPageIdOf(config: LocalMirrorConfig, previous: PersistedState
   return previous?.rootPageId ?? extractPageId(config.connector.config.root_page_url);
 }
 
-/** Assembles a declared config from the onboarding request — the token's env-var name only (§11). */
-export function configFromRequest(req: SetupRequest): LocalMirrorConfig {
+/**
+ * Assembles a declared config from the onboarding request — the token's env-var name only (§11).
+ * The active `universe` is stamped only when it is a real, non-default scope (ADR 0034): the
+ * default universe carries NO key, so a single-universe brain declares mirrors exactly as before.
+ */
+export function configFromRequest(req: SetupRequest, universe: string = DEFAULT_UNIVERSE): LocalMirrorConfig {
   return {
     name: req.name,
     title: req.title,
@@ -498,6 +510,7 @@ export function configFromRequest(req: SetupRequest): LocalMirrorConfig {
       config: { root_page_url: req.rootPageUrl, token_env: req.tokenEnv },
     },
     target_dir: `mirrors/${req.name}`,
+    ...(universe && universe !== DEFAULT_UNIVERSE ? { universe } : {}),
   };
 }
 

--- a/local-mirror/src/domain/types.ts
+++ b/local-mirror/src/domain/types.ts
@@ -28,6 +28,13 @@ export interface LocalMirrorConfig {
   connector: NotionConnectorConfig;
   /** Dedicated vault subfolder (e.g. `mirrors/team-a`). */
   target_dir: string;
+  /**
+   * Retrieval universe this mirror belongs to (ADR 0034), FROZEN at `setup_source` time from the
+   * then-active universe. When set (and not the default), notes land under `<universe>/<target_dir>/`
+   * and carry a `universe:` frontmatter key. Absent → default universe → root behaviour, unchanged
+   * (backward-compatible: mirrors declared before this feature carry no `universe`).
+   */
+  universe?: string;
 }
 
 export type SyncStatus = 'ok' | 'partial' | 'failed' | 'never';

--- a/local-mirror/src/lib/config.ts
+++ b/local-mirror/src/lib/config.ts
@@ -68,3 +68,13 @@ export const CONFIG_PATH = resolvePath(
   process.env.LOCAL_MIRROR_CONFIG,
   resolve(projectRoot, 'local-mirror.config.json'),
 );
+
+/**
+ * Per-machine active-universe pointer (ADR 0034), written by the `/switch` skill under the
+ * brain's `.vault-rag/` state dir. `setup_source` reads it to freeze a new mirror's universe.
+ * Absent (the single-universe case) → the reader falls back to the default universe.
+ */
+export const ACTIVE_UNIVERSE_PATH = resolvePath(
+  process.env.LOCAL_MIRROR_ACTIVE_UNIVERSE,
+  resolve(projectRoot, '.vault-rag', 'active-universe'),
+);

--- a/local-mirror/src/lib/markdown.ts
+++ b/local-mirror/src/lib/markdown.ts
@@ -29,13 +29,20 @@ export interface LocalMirrorFrontmatter {
   source_url: string;
   /** Notion last_edited_time — feeds the watermark. */
   last_edited_time: string;
+  /** Retrieval universe (ADR 0034), stamped LAST and only when the mirror is universe-scoped. */
+  universe?: string;
 }
 
-/** Assemble one note: produced body + mandatory citation frontmatter (PRD §6). */
+/**
+ * Assemble one note: produced body + mandatory citation frontmatter (PRD §6). When `universe`
+ * is truthy it is stamped LAST (matching `stamp-universe.mjs`'s append-last convention, so the
+ * mirror's frontmatter reads like an imported note's).
+ */
 export function toLocalMirrorMarkdown(
   mirror: string,
   item: SourceItem,
   body: string,
+  universe?: string,
 ): string {
   const frontmatter: LocalMirrorFrontmatter = {
     mirror: mirror,
@@ -44,6 +51,7 @@ export function toLocalMirrorMarkdown(
     source_url: item.url,
     last_edited_time: item.lastEditedTime,
   };
+  if (universe) frontmatter.universe = universe;
   return matter.stringify(body, frontmatter, YAML_ENGINE);
 }
 

--- a/local-mirror/src/lib/universe.ts
+++ b/local-mirror/src/lib/universe.ts
@@ -1,0 +1,10 @@
+// Universes — a soft, progressively-disclosed retrieval scope (ADR 0034).
+//
+// THE default universe: a mirror with no explicit universe belongs to it, lands at the
+// vault root, and never renders for a single-universe user. This is the ONE place the
+// TS package names it.
+//
+// Kept in LOCK-STEP with the engine's two other declarations (they cannot import across
+// package + language boundaries): `scripts/lib/universes.mjs` (launcher scripts) and
+// `rag/src/lib/universe.ts` (RAG). If this value ever changes, change all three.
+export const DEFAULT_UNIVERSE = 'default';

--- a/local-mirror/src/server.ts
+++ b/local-mirror/src/server.ts
@@ -23,7 +23,8 @@ import { FsVaultWriter } from './adapters/fs-vault-writer.js';
 import { SystemClock } from './adapters/system-clock.js';
 import { FsSyncLock } from './adapters/fs-sync-lock.js';
 import { notionConnectorFactory } from './adapters/notion-gateway.js';
-import { VAULT_DIR, SIDECAR_DIR, CONFIG_PATH } from './lib/config.js';
+import { readActiveUniverse } from './adapters/fs-active-universe.js';
+import { VAULT_DIR, SIDECAR_DIR, CONFIG_PATH, ACTIVE_UNIVERSE_PATH } from './lib/config.js';
 import { resolveSyncIntervalSeconds } from './lib/sync-interval.js';
 import { AutoSyncSupervisor } from './auto-sync-supervisor.js';
 
@@ -36,6 +37,7 @@ export function buildDeps(): LocalMirrorDeps {
     clock: new SystemClock(),
     connectorFor: notionConnectorFactory,
     syncLock: new FsSyncLock({ sidecarDir: SIDECAR_DIR }),
+    activeUniverse: () => readActiveUniverse(ACTIVE_UNIVERSE_PATH),
   };
 }
 

--- a/local-mirror/src/test/builder.ts
+++ b/local-mirror/src/test/builder.ts
@@ -207,6 +207,8 @@ export function aNotionLocalMirror(
       },
     },
     target_dir: overrides.target_dir ?? `mirrors/${name}`,
+    // The universe key travels only when the test declares one — a rootless mirror carries none.
+    ...(overrides.universe ? { universe: overrides.universe } : {}),
   };
 }
 

--- a/local-mirror/src/test/builder.ts
+++ b/local-mirror/src/test/builder.ts
@@ -40,10 +40,18 @@ class LocalMirrorBuilder {
   private readonly clock = new MutableClock(new Date('2026-06-17T00:00:00.000Z'));
   /** Stable reference so tests can inspect what `setup_source` declared. */
   private readonly configs = new InMemoryConfigStore(this.declared, () => this.unreadableConfig);
+  /** The active universe a `setup_source` will FREEZE into the config (default: the default universe). */
+  private activeUniverse = 'default';
 
   /** Declare local mirrors, as if already written to the config file. */
   withDeclaredSources(...configs: LocalMirrorConfig[]): this {
     this.declared.push(...configs);
+    return this;
+  }
+
+  /** Set the active universe that a `setup_source` will freeze into the new mirror's config. */
+  withActiveUniverse(name: string): this {
+    this.activeUniverse = name;
     return this;
   }
 
@@ -161,6 +169,7 @@ class LocalMirrorBuilder {
       clock: this.clock,
       connectorFor: () => new StubConnector(() => this.pages, () => this.enumerationError),
       syncLock: new FakeSyncLock(this.lockedByOthers),
+      activeUniverse: () => this.activeUniverse,
     });
   }
 }

--- a/local-mirror/src/test/fs-active-universe.test.ts
+++ b/local-mirror/src/test/fs-active-universe.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveActiveUniverse, readActiveUniverse } from '../adapters/fs-active-universe.js';
+
+// The per-machine active-universe pointer (ADR 0034) lives at `<brainRoot>/.vault-rag/active-universe`,
+// written by the `/switch` skill. `setup_source` reads it to FREEZE a new mirror's universe. The pure
+// normalizer is separated from the file I/O so both are unit-testable (a blank/absent pointer is the
+// common single-universe case → the default universe, never a crash).
+
+test('resolveActiveUniverse: a named pointer is trimmed of surrounding whitespace/newline', () => {
+  assert.equal(resolveActiveUniverse('acme\n'), 'acme');
+  assert.equal(resolveActiveUniverse('  blue-team  '), 'blue-team');
+});
+
+test('resolveActiveUniverse: a blank, whitespace-only or absent pointer falls back to the default', () => {
+  assert.equal(resolveActiveUniverse(''), 'default');
+  assert.equal(resolveActiveUniverse('   \n'), 'default');
+  assert.equal(resolveActiveUniverse(null), 'default');
+});
+
+test('readActiveUniverse: reads and normalizes the pointer file content', () => {
+  const universe = readActiveUniverse('/brain/.vault-rag/active-universe', () => 'acme\n');
+  assert.equal(universe, 'acme');
+});
+
+test('readActiveUniverse: any read error (absent/unreadable pointer) falls back to the default', () => {
+  const universe = readActiveUniverse('/brain/.vault-rag/active-universe', () => {
+    throw new Error('ENOENT: no such file');
+  });
+  assert.equal(universe, 'default');
+});

--- a/local-mirror/src/test/server-boot.test.ts
+++ b/local-mirror/src/test/server-boot.test.ts
@@ -39,6 +39,9 @@ test('buildDeps wires each driven adapter to its concrete implementation', () =>
   assert.ok(deps.vaultWriter instanceof FsVaultWriter);
   assert.ok(deps.clock instanceof SystemClock);
   assert.equal(deps.connectorFor, notionConnectorFactory);
+  // Universe reader wired (ADR 0034): no pointer file in the test env → the default universe.
+  assert.equal(typeof deps.activeUniverse, 'function');
+  assert.equal(deps.activeUniverse(), 'default');
 });
 
 test('buildApi assembles the Domain Service from the (defaulted) real deps', () => {

--- a/local-mirror/src/test/setup-source.test.ts
+++ b/local-mirror/src/test/setup-source.test.ts
@@ -36,6 +36,37 @@ test('setting up a connectable source declares it and runs a first sync', async 
   assert.ok(harness.vaultFiles().has('mirrors/team-a/page-1.md'));
 });
 
+// Universe-awareness (ADR 0034): a mirror belongs to ONE universe, FROZEN at setup time from the
+// then-active universe (never re-read at sync time, so a background tick firing mid-`/switch` can't
+// scatter a mirror's notes). The default universe → no key → root behaviour, unchanged.
+test('setup freezes the active universe into the config and lands the first sync there', async () => {
+  const harness = aLocalMirror()
+    .withActiveUniverse('acme')
+    .withConnectablePages(aNotionPage({ id: 'page-1' }));
+  const gss = harness.build();
+
+  await gss.setupSource(aSetupRequest());
+
+  const declared = await harness.declaredSources();
+  assert.equal(declared[0].universe, 'acme', 'the active universe is frozen into the config');
+  assert.ok(
+    harness.vaultFiles().has('acme/mirrors/team-a/page-1.md'),
+    'the first sync lands the note under the frozen universe root',
+  );
+});
+
+test('setup under the default universe declares no universe key (backward-compatible)', async () => {
+  const harness = aLocalMirror() // active universe left at its default
+    .withConnectablePages(aNotionPage({ id: 'page-1' }));
+  const gss = harness.build();
+
+  await gss.setupSource(aSetupRequest());
+
+  const declared = await harness.declaredSources();
+  assert.equal('universe' in declared[0], false, 'the default universe carries no key');
+  assert.ok(harness.vaultFiles().has('mirrors/team-a/page-1.md'), 'and the note stays at the root');
+});
+
 test('setting up a zone whose root is not connected returns a clear message and declares nothing', async () => {
   const harness = aLocalMirror(); // no pages → scoped search returns 0
   const gss = harness.build();

--- a/local-mirror/src/test/sync-all.test.ts
+++ b/local-mirror/src/test/sync-all.test.ts
@@ -63,7 +63,7 @@ function buildSyncOver(specs: SourceSpec[]): {
   const syncLock = { acquire: () => true, release: () => {} };
 
   return {
-    api: new LocalMirror({ configStore, stateStore, vaultWriter, clock, connectorFor, syncLock }),
+    api: new LocalMirror({ configStore, stateStore, vaultWriter, clock, connectorFor, syncLock, activeUniverse: () => 'default' }),
     written,
     deleted,
   };

--- a/local-mirror/src/test/sync-writes-vault.test.ts
+++ b/local-mirror/src/test/sync-writes-vault.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { parseLocalMirrorMarkdown } from '../lib/markdown.js';
-import { aLocalMirror, aNotionPage } from './builder.js';
+import { aLocalMirror, aNotionLocalMirror, aNotionPage } from './builder.js';
 
 // Acceptance test at the API port (ILocalMirror), driven by the Builder with a
 // stubbed connector and an in-memory vault. A sync turns each enumerated page into one
@@ -30,6 +30,43 @@ test('syncing a source writes one local-mirror .md per page, with mandatory fron
   assert.equal(data.source_id, 'abc123');
   assert.equal(data.title, 'Sample error catalog');
   assert.match(content, /When the API returns 402/);
+});
+
+// Universe-awareness (ADR 0034): a mirror scoped to a universe lands its notes under the
+// universe root, mirroring how `/import --universe` files + stamps notes so retrieval scope
+// travels with the file. A rootless mirror (no universe, or the default) is unchanged.
+test('a universe-scoped mirror writes under <universe>/mirrors/<name>/ and stamps universe', async () => {
+  const page = aNotionPage({ id: 'abc123', content: 'Scoped body.\n' });
+  const harness = aLocalMirror()
+    .withDeclaredSources(aNotionLocalMirror({ universe: 'acme' }))
+    .withNotionPages(page);
+  const gss = harness.build();
+
+  const report = await gss.sync('team-a');
+
+  assert.equal(report.written, 1);
+  const file = harness.vaultFiles().get('acme/mirrors/team-a/abc123.md');
+  assert.ok(file, 'expected the note under the universe-prefixed path');
+  assert.equal(harness.vaultFiles().has('mirrors/team-a/abc123.md'), false, 'never at the bare root');
+  const { data } = parseLocalMirrorMarkdown(file);
+  assert.equal(data.universe, 'acme');
+  // Stamped LAST (stamp-universe.mjs's append-last convention): after the citation keys.
+  assert.ok(file.indexOf('universe:') > file.indexOf('last_edited_time:'), 'universe stamped last');
+});
+
+test('a rootless mirror (no universe) writes at the bare root and stamps no universe key', async () => {
+  const page = aNotionPage({ id: 'abc123', content: 'Rootless body.\n' });
+  const harness = aLocalMirror()
+    .withDeclaredSources(aNotionLocalMirror()) // no universe declared
+    .withNotionPages(page);
+  const gss = harness.build();
+
+  await gss.sync('team-a');
+
+  const file = harness.vaultFiles().get('mirrors/team-a/abc123.md');
+  assert.ok(file, 'a rootless mirror keeps the historical root path');
+  const { data } = parseLocalMirrorMarkdown(file);
+  assert.equal('universe' in data, false, 'no universe key on a rootless mirror');
 });
 
 test('syncing a source writes one .md per enumerated page', async () => {

--- a/maintainers/plans/prospective/harness-universe-blindspot-hardening-action.md
+++ b/maintainers/plans/prospective/harness-universe-blindspot-hardening-action.md
@@ -1,0 +1,69 @@
+# Action plan — harden the harness against cross-cutting-contract blind spots (the universe lesson)
+
+> **Why this plan exists.** Introducing universes (ADR 0034) broke **six** distinct components,
+> each caught in *field-verify*, none by our green test suites: `/lint` resolver, `/lint`
+> orphan-exclude, `/lint` same-note anchors, `/consolidate` (resolver + capture-zone), `/file-back`
+> placement, `/local-mirror` placement. One shared failure mode, one lesson. Owner asked (2026-07-21):
+> *why did we let so many side-effects through, and how do we improve the harness?* This plan is the
+> answer, scoped to the launcher repo.
+
+## Root cause (the reframe)
+
+Universes were framed as a **soft, additive, invisible-until-opted-in** feature (true for the *data
+model*), which created a false impression of a small blast radius. In the **code**, universes changed
+the **vault-path contract**: every component that computes or parses a vault-relative path gained a
+leading `<universe>/` segment it never accounted for. Three mechanical causes followed:
+
+1. **All fixtures were single-universe (root = the `default` universe).** But `default` is exactly the
+   value where the prefix is **absent** — the one case that *cannot* reveal the bug. Our suites
+   exercised the only universe value incapable of killing the "ignores the universe segment" mutant.
+   (This is the mutation-testing lesson — ≥2 diverse values, feed present *and* absent — but applied one
+   layer too low: at assertions, not at fixtures.)
+2. **No central vault-path seam.** Each component re-derives path logic (`buildResolver`,
+   `isUnderZone`/`startsWith`, `target_dir`, `filedNotePath`, the mirror's write path). Universe-
+   awareness therefore had to be re-implemented — and re-forgotten — in N places.
+3. **No "consumers audited" gate on a cross-cutting change.** The universes PR never enumerated *who
+   parses a vault path*. Each consumer was discovered broken later, in the field.
+
+## Tracking
+
+- [ ] **M1 — Non-default fixture everywhere (the cheap, high-leverage guard).**
+  - [ ] Add a convention to `maintainers/CONVENTIONS.md`: any suite that consumes a vault path MUST
+        ship a fixture under a **named (non-`default`) universe**, as a twin of the `default` case.
+  - [ ] Backfill the twin on the existing universe-path consumers whose suites still only exercise
+        `default`: audit `wiki-lint` (`scripts/lib/`), `consolidation-candidates`, `file-back`/`filed-note`,
+        `import` stamping. (Local-mirror already has both twins as of PR #43 — use it as the model.)
+  - [ ] Cross-link the convention to the mutation-testing assertion rules (same idea, one layer up).
+- [ ] **M2 — One vault-path seam (the structural fix; needs an ADR).**
+  - [ ] Write **ADR 0035** (`maintainers/decisions/0035-*.md`): a single codec module is THE place that
+        maps `(universe, relPath) <-> vaultPath` and answers `isUnderZone(vaultPath, zone)`
+        universe-insensitively. Crux + prior-art block + `Scope:` field (per CONVENTIONS conventions).
+  - [ ] Decide the seam's home: launcher scripts consume it (`scripts/lib/`), and the TS packages
+        (`rag/`, `local-mirror/`) cannot import across package+language — so document the **lock-step**
+        contract (like `DEFAULT_UNIVERSE` today) rather than pretend a single shared import.
+  - [ ] Route the existing re-derivers through it (resolver, orphan-exclude, capture-zone, file-back,
+        mirror). TDD, behaviour-preserving; the M1 twins are the safety net for the refactor.
+- [ ] **M3 — Cross-cutting-contract gate (lightweight process).**
+  - [ ] Add to `maintainers/CONVENTIONS.md` a PR checklist item: when a change alters the **shape** of a
+        value multiple components parse (vault path, frontmatter schema, index record), the PR carries a
+        **"Consumers audited"** section listing every consumer + its coverage under the new shape.
+  - [ ] State the trigger crisply so it is unambiguous (shape-of-a-parsed-value change, not any change).
+
+## Deliberately deferred (owner did NOT pick — record so we don't relitigate)
+
+- [ ] **Realistic universe vault CI job** (seed ~40 notes under a named universe, run each skill, assert
+      no false-positive explosion). Would have gone red on all six bugs at once, but heavier; **not
+      selected 2026-07-21**. Revisit if a *seventh* universe blind spot slips through despite M1–M3.
+
+## The COMMENT (how)
+
+- Order: **M1 first** (cheap, immediately prevents recurrence), **M3 next** (pure doc, no code risk),
+  **M2 last** (the refactor — safest once M1's twins exist to catch a regression).
+- Artifacts in English; ADR follows the repo's ADR conventions (Crux block, prior-art / anti-NIH,
+  `Scope:` field). POSIX-at-the-source discipline preserved (Windows CI is the arbiter).
+- Not urgent / not release-blocking: this hardens *future* cross-cutting changes; it does not gate the
+  current release (PR #43). Pick it up after the release is cut.
+
+> Links: ADR 0034 (universes), `post-v3.1.0-ux-backlog.md` (where the six bugs were logged + fixed),
+> the mutation-testing assertion rules (skill `tdd-discipline`), and the convention memories
+> [[cross-platform-ci-is-the-arbiter]] / [[validate-shipped-not-test-instance]].

--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -135,32 +135,37 @@ behaviour unchanged** (backward-compatible: mirrors declared before this feature
 
 ### Tracking (TDD, outside-in via the Builder — the suite's style; `local-mirror/` is a TS package, `npm test`)
 
-- [ ] **Step 1 — sync write path (acceptance, `sync-writes-vault.test.ts`).** A mirror whose config
+- [x] **Step 1 — sync write path (acceptance, `sync-writes-vault.test.ts`).** A mirror whose config
       carries `universe: 'acme'` writes under `acme/mirrors/<name>/<id>.md` and stamps `universe: acme`
-      in frontmatter; a rootless mirror is unchanged. Drive:
-  - [ ] `types.ts` → `LocalMirrorConfig.universe?: string`; `LocalMirrorFrontmatter.universe?: string`.
-  - [ ] `lib/markdown.ts` → `toLocalMirrorMarkdown(mirror, item, body, universe?)` stamps `universe`
-        LAST when truthy (matches `stamp-universe.mjs`'s append-last convention).
-  - [ ] `domain/local-mirror.ts` `syncLocked` → prefix `vaultPath` with `${config.universe}/` when set,
-        pass `config.universe` to `toLocalMirrorMarkdown`. State stores the actual path → delete/reconcile
-        stay consistent by construction.
-  - [ ] `test/builder.ts` → `aNotionLocalMirror({ universe })` includes the key only when provided.
-- [ ] **Step 2 — freeze at setup (acceptance, `setup-source.test.ts`).** `setupSource` with active
-      universe `'acme'` declares a config carrying `universe: 'acme'`; with `'default'` → no `universe`.
-  - [ ] `LocalMirrorDeps` gains `activeUniverse: () => string` (used ONLY by setupSource, not the hot
-        sync path); `configFromRequest(req, universe)` sets `universe` only when truthy and `!== 'default'`.
-  - [ ] `test/builder.ts` → `withActiveUniverse(name)`, default `() => 'default'` so existing tests pass.
-  - [ ] Define a local `DEFAULT_UNIVERSE = 'default'` const in the TS package (lock-step comment with
+      in frontmatter; a rootless mirror is unchanged. _(2026-07-20 · `4e7ce6a`)_ Drove:
+  - [x] `types.ts` → `LocalMirrorConfig.universe?: string`; `LocalMirrorFrontmatter.universe?: string`.
+  - [x] `lib/markdown.ts` → `toLocalMirrorMarkdown(mirror, item, body, universe?)` stamps `universe`
+        LAST when truthy (matches `stamp-universe.mjs`'s append-last convention; asserted by raw order).
+  - [x] `domain/local-mirror.ts` → extracted a pure `vaultPathFor(config, id)` that prefixes with
+        `${config.universe}/` when set; state stores the actual path → delete/reconcile stay consistent.
+  - [x] `test/builder.ts` → `aNotionLocalMirror({ universe })` includes the key only when provided.
+        Triangulated by the rootless twin (root path, no `universe` key).
+- [x] **Step 2 — freeze at setup (acceptance, `setup-source.test.ts`).** `setupSource` with active
+      universe `'acme'` declares a config carrying `universe: 'acme'` AND lands the first sync there; with
+      `'default'` → no `universe`, note at root. _(2026-07-20 · `266aea8`)_
+  - [x] `LocalMirrorDeps` gains `activeUniverse: () => string` (read ONLY by setupSource, never the hot
+        sync path); `configFromRequest(req, universe)` stamps `universe` only when truthy and `!== 'default'`.
+  - [x] `test/builder.ts` → `withActiveUniverse(name)`, default `'default'` so existing tests pass.
+  - [x] Defined a local `DEFAULT_UNIVERSE = 'default'` const in `lib/universe.ts` (lock-step comment with
         `scripts/lib/universes.mjs` / `rag/src/lib/universe.ts` — cannot import across package + language).
-- [ ] **Step 3 — real adapter + server wiring.** A reader for `<projectRoot>/.vault-rag/active-universe`
-      (trim, fallback `'default'`; POSIX, cf. the Windows `vaultRagDir` fix) wired into `buildDeps()`
-      (`server.ts`), anchored on `projectRoot` (already the brain root in `lib/config.ts`). Unit-test it.
-- [ ] **Full suite green** (`npm test`, baseline was 205) + **repo-wide** `node --test` for the launcher.
-      Cross-platform reflex: POSIX paths at the source (Windows CI is the arbiter).
-- [ ] **Known limitation to note in the PR (do NOT over-engineer a fix):** a mirror declared BEFORE a
-      universe existed keeps writing at root; if you later activate a universe, only genuinely-changed
-      items would move, so a transition could momentarily leave a root copy + a universe copy. Acceptable
-      (universes + mirror is a brand-new combo; fresh mirrors are declared inside their universe). Log it.
+- [x] **Step 3 — real adapter + server wiring.** `adapters/fs-active-universe.ts`: pure
+      `resolveActiveUniverse` (trim, blank/whitespace/absent → `'default'`) split from the file read, any
+      read error degrades to the default; wired into `buildDeps()` via `ACTIVE_UNIVERSE_PATH`
+      (`<brainRoot>/.vault-rag/active-universe`, in `lib/config.ts`). Unit-tested + buildDeps wiring
+      asserted through the real composition root. _(2026-07-20 · `266aea8`)_
+- [x] **Full suite green** (`npm test` → **213**, baseline 205) + **repo-wide** `node --test` for the
+      launcher (**740 pass / 0 fail / 1 todo**) + `tsc --noEmit` clean + `tsc` build clean. POSIX paths at
+      the source (vault paths built with literal `/`; the pointer is read with native `resolve`, not stored).
+      _(2026-07-20 — local green; Windows CI is the final arbiter on the PR.)_
+- [x] **Known limitation noted in the PR (no over-engineered fix):** a mirror declared BEFORE a universe
+      existed keeps writing at root; if you later activate a universe, only genuinely-changed items would
+      move, so a transition could momentarily leave a root copy + a universe copy. Acceptable (universes +
+      mirror is a brand-new combo; fresh mirrors are declared inside their universe). _(2026-07-20 — in PR body.)_
 
 > Links: ADR 0034 (universes), the universes plan (`universes-progressive-disclosure-action.md` → Step 6,
 > import stamping), FU3 in this file (the sibling file-back universe fix, PR #43),

--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -112,9 +112,17 @@ replicates a Notion zone as Markdown), so mirrored notes are **indexed like any 
 > 🎯 **PICKED UP 2026-07-20 — bundled into the same release as PR #43** (the `/lint` + file-back
 > follow-ups). Release codename chosen: **"The One Where /lint Quiets Down and Filing Finds Its
 > Universe"**. This closes the **write-path universe trilogy**: `/import` ✅ · file-back ✅ (#43) ·
-> **`/local-mirror` ← this**. Release is **NOT cut yet** (Thomas's call). Do this on its **own branch
-> + PR** (`feat/local-mirror-universe-aware`, off `main` once #43 has merged), then Thomas cuts the
-> release covering both.
+> **`/local-mirror` ← this**. Release is **NOT cut yet** (Thomas's call).
+>
+> **Branching (decided 2026-07-20, supersedes the earlier "own branch off main once #43 merged").**
+> Build this on the **SAME branch as #43** (`fix/lint-followups-work-zones-and-file-back-universe`);
+> #43 grows into THE release-PR covering the whole trilogy close, merged **once** at release time.
+> Rationale: a fresh install copies the launcher's **`main` HEAD** (`installer.mjs` git-ls-files copy),
+> so merging #43 to `main` first would expose it to every new install **before** the joint release —
+> exactly what we must avoid. One branch, one merge, nothing on `main` before the release. The
+> `local-mirror/` package touches no file of #43, so its commits stay cleanly separable in history.
+> (`update-engine` reaches deployed brains only via the latest tag, ADR 0017, so THEY are unaffected
+> until the release is cut — the exposure is fresh-installs-only, hence this decision.)
 
 ### Frozen design decision (owner-approved reasoning, 2026-07-20)
 

--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -189,12 +189,15 @@ never patch it inside a deployed brain** (a local patch is clobbered by the mani
 > (fix the engine source, not the deployed brain), the axis-1 wiki-health plan
 > (`wiki-health-axis1-mechanisms-action.md`).
 
-## 🧹 Make `/lint` stop crying wolf on normal work-notes and raw dumps (2 engine follow-ups)
+## 🧹 Make `/lint` stop crying wolf on normal work-notes and raw dumps (3 engine follow-ups) — ✅ SHIPPED
 
+> **Status: ✅ SHIPPED (2026-07-20).** All three follow-ups built in TDD on a single branch, one PR
+> (harness only, no reindex): FU1+FU2 in `74ee136`, FU3 in `9bb905e`. The recommended defaults were
+> picked (path-prefix / lint-side exemption / caller-passes-universe). Ships in the next patch release.
+>
 > **Origin (2026-07-19, field-verify of v3.6.1 on a real single-universe vault ~410 notes).** With the
-> universe-aware fix live, the report is trustworthy — but it still flags two categories that are
-> **structural noise, not rot**. Two engine improvements were logged from the field (deferred here on
-> purpose: **no code yet**, owner picks the approach when picked up). The reflex is the same as the
+> universe-aware fix live, the report is trustworthy — but it still flagged categories that are
+> **structural noise, not rot**. Improvements logged from the field. The reflex is the same as the
 > regression above: **fix the generic engine source so every brain benefits**, never hand-patch or
 > hard-code one brain's personal taxonomy ([[validate-shipped-not-test-instance]]).
 
@@ -205,20 +208,19 @@ folders are legitimately unlinked by design (nobody links back to a meeting writ
 On the field vault ~110 of 178 reported orphans were exactly this false positive. The orphan-exclude
 default (`daily/`, `raw-sources/`, `inbox/`, `actions-log.md`) predates those zones.
 
-- [ ] **Extend `DEFAULT_ORPHAN_EXCLUDE`** (`scripts/lib/wiki-lint.mjs`) to the folders **the engine's
+- [x] **Extend `DEFAULT_ORPHAN_EXCLUDE`** (`scripts/lib/wiki-lint.mjs`) to the folders **the engine's
       own shipped skills write** and that are never linked to: `meetings/`, `briefings/` (sync-sources),
       `prep-1-1/` (prepare-1-1), `coaching/` (coach). These are generic — every brain has them.
-  - [ ] Keep it **universe-prefix-insensitive** by reusing the existing `isUnderZone` helper (already
+      _(2026-07-20 · 74ee136)_
+  - [x] Keep it **universe-prefix-insensitive** by reusing the existing `isUnderZone` helper (already
         in place from v3.6.1) — no new path logic.
-  - [ ] **Do NOT bake in brain-specific folders** (e.g. `prep-day/`, `rapport-etonnement/`): those stay
+  - [x] **Do NOT bake in brain-specific folders** (e.g. `prep-day/`, `rapport-etonnement/`): those stay
         per-brain, added through `options.orphanExclude` (a brain-side lint config is a separate item).
-  - [ ] Fixes a latent **inconsistency** en passant: `meetings/` is already a `/consolidate` capture
+  - [x] Fixes a latent **inconsistency** en passant: `meetings/` is already a `/consolidate` capture
         zone (`DEFAULT_CAPTURE_ZONES`) but was missing from the lint orphan-exclude.
-- [ ] **Decision (deferred — owner to pick when built):** path-prefix list (above, smallest change) **vs**
-      a cleaner **type-based** exemption (exclude any note whose `type` is a capture/work type —
-      meeting/briefing/prep/coaching/daily — symmetric to `entityTypes`). Default recommendation: the
-      path-prefix list, consistent with the current design; the type-based refactor is a nice-to-have.
-- [ ] **TDD** on `wiki-lint.mjs` (baby-steps, fail-first); harness only, no reindex; carry via a patch
+- [x] **Decision (owner picked):** path-prefix list (smallest change, consistent with the current
+      design). The type-based exemption stays a nice-to-have, not built.
+- [x] **TDD** on `wiki-lint.mjs` (baby-steps, fail-first); harness only, no reindex; carry via a patch
       release tag (ADR 0017).
 
 ### Follow-up 2 — a raw dump is not a curated node: don't demand full frontmatter on raw-capture zones
@@ -228,16 +230,15 @@ transcripts** (`raw-sources/transcripts/*`) arrive without it — 43 of them sho
 violations on the field vault. A raw dump is not a curated wiki node; holding it to the full taxonomy is
 the same category error as calling it an orphan.
 
-- [ ] **Exempt raw-capture zones from the required-frontmatter rule** in `lintVault`
+- [x] **Exempt raw-capture zones from the required-frontmatter rule** in `lintVault`
       (`scripts/lib/wiki-lint.mjs`) — parallel to the orphan exemption, reusing `isUnderZone`. Kills the
-      false frontmatter findings **without inventing any dates**.
-- [ ] **Decision (deferred — owner to pick when built):** lint-side exemption (above, recommended, zero
-      fabricated metadata) **vs** stamping minimal frontmatter at **import** time (importer fabricates
-      `created`) **vs** both (exempt in lint + have `sync-sources` write frontmatter for *new*
-      transcripts so future ones are clean). Default recommendation: the lint-side exemption.
-- [ ] Keep the genuinely-actionable frontmatter findings intact (living curated notes still expected to
-      conform) — this only silences the **raw** zones, cf. the "Not part of this regression" note above.
-- [ ] **TDD** on `wiki-lint.mjs`; harness only, no reindex; same patch-release path.
+      false frontmatter findings **without inventing any dates**. _(2026-07-20 · 74ee136)_
+- [x] **Decision (owner picked):** lint-side exemption (zero fabricated metadata). Import-time stamping
+      not built. Only the RAW zones (`daily/`, `raw-sources/`, `inbox/`, `actions-log.md`) are exempt.
+- [x] Keep the genuinely-actionable frontmatter findings intact (living curated notes still expected to
+      conform) — this only silences the **raw** zones. Curated work-zones (`meetings/` etc.) stay held
+      to the taxonomy (locked by a test asserting a `meetings/` note still surfaces its missing keys).
+- [x] **TDD** on `wiki-lint.mjs`; harness only, no reindex; same patch-release path.
 
 ### Follow-up 3 — the file-back builder is not universe-aware (files new notes at the vault root)
 
@@ -250,16 +251,17 @@ manual placement (the field brain worked around it with a direct `Write` under t
 the gap). This is **distinct** from import stamping (Step 6, done — that stamps *imported* notes, via
 `stamp-universe.mjs`); here it's the *file-back* write path.
 
-- [ ] **Make `renderFiledNote` / `filedNotePath` universe-aware:** prefix the path with the **active
+- [x] **Make `renderFiledNote` / `filedNotePath` universe-aware:** prefix the path with the **active
       universe** (`vault/<universe>/<folder>/…`) and stamp the `universe:` key, when a universe is active
-      — reusing the same active-universe source the reader anchors on (registry / `.vault-rag/`, cf. the
-      universes plan). A default/root brain (no universe) keeps today's behaviour exactly.
-- [ ] **Decision (deferred):** does the builder **read** the active universe itself, or does the caller
-      (`file-back-note.mjs` CLI / the skill) pass it into the spec? Lean: pass it in (keep the pure core
-      I/O-free; the thin CLI resolves the active universe), so `filed-note.mjs` stays a pure builder.
-- [ ] **TDD** on `filed-note.mjs` (pure core, already 15 tests) + the CLI; harness only, no reindex.
-- [ ] Corrects the audit note above (the file-back universe **placement** was flagged as "a separate
-      concern" — this is that concern, now a tracked item, not the import-stamping one).
+      — reusing the same active-universe source the reader anchors on (`readActiveUniverse` on
+      `.vault-rag/`). A default/root brain (no universe) keeps today's behaviour exactly.
+      _(2026-07-20 · 9bb905e)_
+- [x] **Decision (owner picked):** the caller passes it in. The thin CLI (`file-back-note.mjs`) resolves
+      the active universe via `readActiveUniverse` and injects it into the spec, so `filed-note.mjs`
+      stays a pure, I/O-free builder. Active universe wins over any spec-supplied one.
+- [x] **TDD** on `filed-note.mjs` (pure core) + the CLI; harness only, no reindex.
+- [x] Corrects the audit note above (the file-back universe **placement** was flagged as "a separate
+      concern" — this is that concern, now shipped, not the import-stamping one).
 
 > Links: the axis-1 wiki-health plan (`wiki-health-axis1-mechanisms-action.md`, Tracks A/C own these
 > pure cores), ADR 0009 (deterministic rung-1 cores), ADR 0034 (universes),

--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -100,7 +100,7 @@ are not). Surfaced by Thomas during the universes field-verify (2026-07-19).
 
 > Links: ADR 0034 (universes), [[brain-permission-posture-readonly]] (UUID connectors, single-account).
 
-## 💡 Idea — make `/local-mirror` universe-aware (parity with `/import --universe`)
+## 🔭 Action plan — make `/local-mirror` universe-aware (parity with `/import --universe`)
 
 `/import` gained `--universe` (ADR 0034 Step 6): imported notes are filed under `vault/<universe>/` and
 stamped `universe:` in frontmatter. **`/local-mirror`** also lands content **in the vault** (it
@@ -109,17 +109,54 @@ replicates a Notion zone as Markdown), so mirrored notes are **indexed like any 
 `default` regardless of the active universe. Asymmetry found during the universes field-verify
 (2026-07-19): import is universe-aware, the mirror is not.
 
-- [ ] **Behaviour:** stamp mirrored notes with the **active** universe (read from `.vault-rag/`, as the
-  engine does) or an explicit declared target; file them under `vault/<universe>/…` for a created
-  universe, root for the default. Reuse the pure `stamp-universe.mjs` already used by import;
-  **additive**, never clobber an existing `universe:` key.
-- [ ] **Not a regression:** mirrors always produced `default` notes; this is an **enhancement**, out of
-  scope of the shipped universes plan (which covered `/import` only). Safe to defer.
-- [ ] **Deterministic + tested:** pure stamping seam, injected fs, cross-platform (POSIX paths at the
-  source, cf. the Windows `vaultRagDir` fix). Promote to an action plan before coding.
+> 🎯 **PICKED UP 2026-07-20 — bundled into the same release as PR #43** (the `/lint` + file-back
+> follow-ups). Release codename chosen: **"The One Where /lint Quiets Down and Filing Finds Its
+> Universe"**. This closes the **write-path universe trilogy**: `/import` ✅ · file-back ✅ (#43) ·
+> **`/local-mirror` ← this**. Release is **NOT cut yet** (Thomas's call). Do this on its **own branch
+> + PR** (`feat/local-mirror-universe-aware`, off `main` once #43 has merged), then Thomas cuts the
+> release covering both.
 
-> Links: ADR 0034 (universes), the universes plan
-> (`universes-progressive-disclosure-action.md` → Step 6, import stamping).
+### Frozen design decision (owner-approved reasoning, 2026-07-20)
+
+A mirror is a **durable, background-synced source that belongs to ONE universe** — so we do **NOT**
+read the volatile active pointer at *sync* time (a background tick firing while you `/switch`ed would
+scatter one mirror's notes across universes). Instead we **freeze the universe into the mirror's config
+at `setup_source` time**, resolved from the then-active universe — exactly mirroring how `/import
+--universe` stamps at import time. The default universe (`"default"`) means **no universe → root
+behaviour unchanged** (backward-compatible: mirrors declared before this feature carry no `universe`).
+
+### Tracking (TDD, outside-in via the Builder — the suite's style; `local-mirror/` is a TS package, `npm test`)
+
+- [ ] **Step 1 — sync write path (acceptance, `sync-writes-vault.test.ts`).** A mirror whose config
+      carries `universe: 'acme'` writes under `acme/mirrors/<name>/<id>.md` and stamps `universe: acme`
+      in frontmatter; a rootless mirror is unchanged. Drive:
+  - [ ] `types.ts` → `LocalMirrorConfig.universe?: string`; `LocalMirrorFrontmatter.universe?: string`.
+  - [ ] `lib/markdown.ts` → `toLocalMirrorMarkdown(mirror, item, body, universe?)` stamps `universe`
+        LAST when truthy (matches `stamp-universe.mjs`'s append-last convention).
+  - [ ] `domain/local-mirror.ts` `syncLocked` → prefix `vaultPath` with `${config.universe}/` when set,
+        pass `config.universe` to `toLocalMirrorMarkdown`. State stores the actual path → delete/reconcile
+        stay consistent by construction.
+  - [ ] `test/builder.ts` → `aNotionLocalMirror({ universe })` includes the key only when provided.
+- [ ] **Step 2 — freeze at setup (acceptance, `setup-source.test.ts`).** `setupSource` with active
+      universe `'acme'` declares a config carrying `universe: 'acme'`; with `'default'` → no `universe`.
+  - [ ] `LocalMirrorDeps` gains `activeUniverse: () => string` (used ONLY by setupSource, not the hot
+        sync path); `configFromRequest(req, universe)` sets `universe` only when truthy and `!== 'default'`.
+  - [ ] `test/builder.ts` → `withActiveUniverse(name)`, default `() => 'default'` so existing tests pass.
+  - [ ] Define a local `DEFAULT_UNIVERSE = 'default'` const in the TS package (lock-step comment with
+        `scripts/lib/universes.mjs` / `rag/src/lib/universe.ts` — cannot import across package + language).
+- [ ] **Step 3 — real adapter + server wiring.** A reader for `<projectRoot>/.vault-rag/active-universe`
+      (trim, fallback `'default'`; POSIX, cf. the Windows `vaultRagDir` fix) wired into `buildDeps()`
+      (`server.ts`), anchored on `projectRoot` (already the brain root in `lib/config.ts`). Unit-test it.
+- [ ] **Full suite green** (`npm test`, baseline was 205) + **repo-wide** `node --test` for the launcher.
+      Cross-platform reflex: POSIX paths at the source (Windows CI is the arbiter).
+- [ ] **Known limitation to note in the PR (do NOT over-engineer a fix):** a mirror declared BEFORE a
+      universe existed keeps writing at root; if you later activate a universe, only genuinely-changed
+      items would move, so a transition could momentarily leave a root copy + a universe copy. Acceptable
+      (universes + mirror is a brand-new combo; fresh mirrors are declared inside their universe). Log it.
+
+> Links: ADR 0034 (universes), the universes plan (`universes-progressive-disclosure-action.md` → Step 6,
+> import stamping), FU3 in this file (the sibling file-back universe fix, PR #43),
+> [[validate-shipped-not-test-instance]].
 
 ## 🐛 Regression — universes broke `/lint` (make the wiki-health linter universe-aware)
 

--- a/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
+++ b/maintainers/plans/prospective/post-v3.1.0-ux-backlog.md
@@ -77,7 +77,11 @@ one friendly report, with **opt-in fixes** (never silent writes).
 > (`import-ux-folder-picker-and-index-notify-action.md`), the ABI-skew plan
 > (`node-abi-skew-install-runtime-action.md`).
 
-## 💡 Idea — `/switch` should flag the native connectors' single-account limit
+## 🚩 `/switch` flags the native connectors' single-account limit — ✅ SHIPPED
+
+> ✅ **Shipped 2026-07-21 (commit `4e43e70`), in PR #43.** Pure `nativeConnectorsReminder({from,to})`
+> in `scripts/lib/universes.mjs` + wired into `runSwitchCli`'s fast path; `/switch` skill relays the
+> core message verbatim. 7 tests added (pure rule + CLI integration), suite green.
 
 Universes model successive **employers / clients / spheres** (ADR 0034). Switching universe usually
 means switching the **account** you operate under, but the **native MCP connectors** (Slack, Notion,
@@ -86,17 +90,21 @@ Google, mail…) are each bound to **one account** and have **no multi-account**
 reconnects them to the new one: a silent mismatch (the RAG is re-scoped correctly, the live connectors
 are not). Surfaced by Thomas during the universes field-verify (2026-07-19).
 
-- [ ] **Behaviour:** past the disclosure gate (count >= 2), when `/switch` changes the active universe
-  **between two created universes** (not the trivial default toggle), append a one-line, non-nagging
-  reminder, e.g. *"Native connectors are single-account; if this universe uses different accounts
-  (Slack, Notion, Google…), disconnect/reconnect them to match."* Emitted by the **deterministic**
-  switch CLI / skill (like the 1→2 onboarding line), never invented by the LLM (ADR 0009).
-- [ ] **The trap (why we can't automate it):** native connector server names are **per-user UUIDs**,
+- [x] **Behaviour:** the deterministic switch core appends a one-line, non-nagging reminder when a
+  `/switch` **changes** the active universe and **lands in a named universe** (excludes the trivial
+  return to the cross-cutting `default`, and a no-op switch). *Refined from the original "between two
+  created universes": `default → named` also warns, because entering a named sphere IS an account
+  change; only landing back on `default` (no specific employer account) is silent.* Emitted by the
+  **deterministic** switch CLI (like the 1→2 onboarding line), never invented by the LLM (ADR 0009).
+- [x] **The trap (why we can't automate it):** native connector server names are **per-user UUIDs**,
   not pre-authorizable nor introspectable, so we **cannot** tell which connector points at which
   account. The reminder stays **generic advice**, not per-connector automation. Cf.
   [[brain-permission-posture-readonly]].
-- [ ] **Relevance, not enforcement:** the RAG universe boundary is unaffected; this only warns the
-  human about the **live** side. Keep it once-per-switch, quiet, and only past the gate.
+- [x] **Relevance, not enforcement:** the RAG universe boundary is unaffected; this only warns the
+  human about the **live** side. Kept once-per-switch, quiet, and only when landing in a named universe.
+- [ ] **Deliberately NOT covered (note for a future pass):** `create`-and-switch into a named universe
+  does not emit the connectors reminder (it has its own 1→2 onboarding line). Add it there too if the
+  field shows the mismatch bites on create as well.
 
 > Links: ADR 0034 (universes), [[brain-permission-posture-readonly]] (UUID connectors, single-account).
 

--- a/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
+++ b/maintainers/plans/prospective/second-brain-migration-and-engine-upstream-action.md
@@ -203,6 +203,19 @@ names/IDs, org/account emails, product-team names, and any private-project refer
 > (FR) carry a structurally 1:1 body (25 headings each, incl. "Local mirrors" + the local-mirror
 > citation pattern). Verified read-only 2026-07-19; no parity pass needed.
 
+**Track C follow-up (discovered 2026-07-19 during the migration — PENDING Thomas's go on wording).**
+A refinement to the "rephrase, don't copy raw" confidentiality rule surfaced (made first in the personal
+brain, to be upstreamed de-identified). The rule guards against **third-party verbatim leaks**, not
+precision — so for a **precise source whose exact wording carries the meaning** (assessments, figures,
+established terminology, definitions), **keep the exact terms and quote verbatim** rather than paraphrase;
+rephrasing stays mandatory only for (a) **third parties' private messages** (synthesize the substance) and
+(b) **anything meant to leave the repo**. To port into the Confidentiality section of **both** sacred
+templates (`CLAUDE.md.template` EN + `templates/fr/CLAUDE.md.template` FR), framed "private brain", and to
+add to the **Reflex** line: *"in a private brain this governs mainly whether to version something at all,
+not the fidelity of content you've decided to keep."* **Benefits future brains only** — the sacred layer
+is not propagated by `update-engine` (deferred to ROADMAP Gate 4), and the personal brain already carries
+this edit. Proposed EN/FR wording drafted 2026-07-19; apply once approved.
+
 ---
 
 ## Track D — Corpus migration (personal brain)
@@ -210,21 +223,22 @@ names/IDs, org/account emails, product-team names, and any private-project refer
 > **Cross-plan order:** this is Gate 3 of [`../ROADMAP.md`](../ROADMAP.md) — it depends on Gate 1
 > (green) **and** Gate 2 (universes) landing first (see the prerequisites below).
 
-- [ ] Generate a fresh brain from the launcher (after Track A + generic bits of B/C have landed
-      upstream), choosing the embedder consciously (privacy trade-off).
-  - [ ] **Prerequisite (engine):** the *legacy-safe fresh-install constitution layering* ("green") must land
-        in the launcher FIRST, so the regenerated brain is **born two-layer** and future constitution
-        improvements keep flowing to it. See the "Sequencing decision" in
-        `engine-managed-file-merge-strategy.md`. Skipping it would make this brand-new brain a future
-        monolithic-legacy case.
-  - [ ] **Prerequisite (engine): universes** (ADR 0034) must land too, so the brain is born
-        universe-aware and `/import --universe` can stamp the notes at import time. Canonical plan:
-        `universes-progressive-disclosure-action.md` (ROADMAP Gate 2).
-- [ ] From the **new** brain, run `/import --universe <name>` pointing at the source vault → 405 notes +
-      attachments, **stamped into their universe** (demo skipped, no overwrite).
-- [ ] Reindex; verify with a canary query (`node scripts/verify-rag.mjs` → exit 0).
+- [x] Generate a fresh brain from the launcher, choosing the embedder consciously (privacy trade-off).
+      _(2026-07-19 — the user installed a fresh two-layer, universe-aware brain themselves from Claude
+      Desktop; **in-process** embedder chosen, so re-embeds stay free/offline.)_
+  - [x] **Prerequisite (engine):** the *legacy-safe fresh-install constitution layering* ("green") —
+        shipped (ROADMAP Gate 1, PR #37). Brain born two-layer.
+  - [x] **Prerequisite (engine): universes** (ADR 0034) — shipped (ROADMAP Gate 2, PR #38). Brain born
+        universe-aware; `/import --universe` stamps at import time.
+- [x] From the **new** brain, run `/import --universe <name>` pointing at the source vault → ~422 notes +
+      attachments, **stamped into their universe** (demo skipped, no overwrite). _(2026-07-19 — imported;
+      the universe was registered so the notes are `/switch`-able (cf. fix #40); `/switch` + scoped search
+      verified live.)_
+- [ ] Reindex; verify with a canary query (`node scripts/verify-rag.mjs` → exit 0). _(reindex ran in the
+      background via the live watcher; canary still to confirm once the index reaches the full count.)_
 - [ ] Layer the **private** skills (Track B) and the **merged** constitution (Track C) into the new
-      brain (these are the parts that never go through the launcher).
+      brain (these are the parts that never go through the launcher). _(next, AFTER the `/lint` linter
+      fix — see the backlog regression entry, resumed first post-`/clear`.)_
 
 > **Not a fleet fixture.** The source brain is **not** a Kenjaku brain (it only supplies the notes to
 > `/import`), so it is **not** a legacy-upgrade fixture. Re-layering the brains already deployed from an

--- a/scripts/file-back-note.mjs
+++ b/scripts/file-back-note.mjs
@@ -19,6 +19,7 @@ import { dirname, join } from "node:path";
 
 import { renderFiledNote } from "./lib/filed-note.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
+import { readActiveUniverse, vaultRagDir } from "./lib/universes.mjs";
 
 // Vault paths are displayed, compared and written in POSIX form so behaviour is
 // identical across platforms — on Windows join() yields backslashes, which would
@@ -30,6 +31,11 @@ const toPosix = (p) => p.split("\\").join("/");
 export const realFileBackDeps = {
   cwd: () => process.cwd(),
   today: () => new Date().toISOString().slice(0, 10),
+  // The active universe (ADR 0034): a filed-back answer lands in the universe you
+  // are working in, so it stays on-scope for that universe's retrieval. Read from
+  // the brain's .vault-rag pointer, anchored on cwd like the vault write path. A
+  // default/single-universe brain reads back "default" → note stays at the root.
+  universe: () => readActiveUniverse({ existsSync, readFileSync }, vaultRagDir(process.cwd())),
   readInput: () => readFileSync(0, "utf8"),
   exists: (p) => existsSync(p),
   writeFile: (p, content) => {
@@ -53,7 +59,7 @@ export function runFileBack(argv, deps = realFileBackDeps) {
 
   let note;
   try {
-    note = renderFiledNote({ ...spec, today: deps.today() });
+    note = renderFiledNote({ ...spec, today: deps.today(), universe: deps.universe() });
   } catch (err) {
     deps.error(`✗ ${err.message}`);
     return 1;

--- a/scripts/file-back-note.test.mjs
+++ b/scripts/file-back-note.test.mjs
@@ -19,6 +19,7 @@ function fakeDeps(overrides = {}) {
   const deps = {
     cwd: () => "/brain",
     today: () => "2026-07-17",
+    universe: () => overrides.universe ?? "default",
     readInput: () => overrides.input ?? "{}",
     exists: (p) => existing.has(p),
     writeFile: (p, content) => writes.push({ path: p, content }),
@@ -44,6 +45,16 @@ test("runFileBack — writes a conformant note under vault/, logs the path, exit
   assert.match(writes[0].content, /^---\ntype: topic\ncreated: 2026-07-17\nupdated: 2026-07-17\n/);
   assert.match(writes[0].content, /## Related\n\n- \[\[topics\/rag\]\]\n$/);
   assert.deepEqual(logs, ["✓ Filed back: vault/topics/capacity-management.md"]);
+});
+
+test("runFileBack — files the note under the ACTIVE universe, stamping universe:", () => {
+  const spec = JSON.stringify({ type: "person", title: "Jane Doe", tags: ["team"], body: "b" });
+  const { deps, logs, writes } = fakeDeps({ input: spec, universe: "acme" });
+  const code = runFileBack([], deps);
+  assert.equal(code, 0);
+  assert.equal(writes[0].path, "/brain/vault/acme/people/jane-doe.md");
+  assert.match(writes[0].content, /\nuniverse: acme\n/);
+  assert.deepEqual(logs, ["✓ Filed back: vault/acme/people/jane-doe.md"]);
 });
 
 test("runFileBack — refuses to overwrite an existing note, writes nothing, exits 1", () => {

--- a/scripts/lib/filed-note.mjs
+++ b/scripts/lib/filed-note.mjs
@@ -9,6 +9,17 @@
 
 // Turn a human title into a filename-safe slug: lowercased, accent-stripped,
 // kebab-case (e.g. "Jane Doe" → "jane-doe").
+import { DEFAULT_UNIVERSE } from "./universes.mjs";
+
+// The active universe carried by a spec, or null when the note belongs to the
+// vault root — no universe, or the implicit default (ADR 0034: a default-universe
+// brain lives at the root and behaves exactly as a single-universe brain). Pure:
+// just the constant, no I/O. Kept as the single gate so the path and the
+// frontmatter agree on what "in a universe" means.
+function activeUniverse(spec) {
+  return spec.universe && spec.universe !== DEFAULT_UNIVERSE ? spec.universe : null;
+}
+
 export function slugify(title) {
   const slug = title
     .normalize("NFD")
@@ -45,7 +56,9 @@ export function filedNotePath(spec) {
     throw new Error(`type "${spec.type}" requires a date (YYYY-MM-DD) for its filename`);
   }
   const stem = DATED.has(spec.type) ? `${spec.date}-${slugify(spec.title)}` : slugify(spec.title);
-  return `${folder}/${stem}.md`;
+  const universe = activeUniverse(spec);
+  const prefix = universe ? `${universe}/` : "";
+  return `${prefix}${folder}/${stem}.md`;
 }
 
 // Build a filed-back note as { path, content }. The content is conformant to the
@@ -60,12 +73,16 @@ export function renderFiledNote(spec) {
   }
   const links = spec.links ?? [];
   const path = filedNotePath(spec);
+  const universe = activeUniverse(spec);
   const frontmatter = [
     "---",
     `type: ${spec.type}`,
     `created: ${spec.today}`,
     `updated: ${spec.today}`,
     `tags: [${spec.tags.join(", ")}]`,
+    // Additive scope key so retrieval travels with the file (ADR 0034), appended
+    // last to match the import stamper (stamp-universe.mjs). Omitted at the root.
+    ...(universe ? [`universe: ${universe}`] : []),
     "---",
   ].join("\n");
   const related =

--- a/scripts/lib/filed-note.test.mjs
+++ b/scripts/lib/filed-note.test.mjs
@@ -71,6 +71,27 @@ test("filedNotePath — a dated type without a date throws (fail-loud)", () => {
   );
 });
 
+// ── universe-awareness (ADR 0034): a filed note lands in the active universe ────
+
+test("filedNotePath — an active universe prefixes the path with <universe>/", () => {
+  assert.equal(
+    filedNotePath({ type: "person", title: "Jane Doe", universe: "acme" }),
+    "acme/people/jane-doe.md",
+  );
+});
+
+test("filedNotePath — a dated type under a universe keeps its date, prefixed", () => {
+  assert.equal(
+    filedNotePath({ type: "meeting", title: "Q3 Review", date: "2026-07-17", universe: "acme" }),
+    "acme/meetings/2026-07-17-q3-review.md",
+  );
+});
+
+test("filedNotePath — the default universe (and no universe) stays at the vault root", () => {
+  assert.equal(filedNotePath({ type: "topic", title: "RAG", universe: "default" }), "topics/rag.md");
+  assert.equal(filedNotePath({ type: "topic", title: "RAG" }), "topics/rag.md");
+});
+
 // ── renderFiledNote: a taxonomy-conformant { path, content } by construction ───
 
 test("renderFiledNote — throws when today is missing (created/updated would be blank)", () => {
@@ -123,6 +144,45 @@ tags: [architecture]
 We go modular monolith.
 `,
   });
+});
+
+test("renderFiledNote — under an active universe, prefixes the path and stamps universe:", () => {
+  const note = renderFiledNote({
+    type: "topic",
+    title: "Capacity Management",
+    tags: ["rag"],
+    body: "The distilled answer.",
+    today: "2026-07-17",
+    universe: "acme",
+  });
+  assert.deepEqual(note, {
+    path: "acme/topics/capacity-management.md",
+    content: `---
+type: topic
+created: 2026-07-17
+updated: 2026-07-17
+tags: [rag]
+universe: acme
+---
+
+# Capacity Management
+
+The distilled answer.
+`,
+  });
+});
+
+test("renderFiledNote — the default universe stamps no universe: key (root behaviour unchanged)", () => {
+  const note = renderFiledNote({
+    type: "topic",
+    title: "X",
+    tags: ["a"],
+    body: "b",
+    today: "2026-07-17",
+    universe: "default",
+  });
+  assert.equal(note.path, "topics/x.md");
+  assert.equal(note.content.includes("universe:"), false);
 });
 
 test("renderFiledNote — builds path + conformant frontmatter, body, and woven [[links]]", () => {

--- a/scripts/lib/universes.mjs
+++ b/scripts/lib/universes.mjs
@@ -129,7 +129,12 @@ export function runSwitchCli(io, dir, argv) {
 
   // switch (fast path / explicit)
   const res = switchToUniverse(io, dir, intent.name);
-  if (res.ok) return { code: 0, message: `switched to '${res.name}'` };
+  if (res.ok) {
+    // Landing in a named universe? Deterministically remind that the single-account
+    // native connectors don't follow the switch (empty for the trivial toggles).
+    const reminder = nativeConnectorsReminder({ from: current, to: res.name });
+    return { code: 0, message: `switched to '${res.name}'` + reminder };
+  }
   if (res.reason === "unknown") {
     return {
       code: 1,
@@ -137,6 +142,23 @@ export function runSwitchCli(io, dir, argv) {
     };
   }
   return { code: 1, message: "no universe name given" };
+}
+
+/**
+ * The one-line, non-nagging reminder that native MCP connectors (Slack, Notion,
+ * Google, mail…) are single-account and do NOT follow a universe switch: after
+ * landing in a named universe the connectors still point at the previous account
+ * until the user reconnects them (ADR 0034 — the RAG scope IS re-pointed, the live
+ * connectors are not). Emitted deterministically by the CLI (ADR 0009), never
+ * invented by the LLM. Pure.
+ */
+export function nativeConnectorsReminder({ from, to }) {
+  if (to === from) return "";
+  if (to === DEFAULT_UNIVERSE) return "";
+  return (
+    `\nHeads-up: native connectors (Slack, Notion, Google, mail…) are single-account and ` +
+    `don't follow this switch. If '${to}' uses different accounts, disconnect/reconnect them to match.`
+  );
 }
 
 /** Path of the committed registry of created universes, inside the .vault-rag dir. */

--- a/scripts/lib/universes.test.mjs
+++ b/scripts/lib/universes.test.mjs
@@ -14,6 +14,7 @@ import {
   vaultRagDir,
   runSwitchCli,
   isMultiverse,
+  nativeConnectorsReminder,
   DEFAULT_UNIVERSE,
 } from "./universes.mjs";
 
@@ -251,6 +252,31 @@ test("runSwitchCli switch to an unknown universe exits 1 and lists the available
   assert.equal(readActiveUniverse(io, DIR), DEFAULT_UNIVERSE);
 });
 
+test("runSwitchCli switch between two named universes appends the connectors reminder", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme", "blue"]);
+  writeActiveUniverse(io, DIR, "acme");
+
+  const res = runSwitchCli(io, DIR, ["blue"]);
+
+  assert.equal(res.code, 0);
+  assert.match(res.message, /switched to 'blue'/);
+  assert.match(res.message, /single-account/i);
+  assert.equal(readActiveUniverse(io, DIR), "blue");
+});
+
+test("runSwitchCli switch back to the default scope does NOT append the reminder", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+  writeActiveUniverse(io, DIR, "acme");
+
+  const res = runSwitchCli(io, DIR, ["default"]);
+
+  assert.equal(res.code, 0);
+  assert.match(res.message, /switched to 'default'/);
+  assert.doesNotMatch(res.message, /single-account/i);
+});
+
 test("runSwitchCli current prints the active universe (exit 0)", () => {
   const io = fakeFs();
   writeActiveUniverse(io, DIR, "acme");
@@ -282,4 +308,31 @@ test("isMultiverse turns true the moment a first universe is created (default + 
 
 test("isMultiverse stays true past the boundary (three universes)", () => {
   assert.equal(isMultiverse(["acme", "blue"]), true);
+});
+
+// ── nativeConnectorsReminder: single-account connectors don't follow a switch ──
+test("nativeConnectorsReminder warns when switching between two named universes", () => {
+  const msg = nativeConnectorsReminder({ from: "acme", to: "blue" });
+  assert.match(msg, /single-account/i);
+  // Names the target so the user knows which universe's accounts to line up.
+  assert.match(msg, /'blue'/);
+});
+
+test("nativeConnectorsReminder stays silent when switching back to the default scope", () => {
+  // Default is the cross-cutting scope, tied to no specific employer/client account:
+  // the trivial toggle needs no warning.
+  assert.equal(nativeConnectorsReminder({ from: "acme", to: DEFAULT_UNIVERSE }), "");
+});
+
+test("nativeConnectorsReminder stays silent on a no-op switch (same universe)", () => {
+  // Re-selecting the current universe changes no account context.
+  assert.equal(nativeConnectorsReminder({ from: "acme", to: "acme" }), "");
+});
+
+test("nativeConnectorsReminder warns when leaving the default scope for a named universe", () => {
+  // default → named IS an account-context change (entering a specific sphere), so
+  // this is NOT the excluded trivial toggle: it warns and names the target.
+  const msg = nativeConnectorsReminder({ from: DEFAULT_UNIVERSE, to: "acme" });
+  assert.match(msg, /single-account/i);
+  assert.match(msg, /'acme'/);
 });

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -72,11 +72,23 @@ export function isUnderZone(path, prefix) {
   return firstSlash !== -1 && path.slice(firstSlash + 1).startsWith(prefix);
 }
 
-// Raw-capture zones: notes here are legitimately unlinked (a daily log, an inbox
-// dump, the append-only activity ledger), so they are excluded from the orphan rule
-// by default. `actions-log.md` is a grep-able ledger, not a wiki node — nobody links
-// TO it, so flagging it orphan is a permanent false positive.
-const DEFAULT_ORPHAN_EXCLUDE = ["daily/", "raw-sources/", "inbox/", "actions-log.md"];
+// Zones whose notes are legitimately unlinked by design, so they are excluded
+// from the orphan rule by default. Two families:
+//   - raw captures: a daily log, an inbox dump, imported raw sources, and the
+//     append-only activity ledger (`actions-log.md` is a grep-able ledger, not a
+//     wiki node — nobody links TO it, so flagging it orphan is a permanent lie).
+//   - engine work-zones: folders the shipped skills write, that nobody links back
+//     to (a meeting write-up, a sync-sources briefing, a 1-1 prep, a coaching note).
+// Brain-specific work folders (e.g. `prep-day/`) stay per-brain via options.orphanExclude.
+const RAW_CAPTURE_ZONES = ["daily/", "raw-sources/", "inbox/", "actions-log.md"];
+const ENGINE_WORK_ZONES = ["meetings/", "briefings/", "prep-1-1/", "coaching/"];
+const DEFAULT_ORPHAN_EXCLUDE = [...RAW_CAPTURE_ZONES, ...ENGINE_WORK_ZONES];
+
+// A raw dump is not a curated wiki node: an imported transcript, an inbox scratch,
+// the append-only ledger arrive without the taxonomy frontmatter and shouldn't be
+// held to it. Only the RAW zones are exempt — curated work-zones (meetings/ etc.)
+// are written by skills WITH frontmatter, so a missing key there is genuine rot.
+const DEFAULT_FRONTMATTER_EXEMPT = RAW_CAPTURE_ZONES;
 
 // Frontmatter `type` values that make a note a curated "entity page" (subject to
 // the stale rule). Configurable via options.entityTypes.
@@ -105,11 +117,14 @@ function daysBetween(laterIso, earlierIso) {
 //   orphanExclude — path prefixes whose notes are never flagged as orphans.
 //   entityTypes  — frontmatter `type` values treated as entity pages.
 //   staleDays    — how many days behind its freshest reference makes an entity stale.
+//   frontmatterExempt — path prefixes (raw-capture zones) exempt from the required-
+//                       frontmatter rule (a raw dump is not a curated node).
 export function lintVault(notes, options = {}) {
   const orphanExclude = options.orphanExclude ?? DEFAULT_ORPHAN_EXCLUDE;
   const entityTypes = options.entityTypes ?? DEFAULT_ENTITY_TYPES;
   const staleDays = options.staleDays ?? DEFAULT_STALE_DAYS;
   const requiredFrontmatter = options.requiredFrontmatter ?? DEFAULT_REQUIRED_FRONTMATTER;
+  const frontmatterExempt = options.frontmatterExempt ?? DEFAULT_FRONTMATTER_EXEMPT;
 
   const resolve = buildResolver(notes);
   const danglingLinks = [];
@@ -151,6 +166,7 @@ export function lintVault(notes, options = {}) {
   }
   const frontmatterViolations = [];
   for (const note of notes) {
+    if (frontmatterExempt.some((prefix) => isUnderZone(note.path, prefix))) continue;
     const missing = requiredFrontmatter.filter((key) => !isPresent(note.frontmatter[key]));
     if (missing.length > 0) frontmatterViolations.push({ path: note.path, missing });
   }

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -134,6 +134,19 @@ test("lintVault — raw-capture zones stay excluded under a universe prefix (<un
   assert.deepEqual(report.orphans, ["acme/topic.md"]);
 });
 
+test("lintVault — the engine's own work-zones (meetings/, briefings/, prep-1-1/, coaching/) are never orphans", () => {
+  // The shipped skills write these and nobody links back to a meeting write-up or
+  // a 1-1 prep — legitimately unlinked by design, so not rot. Universe-insensitive.
+  const report = lintVault([
+    { path: "meetings/2026-07-15-revue.md", frontmatter: {}, body: "" },
+    { path: "briefings/2026-07-18.md", frontmatter: {}, body: "" },
+    { path: "acme/prep-1-1/alice.md", frontmatter: {}, body: "" },
+    { path: "acme/coaching/2026-07-19.md", frontmatter: {}, body: "" },
+    { path: "topic.md", frontmatter: {}, body: "" },
+  ]);
+  assert.deepEqual(report.orphans, ["topic.md"]);
+});
+
 test("lintVault — the append-only ledger (actions-log.md) is a raw zone, never an orphan", () => {
   const report = lintVault([
     { path: "actions-log.md", frontmatter: { type: "log" }, body: "" },
@@ -188,6 +201,22 @@ test("lintVault — an empty string or empty array counts as a missing required 
   ]);
   assert.deepEqual(report.frontmatterViolations, [
     { path: "empties.md", missing: ["updated", "tags"] },
+  ]);
+});
+
+test("lintVault — raw-capture zones are exempt from required frontmatter, curated notes still held", () => {
+  // A raw dump (an imported transcript, an inbox scratch) is not a curated wiki
+  // node — holding it to the full taxonomy is the same category error as calling
+  // it an orphan. But curated work-zones (meetings/ etc.) DO carry frontmatter, so
+  // a missing key there is genuine rot and must still surface. No dates invented.
+  const report = lintVault([
+    { path: "raw-sources/transcripts/2026-07-19.md", frontmatter: {}, body: "" },
+    { path: "acme/inbox/scratch.md", frontmatter: {}, body: "" },
+    { path: "acme/actions-log.md", frontmatter: {}, body: "" },
+    { path: "meetings/2026-07-15-revue.md", frontmatter: { type: "meeting" }, body: "" },
+  ]);
+  assert.deepEqual(report.frontmatterViolations, [
+    { path: "meetings/2026-07-15-revue.md", missing: ["created", "updated", "tags"] },
   ]);
 });
 


### PR DESCRIPTION
## Why

Universes (ADR 0034) shipped as a **soft, invisible-until-opted-in** retrieval scope, but the feature
was only half wired: the **data model** knew about universes while the **write paths did not**. New
notes filed at the vault **root** regardless of the active universe (`/file-back`), a `/local-mirror`
indexed every mirrored note as `default`, and `/switch` re-scoped the RAG **but said nothing** about
the native connectors still pointing at the previous account. On top of that, the field-verify of the
universe-aware `/lint` on a real ~410-note vault surfaced structural noise (work-zones and raw dumps
flagged as if they were rot).

This branch is **THE release-PR that makes universes operational end to end**: everything you *write*
now lands in the active universe, `/switch` warns you about the live connectors, and `/lint` stops
crying wolf. The reflex throughout is the same as the regression fix (#41): fix the **generic engine
source** so every brain benefits, never hard-code one brain's taxonomy. Everything is **harness only,
no reindex**, and ships in the next patch release, codename **"The One Where Everything Finds Its
Universe"** (release **not cut yet**, owner's call).

> **Why one branch and not merge-then-stack.** A fresh install copies the launcher's `main` HEAD
> (`installer.mjs` git-ls-files copy), so merging any part to `main` first would expose it to new
> installs **before** the joint release. `update-engine` reaches deployed brains only via the latest
> tag (ADR 0017), so the exposure would be fresh-installs-only, but still premature. One branch, one
> merge, nothing on `main` before the release.

## Skills & commands touched

> The heart of the release: the write path and the switch UX finally follow the active universe. Only
> `/switch`'s `SKILL.md` needed prose changes; the rest changed **behaviour via their engine scripts**
> (deterministic cores, ADR 0009), so the skills relay the new output without new logic of their own.

| Command / skill | What changed in this release | Where |
| --- | --- | --- |
| **`/lint`** | Stops crying wolf: engine work-zones are no longer "orphans", raw-capture zones are exempt from required frontmatter, and link resolution is universe-aware. | `scripts/lib/wiki-lint.mjs` |
| **`/file-back`** | Files new notes **into the active universe** (`<universe>/…` + additive `universe:` stamp) instead of the vault root. | `scripts/lib/filed-note.mjs`, `scripts/file-back-note.mjs` |
| **`/local-mirror`** | A mirror lands its content **in the active universe**, frozen at `setup_source` time and never re-read on the hot sync path. | `local-mirror/**` |
| **`/switch`** | Flags that the **single-account native connectors** (Slack, Notion, Google, mail…) do NOT follow a switch, when landing in a **named** universe. | `scripts/lib/universes.mjs`, `.claude/skills/switch/SKILL.md` |
| `/import` | *(already shipped)* Stamps the target universe at import time, the first leg of the write-path trilogy this PR closes. | — |

## What

**FU1 · a note nobody links to is not always an orphan.** `74ee136`
Extend `DEFAULT_ORPHAN_EXCLUDE` (`wiki-lint.mjs`) to the engine's own shipped work-zones (`meetings/`,
`briefings/`, `prep-1-1/`, `coaching/`): nobody links back to a meeting write-up or a 1-1 prep, so they
are legitimately unlinked by design (~110/178 field orphans were this false positive). Universe-
insensitive via the existing `isUnderZone`. Fixes en passant the latent inconsistency where `meetings/`
was already a `/consolidate` capture zone but missing from the lint orphan-exclude.

**FU2 · a raw dump is not a curated node.** `74ee136`
Exempt the raw-capture zones (`daily/`, `raw-sources/`, `inbox/`, `actions-log.md`) from the required-
frontmatter rule (43 field findings), **without inventing any dates**. Curated work-zones stay held to
the taxonomy, locked by a test asserting a `meetings/` note still surfaces its missing keys.

**FU3 · the file-back builder is now universe-aware.** `9bb905e`
`filedNotePath` now prefixes `<universe>/` and `renderFiledNote` stamps an additive `universe:` key
(appended last, like the import stamper) when an active universe is passed. The default/root brain keeps
today's behaviour exactly. The pure core stays I/O-free: the thin CLI (`file-back-note.mjs`) resolves
the active universe via `readActiveUniverse` and injects it. Distinct from import stamping (which stamps
*imported* notes): this is the *file-back write* path.

**`/local-mirror` is now universe-aware (the trilogy close).** `4e7ce6a`, `266aea8`
A local mirror also lands content in the vault, yet `local-mirror/` had zero universe-awareness, so
every mirrored note was indexed as `default` regardless of the active universe. Now:
- A mirror whose config carries a universe writes under `<universe>/<target_dir>/<id>.md` and stamps a
  `universe:` key **last** (append-last convention). A rootless mirror is unchanged (root path, no key),
  so mirrors declared before this feature stay backward-compatible.
- The universe is **frozen at `setup_source` time** from the then-active universe, read via a real
  `<brainRoot>/.vault-rag/active-universe` adapter, and **never re-read on the hot sync path**. This is
  the deliberate design choice: a background sync tick firing while the user `/switch`es must not
  scatter one mirror's notes across universes. A mirror belongs to exactly one universe, decided when it
  is declared, exactly as `/import --universe` stamps at import time.

**`/switch` flags the single-account native connectors.** `4e43e70`
A `/switch` re-points the RAG scope, but the native MCP connectors are each bound to one account with no
multi-account notion, so right after a switch they still point at the previous account: a silent
mismatch the RAG can't surface (field-verified 2026-07-19). The deterministic core now appends a one-
line, non-nagging reminder when a switch **changes** the active universe and **lands in a named
universe** (excludes the trivial return to the cross-cutting `default`, and a no-op). A pure
`nativeConnectorsReminder({from,to})` holds the rule; `runSwitchCli` reuses the already-read previous
pointer; the skill relays the core message verbatim. The reminder stays **generic advice** (native
server names are per-user UUIDs, neither introspectable nor pre-authorizable), never per-connector
automation.

## Decisions (backlog deferred to the owner, recommended defaults picked)

- FU1 → **path-prefix list** (smallest change, consistent with the design) over a type-based refactor.
- FU2 → **lint-side exemption** (zero fabricated metadata) over import-time stamping.
- FU3 → the **CLI resolves and passes** the active universe, keeping `filed-note.mjs` a pure builder.
- `/local-mirror` → **freeze at setup, not at sync** (a mirror is a durable single-universe source); the
  default universe carries no key so single-universe brains are untouched.
- `/switch` → warn when **landing in a named universe** (broader than the original "between two created
  universes": `default → named` is a real account-context change; only landing back on `default` is
  silent). Scoped to the switch fast path; `create`-and-switch is deliberately left for a future pass.

## Known limitation (no over-engineered fix)

A mirror declared **before** a universe existed keeps writing at the root. If you later activate a
universe, only genuinely-changed items would move on the next sync, so a transition could momentarily
leave a root copy plus a universe copy of the same note. This is acceptable: universes + mirror is a
brand-new combo, and fresh mirrors are declared **inside** their universe (frozen at setup). Not worth a
migration path for a combination no deployed brain is in yet.

## Tests

- Launcher harness suite: **746 pass / 0 fail** (1 pre-existing skip). Covers the work-zone/raw-dump
  exemptions, the file-back universe path prefix + `universe:` stamp, the CLI filing under the active
  universe, and the `/switch` connectors reminder (pure rule triangulated across named↔named,
  named→default, no-op and default→named, plus CLI append/non-append integration).
- `local-mirror` package: **213 pass** (baseline 205), `tsc --noEmit` + `tsc` build clean. New tests
  cover the universe-scoped write path + stamp-last, triangulated by the rootless twin; the setup-time
  freeze (config + first sync) triangulated by the default twin; the active-universe reader normalizer
  (trim / blank / whitespace / null) + injected-read error fallback; and the `buildDeps` wiring through
  the real composition root.

Cross-platform reflex: vault paths are built with literal `/`, and the pointer is read with a native
`resolve` (never stored), so Windows CI is the final arbiter here.

Backlog updated: `post-v3.1.0-ux-backlog.md` marked ✅ SHIPPED / ticked with per-step `(date · commit)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
