### PR TITLE
docs(plans): archive the shipped universes plan + refresh its stale status

### DIFF
--- a/maintainers/plans/ROADMAP.md
+++ b/maintainers/plans/ROADMAP.md
@@ -63,7 +63,7 @@ safe because **nothing forces** the fleet's upgrade in the interim.
         (visible only at count >= 2) + `--universe` import stamp. Bucket-1 change → lands **before** the
         migration *import*.
   - [x] **Decision:** `../decisions/0034-progressive-disclosure-of-universes.md`.
-  - [x] **Canonical plan:** `prospective/universes-progressive-disclosure-action.md`.
+  - [x] **Canonical plan:** `archived/universes-progressive-disclosure-action.md`.
   - [ ] Field-verify a fresh single-universe install is born "today" (no universe folder, no
         frontmatter key, no reminder) and that creating a 2nd universe surfaces `/switch` + the
         reminder + scoped search — at Gate 3 generate time.
@@ -91,7 +91,7 @@ safe because **nothing forces** the fleet's upgrade in the interim.
 | Plan (canonical) | What it delivers | Gate | Status |
 | --- | --- | --- | --- |
 | `prospective/engine-managed-file-merge-strategy.md` | Propagate engine improvements into user-editable provided files (constitution + shipped skills) without clobbering edits. | 1 & 4 | 🔭 Prospective / analysis; sequencing decided. |
-| `prospective/universes-progressive-disclosure-action.md` | A soft, progressively-disclosed per-universe retrieval scope over one shared vault/index (ADR 0034). | 2 | ✅ Shipped (PR #38, 2026-07-19). Field-verify folds into Gate 3. |
+| `archived/universes-progressive-disclosure-action.md` | A soft, progressively-disclosed per-universe retrieval scope over one shared vault/index (ADR 0034). | 2 | ✅ Shipped (PR #38 in v3.6.0, then write-path trilogy + `/switch` flag in v3.6.2, 2026-07-21). Plan archived; field-verify folds into Gate 3. |
 | `prospective/second-brain-migration-and-engine-upstream-action.md` | Migrate the pre-existing personal brain (~405 notes) + upstream the generic delta. | 3 | In progress: Tracks A/B/C DONE (PR #29/#30/#32); **Track D now unblocked (Gate 2 shipped)**; F post-migration. |
 
 > Other in-flight plans on their own branches (e.g. wiki-health axis 1, marketing page) are **not

--- a/maintainers/plans/archived/universes-progressive-disclosure-action.md
+++ b/maintainers/plans/archived/universes-progressive-disclosure-action.md
@@ -1,7 +1,8 @@
 <!-- ════════════════════════════════════════════════════════════════════════ -->
-<!-- STATUS: 🔭 PROSPECTIVE — agreed design, not yet built. Canonical plan for   -->
-<!-- the "universes" capability. Ordering: this is the FIRST gate to EXECUTE in  -->
-<!-- ../ROADMAP.md (it must land before the migration import).                    -->
+<!-- STATUS: ✅ SHIPPED. The "universes" capability (ADR 0034) landed in v3.6.0   -->
+<!-- (PR #38, 2026-07-19), with the write-path trilogy + /switch connectors flag  -->
+<!-- following in v3.6.1 / v3.6.2 (2026-07-21). Archived; the residual field-      -->
+<!-- verify folds into ROADMAP Gate 3. Kept for its design record + checkboxes.   -->
 <!-- ════════════════════════════════════════════════════════════════════════ -->
 
 # 🌌 Universes — a soft, progressively-disclosed retrieval scope
@@ -10,10 +11,11 @@
 Read it first: it carries the *why* (threat model, progressive disclosure, the implicit-default
 principle, alternatives rejected). This plan is the *how*.
 
-> **Status (2026-07-19 · `410c694`, branch `docs/universes-progressive-disclosure`):** design agreed and
-> committed (this plan + ADR 0034 + ROADMAP Gate 2). **Implementation not started** — resume at the first
-> unchecked `- [ ]` (Step 1, data model). Land on a fresh code branch (TDD), keep it generic (no
-> `inqom`/`shodo` literals).
+> **Status: ✅ SHIPPED.** The capability was built and released across **v3.6.0** (PR #38, core +
+> progressive disclosure, 2026-07-19), **v3.6.1** (universe-aware `/lint`), and **v3.6.2** (write-path
+> trilogy: import + file-back + local-mirror, plus the `/switch` single-account-connectors flag,
+> 2026-07-21). Kept generic (no `inqom`/`shodo` literals) as designed. The one remaining `- [ ]` is a
+> manual byte-for-byte single-universe field-verify, tracked as ROADMAP Gate 3.
 
 ## What we are building (the capability)
 


### PR DESCRIPTION
## Why

Post-v3.6.2 tidy. The universes capability (ADR 0034) shipped across **v3.6.0** (PR #38) and the
write-path trilogy + `/switch` connectors flag in **v3.6.2**, but the canonical plan's own header
still read *"not yet built / implementation not started"* — stale, and contradicting the ROADMAP,
which already marked it Shipped.

## What

- Correct the plan's STATUS block + body note to **✅ SHIPPED** with the release trail (v3.6.0 → v3.6.2).
- `git mv` the plan into `maintainers/plans/archived/` (convention: a finished plan is archived).
- Repoint the two `ROADMAP.md` references to the archived path, and enrich the Gate 2 status cell.

The one remaining checkbox (a manual single-universe byte-for-byte field-verify) stays tracked as
ROADMAP Gate 3. No code change, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)