### PR TITLE
chore: rename repo to `kenjaku` + update all live links

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,7 +5,7 @@
 
 ## Project goal
 
-`second-brain-generator` is an **installable template** for a second brain: a versioned
+`kenjaku` is an **installable launcher** for a second brain: a versioned
 Markdown vault that a Claude Code agent queries in natural language via a RAG engine.
 Extracted from a personal second brain to be reusable by anyone.
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 > **Kenjaku is a Karpathy-style LLM wiki, reinforced where it counts with battle-tested software.**
 
-[![Latest release](https://img.shields.io/github/v/release/tpierrain/second-brain-generator?sort=semver&display_name=tag&label=latest&color=7c4dff&style=flat-square&logo=github&logoColor=white)](https://github.com/tpierrain/second-brain-generator/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/tpierrain/kenjaku?sort=semver&display_name=tag&label=latest&color=7c4dff&style=flat-square&logo=github&logoColor=white)](https://github.com/tpierrain/kenjaku/releases/latest)
 &nbsp;[![Privacy: local by default](https://img.shields.io/badge/privacy-local%20by%20default-3d5afe?style=flat-square&logo=lock&logoColor=white)](#privacy-à-la-carte--you-decide-who-touches-your-data)
 &nbsp;[![Runs on macOS and Windows](https://img.shields.io/badge/runs%20on-macOS%20%C2%B7%20Windows-2979ff?style=flat-square)](#-install-your-brain-in-one-paste)
 &nbsp;[![Engine: self-upgradable since v3.0.0](https://img.shields.io/badge/engine-self--upgradable%20since%20v3.0.0-651fff?style=flat-square&logo=rocket&logoColor=white)](#keeping-your-brain-fresh--universes--engine-updates--importing-an-old-brain)
-&nbsp;[![Mutation tested with Stryker](https://img.shields.io/badge/mutation%20tested-Stryker-e74c24?style=flat-square&logo=stryker&logoColor=white)](https://github.com/tpierrain/second-brain-generator/tree/main/maintainers/mutation)
+&nbsp;[![Mutation tested with Stryker](https://img.shields.io/badge/mutation%20tested-Stryker-e74c24?style=flat-square&logo=stryker&logoColor=white)](https://github.com/tpierrain/kenjaku/tree/main/maintainers/mutation)
 
 <img src="docs/img/board-hero.png" alt="Meet Kenjaku, your second brain: a relaxed mascot beside a private brain wired to Slack, Drive, Gmail and your calendar that stays on your machine. The promise — never miss what matters, and never drown in the rest; all your work, remembered, always up to date and always sourced. Three pillars: never forget (find anything in seconds from your own sources, never invented), never let anyone down (always know what's on you and by when, no mental load), never drown (plugged into all your tools, filtered to what matters to you). Just ask. Sit down and relax. It's all automated." width="100%">
 
@@ -22,7 +22,9 @@ command line, your call.*
 
 **[🧠 What's a second brain?](#what-is-a-second-brain) · [🚀 Install yours now](#-install-your-brain-in-one-paste) · [📖 View the articles](#the-article-series)**
 
-<sub>🧠 *Why “Kenjaku”? He's the brain-swapping schemer of* Jujutsu Kaisen *— a wink at a second brain you graft on and get to keep. The repo is still `second-brain-generator`.*</sub>
+<sub>🧠 *Why “Kenjaku”?[^1] He's the brain-swapping schemer of* Jujutsu Kaisen*, a wink at a second brain you graft on and get to keep.*</sub>
+
+[^1]: [Kenjaku on the *Jujutsu Kaisen* wiki](https://jujutsu-kaisen.fandom.com/wiki/Kenjaku).
 
 > 🧑 *"Where are we on the billing project — who owns what, and what's been decided?"*
 >
@@ -204,7 +206,7 @@ your notes or skills.
 **Your only hands-on move:** open Claude and paste this one sentence (adapt the name & URL).
 
 ```text
-Install me a second brain named "second-brain" (name to be confirmed) from this generator: https://github.com/tpierrain/second-brain-generator
+Install me a second brain named "second-brain" (name to be confirmed) from this generator: https://github.com/tpierrain/kenjaku
 ```
 
 Claude does everything else: clones the launcher, asks you a few questions **in chat** (name, location,

--- a/SETUP.md
+++ b/SETUP.md
@@ -68,7 +68,7 @@ That's it: the **free tier is active immediately**, no credit card required to g
 > home → `~/<name>`). The installer **refuses if the target folder already exists** — it's the one that creates it.
 
 ```bash
-cd second-brain-generator   # the cloned launcher
+cd kenjaku   # the cloned launcher
 node installer.mjs          # interactive: asks for name, location, your name, language
 ```
 
@@ -77,9 +77,9 @@ node installer.mjs          # interactive: asks for name, location, your name, l
 ```
 You give ONE instruction to Claude Code:
         │   "Install me a second brain named "second-brain" (name to be confirmed)
-        │     from this generator: https://github.com/tpierrain/second-brain-generator"
+        │     from this generator: https://github.com/tpierrain/kenjaku"
         ▼
-    📁 second-brain-generator/   ← the LAUNCHER (Claude clones it): read-only, reusable, never modified
+    📁 kenjaku/   ← the LAUNCHER (Claude clones it): read-only, reusable, never modified
         │
         │   Claude runs the installer in it  →  which CREATES a folder ELSEWHERE
         ▼

--- a/maintainers/CONVENTIONS.md
+++ b/maintainers/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Maintainer conventions — repo-carried, brain-safe
 
-> **Who this is for.** You are **DEVELOPING the launcher itself** (this `second-brain-generator`
+> **Who this is for.** You are **DEVELOPING the launcher itself** (this `kenjaku`
 > repo), **not installing a brain**. These are the durable working rules for maintaining the
 > generator. They are **carried in the repo** so they travel with any clone / any machine / any
 > collaborator — instead of living only in one person's local `~/.claude/` (global rules + machine


### PR DESCRIPTION
## What

The repo is renamed to **`kenjaku`** (was `second-brain-generator`, briefly `kenjaku-the-second-brain-generator`). This PR updates every **live-doc** link and project-name reference to the new slug.

## Why

Investing in the **Kenjaku** brand: a short, memorable repo name to match the product name. GitHub's rename keeps history, releases, tags, issues and stars, and installs **chained redirects** so every former URL still resolves.

## Upgrade safety (verified)

Kenjaku brains in the wild record the launcher URL in their manifest and `git clone` it on `update-engine`. The **original** `second-brain-generator` URL still resolves via redirect (checked with `git ls-remote`, SSH **and** HTTPS) → **brains already installed keep upgrading with zero action.**

⚠️ Guardrail: never recreate a repo at a former name, or its redirect breaks.

## Changes

- **README** — 4 GitHub URLs → `tpierrain/kenjaku`; removed the now-false "the repo is still `second-brain-generator`" aside; added a footnote linking *"Why Kenjaku?"* to the Jujutsu Kaisen wiki.
- **SETUP** — install URL + cloned-launcher folder name (`cd` + ASCII) → `kenjaku`.
- **DEVELOPING / CONVENTIONS** — prose project name → `kenjaku`.

## Deliberately untouched

- The internal `<!-- second-brain-generator:installer-stub -->` marker (embedded in already-installed brains' `CLAUDE.md` — renaming it would break stub detection in the wild).
- Archived plans + past release notes keep their historical URLs (they still resolve via the redirect).

## Also done (out of git)

- Disabled the repo's **"public template"** flag (`is_template=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)