### PR TITLE
feat(engine): refresh untouched engine skills on already-installed brains (The One Where the Engine Refreshes Its Skills, but Never Yours)

### DIFF
--- a/.claude/skills/update-engine/SKILL.md
+++ b/.claude/skills/update-engine/SKILL.md
@@ -87,6 +87,15 @@ exactly the engine-owned files, regenerates the launchers, runs `npm install`, r
 - **`exit 1`** → **relay the error as-is** and tell the user the brain was not changed
   past the point of failure. **Never claim success when it failed.**
 
+> 🔁 **MANDATORY — if the output carries the `ENGINE UPDATE UNFINISHED — AGENT, RUN THE UPDATE
+> ONCE MORE` banner, run `node scripts/update-engine.mjs` once more, immediately, WITHOUT asking
+> the user again** (they already asked for this update). This brain came from an engine older than
+> **v3.3.0**, whose orchestrator does not re-run the freshly-written reconciler: the first pass laid
+> the new engine on disk, **only the second one refreshes its untouched engine skills**. Report the
+> **SECOND** run's summary and its restart instruction, not the first one's — and don't make the user
+> wait through a question in between. **It cannot loop**: the second pass records the new versions,
+> so the banner is gone. _(Transitional vector for the pre-v3.3.0 cohort; it disappears with them.)_
+
 > 🛑 **MANDATORY — whenever ANY engine file changed, you MUST end your chat message by telling
 > the user, LOUDLY and in their language, to FULLY RESTART Claude.** This is the **only**
 > Desktop-visible channel: Claude Desktop's Code tab renders **no status bar** — just the chat —

--- a/.claude/skills/update-engine/SKILL.md
+++ b/.claude/skills/update-engine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-engine
-description: "Updates your second brain's ENGINE (the RAG search code, launchers and engine-owned scripts) to a newer version, opt-in and without ever touching your notes, .env, constitution, settings or custom skills. Reindexes only if the index format changed. Use when the user asks to update/upgrade their brain's engine, or to check whether an engine update is available."
-version: 1.1.0
+description: "Updates your second brain's ENGINE (the RAG search code, launchers and engine-owned scripts) to a newer version, opt-in and without ever touching your notes, .env, constitution, settings, your own skills or any engine skill you tailored. Reindexes only if the index format changed. Use when the user asks to update/upgrade their brain's engine, or to check whether an engine update is available."
+version: 1.2.0
 ---
 
 # /update-engine — Upgrade your brain's engine (opt-in, non-destructive)
@@ -10,7 +10,8 @@ version: 1.1.0
 > search code (`rag/`), the launchers and the engine-owned scripts. This skill swaps
 > it for a newer version pinned in the launcher you were generated from, **without
 > ever touching what is yours**: your notes, `.env`, constitution (`CLAUDE.md`),
-> `.claude/settings.json` and any custom skills are left **byte-for-byte unchanged**.
+> `.claude/settings.json`, your own skills and **any engine skill you tailored** are left
+> **byte-for-byte unchanged**.
 >
 > ⚠️ **This is a thin conversational driver.** All the real, testable work lives in
 > the deterministic core `scripts/update-engine.mjs` (ADR 0016). This skill only
@@ -41,7 +42,8 @@ code on disk and may trigger a reindex; it must always be a conscious, accepted 
 | `rag/launch.*`, `scripts/run-node.*` launchers | `.env` (your keys) |
 | engine scripts (`auto-commit`, `auto-push`, `status-line`, `verify-rag`) | `CLAUDE.md` (your constitution) |
 | `update-engine` itself (it self-updates) | `.claude/settings.json` |
-| **missing** engine skills (e.g. `local-mirror`) — _added if absent_ (ADR 0025) | your custom skills **and any engine skill you already have** (`.claude/skills/**`) |
+| **missing** engine skills (e.g. `local-mirror`) — _added if absent_ (ADR 0025) | your **own** skills (`.claude/skills/**`): the engine never declared them, so it can never write them |
+| engine skills **you never edited**: _brought up to date_ (ADR 0026 §8) | any engine skill **you tailored**: kept byte-for-byte, with the engine's newer version dropped **beside** it as `.new` |
 | **missing** engine MCP servers in `.mcp.json` — _added if absent_ (ADR 0025) | any server you added yourself to `.mcp.json` |
 
 ## Procedure
@@ -49,8 +51,12 @@ code on disk and may trigger a reindex; it must always be a conscious, accepted 
 ### Step 1 — Confirm with the user (mandatory, opt-in)
 Explain, plainly:
 - it pulls a newer engine and swaps in the new code, launchers and engine scripts;
-- **your notes, `.env`, constitution, settings and custom skills stay untouched**;
-- it will **reindex only if the index format changed** (a few minutes, nothing lost —
+- **your notes, `.env`, constitution, settings and your own skills stay untouched**;
+- it will **bring up to date the engine skills you never edited**, so improvements shipped
+  since this brain was installed finally reach it; **anything you tailored stands exactly as
+  you wrote it**, and the engine's newer version is simply left beside it as `.new`, yours to
+  adopt or ignore;
+- it will **reindex only if the index format changed** (a few minutes, nothing lost:
   your notes are simply re-encoded);
 - **prerequisites**: `git`, `npm` and a network connection (same as at install). Here
   `npm install` means installing the RAG engine's **dependencies locally** — nothing is

--- a/.claude/skills/update-engine/SKILL.md
+++ b/.claude/skills/update-engine/SKILL.md
@@ -78,6 +78,12 @@ exactly the engine-owned files, regenerates the launchers, runs `npm install`, r
 ### Step 3 — Report (don't pretend)
 - **`exit 0`** → relay the printed summary (new version, how many engine files were
   swapped, whether a reindex ran). Reassure that nothing of theirs was touched.
+  - When the summary lists **engine skill(s) brought up to date**, name them: an
+    improvement shipped months ago has just reached this brain, and silent delivery
+    leaves the user unaware they now have it.
+  - When it says a **customized skill was kept**, relay that too, **with the `.new`
+    path**: their version stands untouched, and the engine's newer one sits beside it —
+    offer to compare the two, or to merge the new bits into theirs, if they want it.
 - **`exit 1`** → **relay the error as-is** and tell the user the brain was not changed
   past the point of failure. **Never claim success when it failed.**
 
@@ -104,8 +110,10 @@ exactly the engine-owned files, regenerates the launchers, runs `npm install`, r
 >   rule (a session not yet rooted in the brain), not what picking up new engine code needs.
 > - Phrase it **in the user's language**, calmly: it is a one-time, harmless step — the brain
 >   wired its own self-healing in the background; one restart and they're done.
-> - The **genuine no-op** (the report shows **no** files swapped and **no** reindex) is the only
->   case where you skip the restart banner — don't cry wolf when nothing changed.
+> - The **genuine no-op** (the report shows **no** files swapped, **no** skill brought up to date
+>   and **no** reindex) is the only case where you skip the restart banner — don't cry wolf when
+>   nothing changed. A refreshed skill counts as a change: its new text loads only at the next
+>   session start, so this conversation still runs the old one.
 >
 > _One-time exception (a brain upgrading from a pre-3.2 engine): the first update runs the
 > OLD orchestrator, so this report won't yet list the new runtime hooks. They are wired

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,11 @@ jobs:
           node-version: ${{ matrix.node }}
 
       # Harness suites — pure .mjs seams (node:test), no deps to install.
+      # `rag/*.test.mjs` belongs here, NOT in the engine job: the postinstall "message in a
+      # bottle" is dependency-free .mjs, so rag's `npm test` (tsx over src/lib/*.test.ts) never
+      # globbed it and it was running nowhere.
       - name: Harness tests
-        run: node --test "scripts/*.test.mjs" "scripts/lib/*.test.mjs"
+        run: node --test "scripts/*.test.mjs" "scripts/lib/*.test.mjs" "rag/*.test.mjs"
 
       # Engine — `npm ci` builds the native binding (better-sqlite3) on this
       # exact Node; the test run then exercises it. This is the real net.

--- a/SETUP.md
+++ b/SETUP.md
@@ -422,8 +422,8 @@ re-encodes in a few minutes, **without losing a single note**.
 
 Your brain ships with a built-in, **opt-in** updater for its **engine** — the RAG search code
 (`rag/src`), the launchers, and the engine-owned scripts (`scripts/`). It **never** touches your
-notes, `.env`, `CLAUDE.md`, `.claude/settings.json` or your custom skills: it only writes files that
-`engine-manifest.json` declares Engine-owned.
+notes, `.env`, `CLAUDE.md`, `.claude/settings.json`, your own skills or any engine skill you
+tailored: it only writes files that `engine-manifest.json` declares Engine-owned.
 
 > 🗺️ **`engine-manifest.json` is the readable map.** It lists *what counts as the engine* and records a
 > `source: { repo, ref }` — the launcher's git URL and the exact tag/commit your engine was built from.
@@ -438,7 +438,8 @@ notes, `.env`, `CLAUDE.md`, `.claude/settings.json` or your custom skills: it on
 > search engine."*
 
 The brain confirms with you first (**opt-in, never automatic**), runs the update, then reports what
-changed: **new version · files swapped · whether a reindex ran · "your files were untouched".**
+changed: **new version · files swapped · skills brought up to date (and those left as you tailored
+them) · whether a reindex ran · "your files were untouched".**
 Because the engine is **observable** (it knows its own version), the brain may also **proactively
 offer** the update.
 
@@ -449,11 +450,18 @@ offer** the update.
 3. Computes a **write-allowlist** plan: overwrite the `replace` bucket (`rag/src`, etc.),
    **regenerate** the `.sh`/`.cmd` launchers, replace the engine-owned scripts (including the updater
    itself).
-4. Runs `npm install` in `rag/` — this installs the engine's **dependencies locally**; it does **not**
+4. **Brings the engine skills you never edited up to date.** Your brain records a fingerprint of every
+   skill file the engine delivered, so it can *prove* which ones you never touched: those are refreshed
+   to the newer version, and improvements shipped since your install finally reach you. **A skill you
+   tailored is never overwritten**: it stands byte-for-byte as you wrote it, and the engine's newer
+   version is dropped **beside** it as `<skill>/SKILL.md.new`, yours to adopt, cherry-pick or delete.
+   The report names both, so a silent delivery never leaves you unaware of what you gained.
+5. Runs `npm install` in `rag/` — this installs the engine's **dependencies locally**; it does **not**
    pull your brain from any registry (self-hosted, ADR 0001).
-5. **Reindexes only if** `indexSchemaVersion` changed (a few minutes); otherwise your index is left
+6. **Reindexes only if** `indexSchemaVersion` changed (a few minutes); otherwise your index is left
    as-is.
-6. Records the new `engineVersion` + `source.ref` and re-seeds the provenance fingerprints.
+7. Records the new `engineVersion` + `source.ref` and re-seeds the provenance fingerprints, so what it
+   just delivered stays refreshable at the update after that.
 
 ### Prerequisites & guarantees
 

--- a/maintainers/decisions/0025-update-engine-installs-missing-engine-skills-and-servers.md
+++ b/maintainers/decisions/0025-update-engine-installs-missing-engine-skills-and-servers.md
@@ -76,8 +76,10 @@ where they are ABSENT — never overwrite, never touch anything the manifest doe
   code or newer; the ≤v3.2.0 cohort heals on its next update (documented, no extra code).
 - **Zero clobber risk.** Install-if-absent means a user-customized engine skill (the `prepare-1-1`
   "refine to your own KPIs" case) is never overwritten. Refreshing the *content* of an
-  already-installed engine skill remains out of scope (it belongs to a future 3-way merge, same as the
-  other `merge` files).
+  already-installed engine skill is out of scope **here** — it is decided in **ADR 0026 §8**, which keeps
+  this clobber-freedom intact by gating any overwrite on **proof** that the file still holds the engine's
+  own bytes (a customized skill is preserved and reported, the engine's newer version dropped beside it).
+  A full 3-way merge of a customized skill remains future work.
 - **The safety core is unchanged in spirit**: still a write-allowlist; the one new bucket is additive
   and conditional, and the sacred scrub on the destructive buckets is intact.
 - **No schema change, no forced reindex.**

--- a/maintainers/decisions/0026-brain-self-converges-via-idempotent-reconciler.md
+++ b/maintainers/decisions/0026-brain-self-converges-via-idempotent-reconciler.md
@@ -5,10 +5,12 @@
   Index format unchanged → no schema bump, no forced reindex. The "residual bootstrap" caveat in
   *Consequences* is accepted as the deliberate trade-off (declarative-data convergence in one pass;
   only a rare reconciler-engine change still lags one update). The blanket-sacred *Safety invariant* carries
-  **two narrow, nominative exceptions** (Decision §5 and §6 + invariant below): the reconciler may **seed
+  **three narrow, nominative exceptions** (Decision §5, §6 and §8 + invariant below): the reconciler may **seed
   (write-if-absent)** the engine-owned health-check note + incrementally reindex it (so the `health_check`
-  canary, ADR 0030, also works on upgraders), and may **merge (add-if-absent)** engine-owned hook entries
-  into `settings.json` (so the v3.3.0 SessionStart runtime hooks reach upgraders, not just fresh installs).
+  canary, ADR 0030, also works on upgraders), may **merge (add-if-absent)** engine-owned hook entries
+  into `settings.json` (so the v3.3.0 SessionStart runtime hooks reach upgraders, not just fresh installs),
+  and may **refresh (overwrite-if-provably-untouched)** an engine-owned skill during an explicit update, so
+  skill improvements reach brains that already have the skill.
 - **Scope:** Second brain (runtime) + Installer — a brain-side **deterministic reconciler** invoked by
   `update-engine` (as a child process) and by the **SessionStart** hook; the installer may reuse the
   same pure libs at install time.
@@ -28,10 +30,12 @@
 >   `engine-manifest.json` (which `update-engine` never refreshes) — through one idempotent **reconciler**,
 >   run after every update (an auto-finalize child process) and at every **SessionStart** (self-heal — plus,
 >   for the one-time pre-3.2 jump, a bootstrap tick on the already-wired `session-status` hook).
-> - **Guarantee —** the reconciler only ever **adds** engine-delivered, engine-owned things **when
->   absent**: engine skill dirs, `.mcp.json` servers, `settings.json` **hook entries**, regenerated
->   launchers, and the single health-check note. It **never** overwrites or deletes the vault, `.env`, the
->   constitution, a user skill, or any user-authored `.mcp.json` server or `settings.json` entry.
+> - **Guarantee —** the reconciler adds engine-delivered, engine-owned things **when absent**: engine
+>   skill dirs, `.mcp.json` servers, `settings.json` **hook entries**, regenerated launchers, and the
+>   single health-check note. It overwrites exactly one thing, under proof: an engine-owned **skill whose
+>   bytes still match what the engine last delivered**, and only during an update the owner explicitly
+>   asked for (§8). It **never** overwrites or deletes the vault, `.env`, the constitution, a user skill,
+>   a **customized** engine skill, or any user-authored `.mcp.json` server or `settings.json` entry.
 > - **Prior art (not NIH) —** this is the canonical **desired-state reconciliation loop** (Kubernetes
 >   controllers, GitOps Argo/Flux, Terraform plan→apply, Chef/Puppet converge, Microsoft DSC Test/Set,
 >   Windows Installer self-healing); **SessionStart is its level-triggered tick**.
@@ -189,6 +193,40 @@ thing we add on top is naming discipline (see the terminology note in `CONVENTIO
    never a delivered duplicate to keep in sync. Accepted consequence: the **launcher itself** no longer
    auto-discovers that skill — it is an engine-delivered asset that runs in a brain, not the launcher.
 
+8. **An engine-owned skill is REFRESHED when — and only when — the brain can PROVE nobody touched it.**
+   Install-if-absent (§7, ADR 0025) delivers a *missing* skill but freezes an *existing* one forever: a
+   brain keeps the skill exactly as it was installed, while the deterministic core the skill drives is
+   refreshed by `replace` at every update — a widening **core/skill drift** on a growing installed base.
+   Convergence therefore extends from *presence* to *content*, without ever weakening user sovereignty:
+   - **The proof already exists on every brain.** The installer records a **sha256 provenance base per
+     `merge` file** and re-seeds it after each update. Bytes equal to the recorded base ⇒ the file is
+     exactly what the engine last delivered ⇒ **overwrite it**. Bytes differ ⇒ the owner customized it
+     (the documented `prepare-1-1` "refine to your own KPIs" case) ⇒ **touch nothing**, drop the engine's
+     newer version **alongside** as `SKILL.md.new`, and **say so** in the report, naming the path. This is
+     the *conffile* answer (Debian `dpkg`/`ucf`, `.rpmnew`), not an auto-merge.
+   - **No base recorded ⇒ no claim.** A brain older than provenance gets neither a refresh nor a sidecar
+     nor a report line: nothing is proven there, and littering it with unexplained `.new` files would be
+     noise, not a choice offered to the owner. **Line endings are not authorship** — a file matching the
+     base *modulo* EOLs counts as untouched, else the whole Windows fleet reads as customized.
+   - **Staged skills (§7) carry a base for free, retroactively.** They live outside the `merge` regime, so
+     they were never fingerprinted; but the brain's **own** `engine-skills/<name>/` copy, read **before**
+     the copy step overwrites it, *is* byte-for-byte what the engine last delivered (install-if-absent
+     copied that very subtree). Read at that instant, it answers the only question the refresh asks, for
+     the whole deployed fleet — and it is self-maintaining, since `replace` leaves the next base behind.
+   - **Only during an update the owner asked for** — the reconciler runs with `sourceDir !== brainDir`
+     only when it was handed **fetched** content (the auto-finalize child, §2). SessionStart self-heal
+     passes `sourceDir === brainDir`: no new content, nobody asked, **nothing is ever overwritten there**.
+     ADR 0026's additive invariant keeps holding exactly where it matters — at every silent tick.
+   - **Locale-aware by construction.** The source is resolved per the brain's own recorded locale, so a
+     French brain receives the French skill and is never re-anglicized by an update. A skill with no
+     source in that locale falls back to the root — which is precisely what that brain was installed
+     with, so the refresh stays a same-language update.
+   - **Re-seed the provenance of what was refreshed**, in the same run that refreshed it. Without it the
+     refreshed file no longer matches the recorded base at the next update, reads as "customized", and is
+     **never refreshed again** — the feature would die silently after one use.
+   - **A refresh is a change, not a new capability**: the new text loads at the next session start, so the
+     report raises the ordinary restart instruction, with no "run once more" counter.
+
 ### Safety invariant (every test asserts it)
 
 > The reconciler only ever writes manifest-declared engine-owned skills/MCP servers (install-if-absent)
@@ -225,6 +263,22 @@ thing we add on top is naming discipline (see the terminology note in `CONVENTIO
 > - **Cross-OS** — the appended command carries the win32-safe shape (the brain's own `{{NODE}}` prefix +
 >   POSIX `{{PROJECT_ROOT}}`), unit-pinned on darwin and win32 (ADR 0015).
 
+> **⚠️ The one skill-content exception.** The "an existing skill is never written" rule **stands** for
+> every skill the user authored and every engine skill they customized; its **only** exception is that the
+> reconciler MAY **overwrite an engine-owned skill file whose bytes it can prove are still the engine's
+> own**, and **only** when running against fetched content (an explicit update). Enforced by tests:
+> - **Provenance-gated** — a file differing from its recorded base is left byte-identical and reported
+>   preserved, with the engine's version dropped beside it as `.new`; a file with **no** recorded base is
+>   left alone, silently.
+> - **Explicit updates only** — a SessionStart-shaped call (`sourceDir === brainDir`) refreshes **nothing**
+>   and reports nothing (no nagging at every session start).
+> - **Scoped to skills** — only `merge`-declared files **under `.claude/skills/`** (plus the staged skills
+>   of §7) are eligible; the constitution and the engine-owned scripts, also `merge`, stay out.
+> - **Refreshable twice** — refreshing re-seeds provenance, so a second consecutive update is a clean
+>   no-op: neither a refresh nor a "customized" verdict.
+> - **No stale sidecar** — a `.new` left from an earlier update is cleared as soon as its verdict changes,
+>   so a surviving sidecar never keeps claiming something newer awaits.
+
 ## Consequences
 
 - **Layer A solved**: one `/update-engine` invocation finishes the job (the auto-finalize child process).
@@ -251,6 +305,18 @@ thing we add on top is naming discipline (see the terminology note in `CONVENTIO
   changes, that change still lags one update. By keeping it a **stable interpreter of declarative
   manifest DATA**, **feature additions** (a new skill dir, MCP server, settings entry) land in **one
   pass**; only the **rare** reconciler-engine change lags. We move the cost from *frequent* to *rare*.
+- **Skill improvements finally reach the brains that already have the skill**, closing the core/skill
+  drift: the deterministic core a skill drives was already refreshed by `replace` at every update, while
+  the prose driving it stayed frozen at install time. Convergence now covers *content*, not only presence.
+- **Customization becomes an explicit, visible state.** A brain is in exactly one of three legible
+  situations per skill — engine's own (refreshed), customized (kept, with the newer version beside it),
+  or unprovable (left alone). The owner is told which, and never has to diff anything to find out.
+- **One pass for every brain at v3.3.0+**, since auto-finalize already collapses the 2-cycle. The older
+  tail — orchestrators without auto-finalize, identified by the `scripts` version their manifest still
+  records at that moment — is carried by a **transitional** directive printed from the engine's
+  `postinstall` (the same "message in a bottle" vector that reaches a frozen orchestrator through
+  `npm install`), asking for the second pass inside the same interaction so the owner still only asks
+  once. It is expected to be **deleted** once that cohort has shrunk, falling back to the 2-cycle.
 - **Upgraders get a real canary** without breaking the vault-sacred guarantee in substance: user data is
   still never read-for-mutation, never overwritten, never deleted — the engine only
   (re)places **its own** health file, in **its own** namespace (`engine-health/`), and only when missing.
@@ -299,6 +365,29 @@ thing we add on top is naming discipline (see the terminology note in `CONVENTIO
   truth** to keep in sync with the very files it describes (the templates + `engine-skills/`). Deriving
   desired-state directly from those delivered files is strictly less to maintain and cannot drift out of
   step with what is actually on disk.
+- **Decide a skill is stale by comparing versions or dates instead of hashing it.** Rejected: a version
+  says what the engine shipped, never whether the owner edited their copy. Only the bytes prove that, and
+  the whole carve-out rests on that proof.
+- **Refresh skills at SessionStart too** (the level-triggered tick, like every other convergence).
+  Rejected: nobody asked for anything at a session start, and the tick has no fetched content to deliver
+  — it would be an overwrite in the dark. Content convergence is tied to the explicit update; presence
+  convergence stays on the tick.
+- **3-way merge a customized skill** (base + theirs + new). Deferred, not dismissed: it is the natural
+  next step, but the conffile answer (keep theirs, drop `.new` beside, tell them) delivers the value with
+  zero auto-merge risk, and a skill is prose — a merged instruction file can read as coherent while
+  saying two contradictory things.
+- **Refresh every skill from the repository root regardless of the brain's locale.** Rejected: it would
+  silently re-anglicize a French brain — the exact trap that keeps the engine constitution layer out of a
+  refreshed regime until it is made locale-aware.
+- **Have the pre-auto-finalize bottle perform the refresh itself** rather than print a directive.
+  Rejected on three independent counts: at `postinstall` time there is no source to refresh **from** (the
+  new skills live in the orchestrator's throw-away clone, and the manifest still records the **old**
+  source), the staged base has already been overwritten by the copy step (so every outdated-but-untouched
+  skill would read as customized), and reconciling inside `npm install` would recurse into it.
+- **Leave the pre-auto-finalize cohort on the documented 2-cycle** (ADR 0025). Considered, and the right
+  fallback once that cohort is small; rejected as the shipping answer while the installed base is
+  growing, because a newcomer landing on an old engine would keep frozen skills until they happened to
+  update twice, with nothing telling them so.
 - **Punch a hole in the sacred scrub to deliver the new skill under `.claude/skills/` via `replace`.**
   Rejected — exposing `.claude/skills/` to engine writes breaks the user-sovereignty core (ADR 0003/0012).
   The non-sacred `engine-skills/` staging dir + install-if-absent (§7) delivers the skill without weakening

--- a/maintainers/decisions/0026-brain-self-converges-via-idempotent-reconciler.md
+++ b/maintainers/decisions/0026-brain-self-converges-via-idempotent-reconciler.md
@@ -232,7 +232,7 @@ thing we add on top is naming discipline (see the terminology note in `CONVENTIO
 > The reconciler only ever writes manifest-declared engine-owned skills/MCP servers (install-if-absent)
 > and regenerated launchers. The vault, `.env`, the constitution, every user-added `.mcp.json`
 > server, every user-authored `settings.json` entry and every non-declared/custom skill are untouchable —
-> **EXCEPT** the two narrow, nominative carve-outs below.
+> **EXCEPT** the three narrow, nominative carve-outs below.
 
 > **⚠️ The one vault exception.** The "vault is untouchable" rule **stands**;
 > its **only** exception is that the reconciler MAY **create** (write-if-absent — **never** overwrite,
@@ -276,6 +276,9 @@ thing we add on top is naming discipline (see the terminology note in `CONVENTIO
 >   of §7) are eligible; the constitution and the engine-owned scripts, also `merge`, stay out.
 > - **Refreshable twice** — refreshing re-seeds provenance, so a second consecutive update is a clean
 >   no-op: neither a refresh nor a "customized" verdict.
+> - **Subtree-complete** — a skill is a *subtree*, and install-if-absent decides at the skill-DIR level,
+>   so a file a release adds **under a skill the brain already has** (`references/…`) is delivered by this
+>   refresh, with a provenance base of its own, instead of reaching no brain at all.
 > - **No stale sidecar** — a `.new` left from an earlier update is cleared as soon as its verdict changes,
 >   so a surviving sidecar never keeps claiming something newer awaits.
 

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -15,7 +15,7 @@
 | Package | Mutation score | As of | Detail |
 |---|---|---|---|
 | **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only |
-| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). ⚠️ `update-engine.mjs` **98.49 %**, `engine-source.mjs` **81.40 %**, `reconcile-brain.mjs` **69.14 %** as of [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) — the last two are **not hardened yet** |
+| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent) |
 | **local-mirror** | **95.63 %** | 2026-07-16 (post-B4) | [re-audit](#full-local-mirror-re-audit--2026-07-16-post-b4) — the 78.69 % closer below is superseded |
 
 Pinned to the release that ships the hardened tests: **v3.4.2** (local-mirror pinned at 78.69 % there —

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -143,8 +143,38 @@ COMMA-SEPARATED `--mutate`, see the gotcha) at a time.
 |---|---|---|---|
 | `scripts/lib/engine-skill-refresh.mjs` | 86.72 % | **100 %** | 119/119, no equivalents _(6d6564b)_ |
 | `scripts/update-engine.mjs` | 51.52 % | **98.49 %** | 196/200, 3 equivalents _(5a04fa4, a54a0b1)_ |
-| `scripts/lib/engine-source.mjs` | — | 81.40 % | 8 survivors — **first measurement, not yet hardened** |
-| `scripts/lib/reconcile-brain.mjs` | — | 69.14 % | 54 survivors — **first measurement, not yet hardened** |
+| `scripts/lib/engine-source.mjs` | 81.40 % | **93.02 %** | 40/43, 3 equivalents _(3790a2e)_ |
+| `scripts/lib/reconcile-brain.mjs` | 71.43 % | **96.45 %** | 162 killed + 1 timeout / 169, 6 equivalents _(3900fbb, fc520b0, e0cd006, 49e1457, a369fe2, e480621)_ |
+
+> **Decision (Thomas, 2026-07-27): both remaining files hardened IN THIS BRANCH**, to the same
+> standard as `update-engine.mjs` — including the survivors this increment never wrote. The two
+> narrower options (increment-only lines; increment + the composition-root seam) were put to him
+> and declined. **Effective 100 % on non-equivalents** for all four files of the increment.
+
+**`reconcile-brain.mjs` — what the 51 survivors were.** ~14 in the process-level wiring (the argv
+slice, the error banner, the exit code, the entry guard), fixed the same way `update-engine.mjs` was:
+extract `runReconcileCliProcess(deps)` + `realReconcileDeps`, leave the entry block as pure wiring,
+spawn it once as a real process, and route the guard through the canonical `isEntrypoint` (this file
+was the last hold-out hand-rolling it — bug B2). ~16 more in the CLI's own contract (missing-flag
+refusal, `--platform` reaching the seams, the manifest write). ~11 in the `.mcp.json` / `settings.json`
+side-channels, where two habits were the root cause: a **self-confirming fixture** (settings.json
+stored with the exact serialiser production writes it with → an unconditional rewrite left it
+byte-identical, so the no-churn guard could not be refuted by its own test) and **two write-reasons
+never isolated** (every repair fixture had BOTH broken hooks and a broken statusLine, so neither term
+of the guard was ever the sole cause). The rest were absent cases never fed: an empty `regenerate`
+bucket, a single-star skill glob, a reconcile with no `local` manifest.
+
+Three production simplifications fell out, all the same lesson: `flagValue`'s length check, `?? {}`
+before an object spread, and (previous step) the sidecar-clear condition could not change a single
+byte — deleting them said the same in less code and removed the mutants. One extraction, `toPosix`,
+makes the win32 `{{PROJECT_ROOT}}` contract verifiable on a POSIX CI, where it was a no-op and thus
+untestable by construction.
+
+> ⚠️ **Method note that paid for itself:** each mutant was hand-applied against the full suite before
+> and after writing its test, rather than reasoned about. That caught one filed as *killed* which was
+> in fact the OTHER branch of the same ternary, still alive because the assertion said `.includes(…)`
+> instead of naming the whole list. See [`RETROSPECTIVE.md`](RETROSPECTIVE.md) Part II for the
+> root-cause analysis of why four files of one increment scored 51–87 % despite Part I's rules.
 
 > ⚠️ **The 2026-07-15 line "`scripts/**` is now fully hardened" was never true of these
 > files.** It covered the three enumerated worst files plus `scripts/lib/**` *as measured

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -15,7 +15,7 @@
 | Package | Mutation score | As of | Detail |
 |---|---|---|---|
 | **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only |
-| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %) |
+| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). ⚠️ `update-engine.mjs` **98.49 %**, `engine-source.mjs` **81.40 %**, `reconcile-brain.mjs` **69.14 %** as of [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) — the last two are **not hardened yet** |
 | **local-mirror** | **95.63 %** | 2026-07-16 (post-B4) | [re-audit](#full-local-mirror-re-audit--2026-07-16-post-b4) — the 78.69 % closer below is superseded |
 
 Pinned to the release that ships the hardened tests: **v3.4.2** (local-mirror pinned at 78.69 % there —
@@ -130,6 +130,49 @@ survivors there are **documented equivalent mutants** (unkillable without touchi
 "effective 100 %" on non-equivalents. The lowest never-hardened tiers, the natural next "B5" targets,
 are rag's **embedders** (~82 %) and `search-degradation` / `reindex-scheduler` / `index-freshness`, plus
 local-mirror's `fs-state-store` and `content-hash`.
+
+---
+
+## Increment 2.5 (engine skill refresh) — Step 10 — 2026-07-27
+
+The gate before merging `feat/engine-skill-refresh`. Scope = the surface the increment
+touched. Run per the recipe below (disposable worktree + `--inPlace`), one file (or one
+COMMA-SEPARATED `--mutate`, see the gotcha) at a time.
+
+| File | Before | After | Note |
+|---|---|---|---|
+| `scripts/lib/engine-skill-refresh.mjs` | 86.72 % | **100 %** | 119/119, no equivalents _(6d6564b)_ |
+| `scripts/update-engine.mjs` | 51.52 % | **98.49 %** | 196/200, 3 equivalents _(5a04fa4, a54a0b1)_ |
+| `scripts/lib/engine-source.mjs` | — | 81.40 % | 8 survivors — **first measurement, not yet hardened** |
+| `scripts/lib/reconcile-brain.mjs` | — | 69.14 % | 54 survivors — **first measurement, not yet hardened** |
+
+> ⚠️ **The 2026-07-15 line "`scripts/**` is now fully hardened" was never true of these
+> files.** It covered the three enumerated worst files plus `scripts/lib/**` *as measured
+> then*; `update-engine.mjs`, `reconcile-brain.mjs` and `engine-source.mjs` appear nowhere
+> in this document before today. Their low scores are **not** a regression from this branch.
+
+**`update-engine.mjs` — what the 96 survivors actually were.** ~40 clustered in the
+top-level `if (isEntrypoint(…))` block: a composition root with no seam. Extracting
+`countNewCapabilities` / `needsRestart` / `armRestartFlag` / `bareHookName` +
+`runUpdateCli(deps)` + `realUpdateDeps` (the `clear-example-notes` idiom) made them
+reachable. Most of the rest were `formatReport` prose: the tests pinned one line each with
+a regex, leaving every other line free to mutate → replaced by **golden assertions on the
+whole report** (quiet no-op / everything-on / steady state / one-capability singular), each
+list carrying **two** entries so a dropped `, ` separator diverges. Two production honesty
+fixes fell out of it: a manifest with no `engineVersion` reads `rag unknown` (not
+`undefined`), and a rejection with no reason prints `no reason given`. The entry point is
+now **spawned as a process** in a test — bug B2 was exactly a guard that silently never
+fired, and nothing else can catch that.
+
+**The 3 remaining survivors are equivalent**, recorded so nobody re-hunts them: the
+`skillsPreserved = []` default mutated to `["Stryker was here"]` (its only reader
+destructures `{ skill, reason }` and `continue`s on `reason !== "customized"` → identical
+output), and two `readFileSync(…, "utf8") → ""` (Node hands back a **Buffer**; both values
+are only `JSON.parse`d or fed to `createHash().update()` → same bytes, same digest).
+
+**Gotcha (cost a whole run):** multiple `--mutate` flags **do not accumulate** — only the
+last one applies. Use ONE comma-separated value:
+`--mutate "scripts/lib/reconcile-brain.mjs,scripts/lib/engine-source.mjs"`.
 
 ---
 

--- a/maintainers/mutation/RETROSPECTIVE.md
+++ b/maintainers/mutation/RETROSPECTIVE.md
@@ -1,4 +1,15 @@
-# Mutation testing — retrospective: what the survivors taught us (Step 6)
+# Mutation testing — retrospectives
+
+> Two passes, a fortnight apart. **[Part I](#part-i--what-the-survivors-taught-us-step-6)** (2026-07-15,
+> Step 6) diagnosed the assertion habits across `rag` / `local-mirror` / `scripts`.
+> **[Part II](#part-ii--why-it-happened-again-increment-25-step-10)** (2026-07-27, Increment 2.5 Step 10)
+> asks the harder question Thomas put next: *given that Part I's rules existed and were engraved, how did
+> we still write four files scoring 51 % to 87 %?* Read Part II first if you want the actionable answer —
+> Part I is the catalogue it builds on.
+
+---
+
+# Part I — what the survivors taught us (Step 6)
 
 > **Dev-only.** This whole folder lives under `maintainers/` and is **excluded from the brain copy**
 > (`scripts/lib/tracked-files.mjs` → `DEV_ONLY_PREFIXES`), so none of it ever reaches a generated brain.
@@ -108,3 +119,110 @@ and its residual equivalents are in the plan's Step 3.
 **Verification:** `scripts/**` suite green (560/560), including the new lint guard and `tracked-files`.
 The doc changes touch only `maintainers/` (never in the rag/local-mirror packages), so no engine re-run
 was needed.
+
+---
+
+# Part II — why it happened again (Increment 2.5, Step 10)
+
+> **2026-07-27.** Written at Thomas's request, at the end of the Step 10 hardening, to answer the question
+> the numbers raise: *Part I's rules existed, were engraved in `tdd-discipline` and in `CONVENTIONS.md`
+> §5bis/§5ter, and had a CI lint. So how did we still ship four files scoring 51 % to 87 %?*
+
+## The numbers that prompt the question
+
+| File | Before | After | Residual |
+|---|---|---|---|
+| `scripts/lib/engine-skill-refresh.mjs` | 86.72 % | **100 %** | 0 |
+| `scripts/update-engine.mjs` | 51.52 % | **98.49 %** | 3 equivalent |
+| `scripts/lib/reconcile-brain.mjs` | 71.43 % | **~96 %** | 6 equivalent |
+| `scripts/lib/engine-source.mjs` | 81.40 % | **93.02 %** | 3 equivalent |
+
+## The headline finding: the discipline stopped at the edge of the domain logic
+
+Rank those four by score and the ordering is not random — it tracks **how the code was written**:
+
+- `engine-skill-refresh.mjs` (86.7 %) was built **in TDD baby-steps** during this increment. It started
+  highest and needed only assertion polish.
+- `engine-source.mjs` (81.4 %) is a **pure module**: small, side-effect-free, easy to drive from a test.
+- `reconcile-brain.mjs` (71.4 %) is a pure core **wrapped in I/O and a CLI**.
+- `update-engine.mjs` (51.5 %) is **mostly composition**: fetch, orchestrate, report, boot.
+
+The rule that predicts the score is not "did we write tests" — all four had tests, and the suite was green
+at 790 before any of this. It is: **was this line reached by a test that was written FIRST, or was it glue
+added afterwards around an already-green core?** In `update-engine.mjs`, ~40 of 96 survivors sat in a single
+top-level `if (isEntrypoint(…))` block; in `reconcile-brain.mjs`, ~22 sat in the CLI around it. That is
+Part I's **C4** — already diagnosed, already engraved — reproduced almost verbatim, twice.
+
+**So the honest answer to "how did this happen" is not that we lacked the rule. It is that the rule was
+written as an assertion habit, and the failure is a DESIGN habit.** You cannot assert your way into a
+composition root: you have to give it a seam *while writing it*. Every time the fix was the same
+(`runUpdateCli(deps)` / `runReconcileCliProcess(deps)` + a `real…Deps` object + one subprocess test), and
+every time the seam was cheap **after** the fact only because the logic underneath was already clean.
+
+## Four failure shapes Part I did not have a name for
+
+**1. The self-confirming fixture.** The no-churn test built its `settings.json` fixture with
+`JSON.stringify(x, null, 2) + "\n"` — i.e. **with the same serialiser the production code writes it with**.
+So "the reconciler must not rewrite a converged brain's settings" could not fail: a reconciler rewriting the
+file on every run left it byte-identical. The test was green and proved nothing. Fix: make the fixture
+**foreign to the writer** (4-space indent, no final newline — the shape a human editor leaves), and the
+claim becomes refutable.
+→ *Rule: a fixture must never be produced by the code under test. If it is, the assertion is a tautology.*
+
+**2. The stub that cannot discriminate.** `countVaultNotes: async () => 0` returns exactly what a real
+empty vault returns, and ignores its argument entirely. A reconciler calling the REAL counter, or calling
+it with no brain dir at all, passed every test. Fix: stubs return values **no real implementation would
+produce** (407 notes), and **record their arguments**.
+→ *Rule: a double's return value must be a fingerprint. If the stub's answer is plausible for the real
+thing, it proves nothing about the wiring.*
+
+**3. The multi-reason condition never isolated.** `if (added.length > 0 || repaired.length > 0 ||
+statusLineRepaired)` had three reasons to fire, and **every fixture triggered at least two of them at once**
+(each broken-Windows fixture had both broken hooks and a broken statusLine). So no single term was ever the
+sole cause, and dropping any one of them kept the suite green — including the one that would have left the
+entire deployed Windows fleet unrepairable.
+→ *Rule: a condition with N reasons needs N tests, each feeding exactly ONE reason. Sharper than "triangulate
+the operator": here every operator was right and the coverage was still a lie.*
+
+**4. Platform-conditional code, invisible on the CI's platform.** `brainDir.split("\\").join("/")` is a
+**no-op on every POSIX path**, so on a macOS/Linux CI no test could distinguish it from `p => p`. The
+Windows contract it encodes (issue #31: Git Bash eats a backslash in a hook command) was therefore untested
+by construction, and a regression would only ever have surfaced on a user's machine. Fix: extract the
+transform into a named exported helper (`toPosix`) and feed it a **Windows-shaped input** on the POSIX CI.
+→ *Rule: any platform-conditional transform must be a pure named function fed foreign-platform data.
+"We can't test that here" means "extract it", not "skip it".*
+
+## The systemic finding: the audit's own success suppressed the re-check
+
+`update-engine.mjs`, `reconcile-brain.mjs` and `engine-source.mjs` appear **nowhere** in Part I's results.
+They were never measured. Yet `RESULTS.md` carried the line *"`scripts/**` is now fully hardened"* — true of
+the three worst files enumerated at the time, false as a statement about the directory. Anyone (including
+us, at the start of Step 10) reading that line concluded the surface was covered and that a low score would
+be a **regression from this branch**. It was not; it was virgin territory wearing a "done" label.
+
+→ *Rule: a hardening claim states the FILES it measured, never a glob. And `mutate:changed` is the trigger
+that makes it self-correcting: it deliberately skips `scripts/**`, which is exactly why `scripts/**` drifted.*
+
+## Two habits that worked, and are worth keeping
+
+- **Hand-applying each mutant against the full suite before and after writing the test.** Cheaper than a
+  Stryker run (seconds vs minutes), and it caught a real mistake here: a mutant I had recorded as *killed*
+  was in fact the OTHER branch of the same ternary, still alive, because the assertion used
+  `.includes(…)` instead of naming the whole list — Part I's C2, reproduced in a branch written after C2 was
+  engraved. Reasoning about mutants is not verifying them.
+- **Simplifying production instead of excusing the mutant.** Three guards in this branch could not change a
+  single byte (`flagValue`'s length check, `?? {}` before an object spread, the sidecar-clear condition of
+  the previous step). Deleting them said the same thing in less code and removed the mutants outright. The
+  temptation each time was to file them under "equivalent" and move on.
+
+## What this changes
+
+The four new shapes above are **assertion/fixture habits** and generalise beyond this repo → they belong in
+the global `tdd-discipline` skill, next to Part I's six. The two findings that are **not** assertion habits
+are the important ones, and they are structural:
+
+1. **Composition roots get their seam when they are WRITTEN, not when they are audited.** The `runXCli(deps)`
+   + `realXDeps` + one-subprocess-test shape is now the default for any new entry point in this repo, not a
+   remediation pattern.
+2. **A hardening claim names files, never globs** — so the next reader cannot mistake unmeasured code for
+   measured code.

--- a/maintainers/plans/ROADMAP.md
+++ b/maintainers/plans/ROADMAP.md
@@ -38,10 +38,19 @@ Decided with Thomas 2026-07-18, extended 2026-07-19 (universes). When juggling p
    **Deferred to AFTER the migration.**
 
 **Why deferring 🔴 is safe:** the constitution is `sacred` and `constitutionTemplate` is frozen at
-`1.0.0`, so no constitution re-layering is forced. Note that Universes (Gate 2) bumps
-`indexSchemaVersion` 1 → 2, so a **v3.2.x → current jump WILL reindex once** (it previously did not);
-`update-engine` handles this with a warning and is state-convergent (one jump converges). Deferral stays
-safe because **nothing forces** the fleet's upgrade in the interim.
+`1.0.0`, so no constitution re-layering is forced. Deferral stays safe because **nothing forces** the
+fleet's upgrade in the interim.
+
+> ⚠️ **Correction (2026-07-27).** This paragraph used to claim that `update-engine` "handles the
+> `indexSchemaVersion` 1 → 2 bump with a warning". It does **not**: the universes commit moved the engine
+> constant to `2` but **never bumped the manifest**, which still reads `1`, and that manifest pair is what
+> `reindex-trigger.mjs` compares. A stamped-`1` brain therefore meets the runtime stale-schema gate on its
+> **first search** after upgrading (fail-loud, self-healing, no corruption) instead of being warned up
+> front. Tracked in `prospective/engine-managed-file-merge-strategy.md` → §"Side-finding"; deliberately
+> NOT folded into Gate 2.5, since bumping the manifest is itself a fleet-wide reindex event.
+
+**Pulled forward (2026-07-27):** Gate **2.5** (refresh untouched engine skills) jumped ahead of the
+migration. Rationale in its gate entry below; it is independent of Gate 3, so the order is reversible.
 
 ---
 
@@ -67,7 +76,23 @@ safe because **nothing forces** the fleet's upgrade in the interim.
   - [ ] Field-verify a fresh single-universe install is born "today" (no universe folder, no
         frontmatter key, no reminder) and that creating a 2nd universe surfaces `/switch` + the
         reminder + scoped search — at Gate 3 generate time.
-- [ ] **Gate 3 — 🧠 Migration generate (depends on Gate 1 + Gate 2). NEXT TO EXECUTE.**
+- [ ] **Gate 2.5 — 🔄 Refresh an UNTOUCHED engine skill (pull-forward of Gate 4A). NEXT TO EXECUTE.**
+  - [ ] Provenance-gated refresh (sha256 base already recorded on every brain): overwrite only what is
+        provably byte-identical to what the engine last delivered; a customized skill is preserved and
+        reported. Lives in `reconcileBrain`, guarded on `sourceDir !== brainDir` so it fires on an
+        explicit update, never at SessionStart.
+  - [ ] **Why it jumped the queue:** the gap is live, not theoretical (12 skill commits since v3.2.2 have
+        reached nobody; `4e43e70` in v3.6.2 will never reach a v3.6.0/v3.6.1 brain), and the frozen share
+        of the fleet grows with the installed base.
+  - [ ] **Canonical plan:** `prospective/engine-managed-file-merge-strategy.md` → §"Increment 2.5".
+- [ ] **Gate 2.6 — 🌌 Universes v2: per-universe profiles + lifecycle (DEPENDS on Gate 2.5).**
+  - [ ] Blocked by design, not by code: its user-facing surface is the `/switch` skill, which cannot
+        reach the existing fleet until Gate 2.5 ships.
+  - [ ] **Canonical plan:** `prospective/universes-profiles-lifecycle-action.md`.
+- [ ] **Gate 3 — 🧠 Migration generate (depends on Gate 1 + Gate 2).**
+  - [ ] **Ordering note (2026-07-27):** Gate 3 is **independent** of 2.5 / 2.6 (different surfaces, no
+        shared file). It was "NEXT TO EXECUTE" before 2.5 was pulled forward. If the personal migration
+        becomes the priority again, flip the order here in one line: nothing in 2.5 / 2.6 blocks it.
   - [ ] Track D: generate brain → `/import --universe` ~405 notes → layer private capabilities.
   - [ ] **Canonical plan:** `prospective/second-brain-migration-and-engine-upstream-action.md` → Track D.
 - [ ] **Gate 4 — 🔴 Fleet re-layering + big-jump upgrade experience (deferred until after Gate 3).**
@@ -90,7 +115,8 @@ safe because **nothing forces** the fleet's upgrade in the interim.
 
 | Plan (canonical) | What it delivers | Gate | Status |
 | --- | --- | --- | --- |
-| `prospective/engine-managed-file-merge-strategy.md` | Propagate engine improvements into user-editable provided files (constitution + shipped skills) without clobbering edits. | 1 & 4 | 🔭 Prospective / analysis; sequencing decided. |
+| `prospective/engine-managed-file-merge-strategy.md` | Propagate engine improvements into user-editable provided files (constitution + shipped skills) without clobbering edits. | 1, **2.5** & 4 | 🟠 Increment 2.5 (skills half) is NEXT TO EXECUTE; the constitution half stays prospective in Gate 4. |
+| `prospective/universes-profiles-lifecycle-action.md` | Per-universe profiles (captured + injected), rename, guarded delete. | 2.6 | 🔭 Design reviewed 2026-07-27; blocked on Gate 2.5 for its user-facing surface. |
 | `archived/universes-progressive-disclosure-action.md` | A soft, progressively-disclosed per-universe retrieval scope over one shared vault/index (ADR 0034). | 2 | ✅ Shipped (PR #38 in v3.6.0, then write-path trilogy + `/switch` flag in v3.6.2, 2026-07-21). Plan archived; field-verify folds into Gate 3. |
 | `prospective/second-brain-migration-and-engine-upstream-action.md` | Migrate the pre-existing personal brain (~405 notes) + upstream the generic delta. | 3 | In progress: Tracks A/B/C DONE (PR #29/#30/#32); **Track D now unblocked (Gate 2 shipped)**; F post-migration. |
 

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -277,9 +277,22 @@ explicit guard:
         child's re-seed with the stale base.
   - [x] Locked by the refresh-twice test: the second run reports **neither** a refresh **nor** a
         `customized` preserve.
-- [ ] **Step 5 — Report what happened**, in the `update-engine` summary: which skills were refreshed,
+- [x] **Step 5 — Report what happened**, in the `update-engine` summary: which skills were refreshed,
       which were **preserved because customized** (naming the `.new` file). Deterministic prose (ADR 0009),
-      unit-tested, relayed verbatim by the skill.
+      unit-tested, relayed verbatim by the skill. _(2026-07-27 · `formatReport` + `refreshUntouchedSkills`)_
+  - [x] **The `.new` sidecar is now actually written** (it was decided in §The decision but no code
+        dropped it): on `preserve: customized` only. `no-provenance` gets **no** sidecar and **no**
+        report line — we cannot prove anything there, and littering an older brain with 9 unexplained
+        `.new` files would be noise, not a choice offered to the owner.
+  - [x] **A stale `.new` is cleared** on any other verdict: once the owner adopted the new version (or
+        we refreshed the file ourselves), a surviving sidecar keeps claiming "something newer awaits".
+  - [x] **A refresh-only update still raises the restart banner** (report + the CLI's persistent restart
+        flag): a refreshed skill is loaded at session start, so THIS conversation still runs the old
+        text. Counted as a *change*, never as a *new capability* (no counter, no "run once more").
+        The steady-state line now says "your engine was updated on disk" (true for a skill too).
+  - [x] The `update-engine` skill relays both lines (EN + `templates/fr`), and its "genuine no-op"
+        carve-out now includes "no skill brought up to date" — else a refresh-only update would
+        wrongly skip the restart banner.
 - [ ] **Step 6 — Pre-v3.3.0 tail:** decide bottle vs documented 2-cycle, then implement the choice.
 - [ ] **Step 7 — ADR:** amend **0026** (the reconciler gains a conditional, provenance-gated overwrite,
       scoped to explicit updates) and cross-note **0025** (its "out of scope, belongs to a future 3-way
@@ -288,7 +301,19 @@ explicit guard:
       synthetic personal edits. Never use real deployed brains' content. Verify the `4e43e70` case
       end-to-end: a v3.6.0 fixture must end up with the v3.6.2 `switch` skill.
 - [ ] **Step 9 — Docs:** SETUP / the `update-engine` skill wording ("your customized skills are never
-      overwritten; you are told when a newer version is available").
+      overwritten; you are told when a newer version is available"). Includes the stale claim in
+      `.claude/skills/update-engine/SKILL.md` §What it touches — "any engine skill you already have" is
+      no longer in the untouched column (an *untouched* one is now refreshed; a *customized* one is not).
+- [ ] **Step 10 — Mutation testing on the impacted surface, LAST, right before the merge** (asked by
+      Thomas, 2026-07-27). The objective signal for this increment is the mutation score, not line
+      coverage: the whole feature is a decision tree (`refreshVerdict`), a guard (`sourceDir !==
+      brainDir`), a re-seed and prose branches — precisely where a surviving mutant means a brain
+      silently loses its customization or never gets refreshed again.
+  - [ ] Scope: `scripts/lib/engine-skill-refresh.mjs`, the refresh block of `scripts/lib/reconcile-brain.mjs`,
+        `reseedProvenance` + step 7 of `scripts/update-engine.mjs`, and `formatReport`'s new branches.
+  - [ ] Kill every surviving mutant with a test (or record why it is equivalent). Watch specifically:
+        the `reason` discrimination (`customized` vs `no-provenance`), the EOL normalization, the
+        `.new` write/clear conditions, and the guard's equality.
 
 ### Side-finding (2026-07-27) — the schema-bump warning was never wired
 

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -487,10 +487,37 @@ explicit guard:
           customized` rewrites the `.new` immediately after, so guarding the clear on the verdict
           cannot change a byte. Clearing **unconditionally** says the same in less code and the
           mutants vanish. Only production change of this step; suite green at 790.
-  - [ ] `reconcile-brain.mjs` + `engine-source.mjs` + `update-engine.mjs`: pass running. Baseline to
-        compare against: `RESULTS.md` records `scripts/**` as **already fully hardened**, so any
-        survivor there is a regression introduced by THIS branch, not pre-existing debt.
-  - [ ] Record the run in `maintainers/mutation/RESULTS.md` (before/after table, per CONVENTIONS §5bis).
+  - [ ] **`scripts/update-engine.mjs` → 51.52 %, 96 survivors** _(measured 2026-07-27)_. **DECISION
+        (Thomas, 2026-07-27): harden it IN THIS BRANCH**, not as a follow-up. The proposal to fix only
+        this increment's own lines and defer the rest was **rejected** — do not re-propose it.
+    - [x] **Qualified before acting: this is NOT a regression from this branch.** `update-engine.mjs`
+          appears **nowhere** in `RESULTS.md`: it was never hardened. The "`scripts/**` is now fully
+          hardened" line covered only the three enumerated worst files (`clear-example-notes`,
+          `auto-push`, `auto-commit`) plus `scripts/lib/**`. So the baseline assumption written one
+          bullet above is **wrong for this file** — corrected here so nobody re-derives it.
+    - [ ] **(a) This increment's own lines.** `L88 if (skillsRefreshed.length > 0)`: the `true` and
+          `>= 0` mutants live, so nothing asserts that an EMPTY list writes **no** line. `L289`: this
+          branch added the `report.skillsRefreshed?.length > 0` term to the restart-flag condition, and
+          it sits inside the untested `if (isEntryPoint)` block.
+    - [ ] **(b) Dead branch, not a missing test.** `L100`'s `newVersionPath ? … : ""` else-branch is
+          **unreachable by construction**: `refreshUntouchedSkills` only ever emits `reason ===
+          "customized"` **with** a `newVersionPath`, and `formatReport` `continue`s on every other
+          reason. Delete the ternary rather than test-cover a state the producer cannot emit
+          (mutation lesson #6: an unreachable branch is a design defect, not an exemption).
+    - [ ] **(c) The composition root has no seam.** The whole top-level `if (isEntryPoint)` block
+          (`L278-302`: newCaps arithmetic, the restart-flag write, the stdout/stderr paths) is
+          **untested**, which is why ~40 of the 96 survivors cluster there. Extract testable seams
+          (at least `needsRestart(report)` and the newCaps computation) instead of leaving it inert.
+    - [ ] **(d) The older prose branches** of `formatReport` (`L47-L143`: hook-name stripping regexes,
+          the singular/plural `capability/capabilities` pair, the restart banner text, the
+          "your notes were left untouched" line). Pre-existing, now in scope by the decision above.
+  - [ ] **`reconcile-brain.mjs` + `engine-source.mjs`: NOT MEASURED YET.** A first attempt passed three
+        separate `--mutate` flags: **they do not accumulate, only the last one applies**, so that run
+        silently measured `update-engine.mjs` alone. Use ONE comma-separated value:
+        `--mutate "scripts/lib/reconcile-brain.mjs,scripts/lib/engine-source.mjs"`. The re-run was
+        still in flight when the session was cleared → **re-run it**.
+  - [ ] Record the run in `maintainers/mutation/RESULTS.md` (before/after table, per CONVENTIONS §5bis),
+        including the honest note that `update-engine.mjs` had never been audited before.
 
 ### Side-finding (2026-07-27) — the schema-bump warning was never wired
 

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -460,6 +460,37 @@ explicit guard:
   - [ ] Kill every surviving mutant with a test (or record why it is equivalent). Watch specifically:
         the `reason` discrimination (`customized` vs `no-provenance`), the EOL normalization, the
         `.new` write/clear conditions, and the guard's equality.
+  - [x] **HOW TO RUN IT (re-derived the hard way 2026-07-27, do not lose this).** `mutate:changed`
+        covers **only** `rag/` + `local-mirror` TS: our surface is `scripts/**`, which it deliberately
+        skips. And the `stryker.scripts.config.mjs` default (`inPlace: false`, sandbox) **cannot work
+        here**: the sandbox copy has no `.git`, so `engine-manifest-integrity` fails the DRY RUN and
+        Stryker aborts before mutating anything. The working recipe is the one in `RESULTS.md`: a
+        **disposable git worktree** + `--inPlace` (git present, deletions confined). Also: the HTML
+        report's embedded literal is **JS, not JSON** (it splits `</script>` into `"<"+"script>"`),
+        so parse it with `new Function`, never `JSON.parse`. First run: `npm install` in
+        `maintainers/mutation/` (node_modules is not committed).
+  - [x] **`scripts/lib/engine-skill-refresh.mjs` → 100 %** (119/119, no equivalent left to excuse),
+        from **86.72 % / 17 survivors**. _(2026-07-27 · `6d6564b`)_ What the survivors actually were:
+    - [x] **`preserve: no-provenance` had no I/O-level test at all** (only the pure verdict), so its
+          report shape, its "writes no `.new`" rule and its stale-sidecar clearing were all unpinned —
+          the last one being a claim ADR 0026 §8 explicitly makes. One test, three mutants.
+    - [x] **Report speaks in SKILLS, refresh works in FILES.** No test had two files in one skill, so
+          the per-skill dedup was invisible on both lists. Now covered both ways, asserting that
+          reporting once still drops a `.new` **per file**. (Reachable only thanks to Step 8.5's F2.)
+    - [x] **The staged-prefix guard was inert before this branch** (a loose file directly under
+          `engine-skills/` is not a skill): with the verdict dropped it changed nothing. Now that an
+          absent file is delivered, an unguarded prefix would write into the owner's skills root.
+    - [x] **A base recorded on CRLF bytes** (Windows clone with autocrlf) matches only the RAW
+          comparison. The drift case was covered; its mirror image was not.
+    - [x] **The 5 sidecar-guard survivors were redundancy, NOT a test gap** — and are recorded here
+          because the temptation to write them off as "equivalent" was the wrong call. `preserve:
+          customized` rewrites the `.new` immediately after, so guarding the clear on the verdict
+          cannot change a byte. Clearing **unconditionally** says the same in less code and the
+          mutants vanish. Only production change of this step; suite green at 790.
+  - [ ] `reconcile-brain.mjs` + `engine-source.mjs` + `update-engine.mjs`: pass running. Baseline to
+        compare against: `RESULTS.md` records `scripts/**` as **already fully hardened**, so any
+        survivor there is a regression introduced by THIS branch, not pre-existing debt.
+  - [ ] Record the run in `maintainers/mutation/RESULTS.md` (before/after table, per CONVENTIONS §5bis).
 
 ### Side-finding (2026-07-27) — the schema-bump warning was never wired
 

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -363,9 +363,17 @@ explicit guard:
             between the two. Added to the harness step (dependency-free `.mjs` seams belong there).
       - [x] The three cohorts were also smoke-run through the real `main()` on fixture brain layouts
             (old scripts → both banners; modern → restart only; converged → silence).
-- [ ] **Step 7 — ADR:** amend **0026** (the reconciler gains a conditional, provenance-gated overwrite,
+- [x] **Step 7 — ADR:** amend **0026** (the reconciler gains a conditional, provenance-gated overwrite,
       scoped to explicit updates) and cross-note **0025** (its "out of scope, belongs to a future 3-way
       merge" consequence is now partially closed). Keep the `Scope:` field per `CONVENTIONS.md`.
+      _(2026-07-27 · `2e49008`)_
+  - [x] Amended **in place** per `CONVENTIONS.md` §6bis (same topic: what the reconciler may write) and
+        written **timelessly** per §6ter — no "amended" scars, no autobiography. Landed as Decision §8 +
+        a third nominative carve-out in the safety invariant, with the Crux guarantee corrected (it
+        claimed the reconciler only ever *adds*) and the STATUS line moved from two exceptions to three.
+  - [x] Rejected alternatives recorded so nobody re-litigates them: version/date instead of hash,
+        refreshing at SessionStart, refreshing from the root regardless of locale, 3-way-merging prose,
+        making the bottle refresh instead of print, and leaving the old cohort on the 2-cycle.
 - [ ] **Step 8 — QA on fixtures** reproduced from real release tags (v3.2.2 / v3.6.0 / v3.6.2), with
       synthetic personal edits. Never use real deployed brains' content. Verify the `4e43e70` case
       end-to-end: a v3.6.0 fixture must end up with the v3.6.2 `switch` skill.

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -374,9 +374,24 @@ explicit guard:
   - [x] Rejected alternatives recorded so nobody re-litigates them: version/date instead of hash,
         refreshing at SessionStart, refreshing from the root regardless of locale, 3-way-merging prose,
         making the bottle refresh instead of print, and leaving the old cohort on the 2-cycle.
-- [ ] **Step 8 — QA on fixtures** reproduced from real release tags (v3.2.2 / v3.6.0 / v3.6.2), with
+- [x] **Step 8 — QA on fixtures** reproduced from real release tags (v3.2.2 / v3.6.0 / v3.6.2), with
       synthetic personal edits. Never use real deployed brains' content. Verify the `4e43e70` case
       end-to-end: a v3.6.0 fixture must end up with the v3.6.2 `switch` skill.
+      _(2026-07-27 · `c2590ae` · `scripts/lib/release-fixture-refresh.test.mjs`)_
+  - [x] **Automated, not a one-off session:** the fixtures are the tags' own bytes, captured with
+        `git show <tag>:<path>` into `maintainers/qa/release-fixtures/<tag>/` (under `maintainers/`,
+        so no brain ever carries QA payload), and the **source is this repository at HEAD** — the
+        assertions are about released content. `v3.6.2` needed no fixture: `switch/SKILL.md` is
+        byte-identical from v3.6.2 to HEAD, so "ends up at HEAD" *is* "ends up at v3.6.2".
+  - [x] **Found a real defect, and fixed it (`c2590ae`): a skill delivered by install-if-absent got
+        NO provenance base**, so it read `no-provenance` at every later update and was frozen the day
+        it arrived — the freeze this increment removes, re-entering by the other door. It bit exactly
+        the cohort we are serving: a v3.2.2 brain receiving `switch` would never have received a
+        later improvement to it. Both manifest writers on the update path now re-seed it.
+  - [x] Two test-side lessons worth keeping: use the **production** `fingerprint` / `reseedProvenance`
+        in a fixture test (a hand-rolled sha256 silently disagreed with the manifest's `sha256:` prefix
+        and turned every untouched skill into "customized"), and simulate the update path with the same
+        helpers it uses, or the QA proves something the product never does.
 - [ ] **Step 9 — Docs:** SETUP / the `update-engine` skill wording ("your customized skills are never
       overwritten; you are told when a newer version is available"). Includes the stale claim in
       `.claude/skills/update-engine/SKILL.md` §What it touches — "any engine skill you already have" is

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -313,44 +313,56 @@ explicit guard:
   - [x] The `update-engine` skill relays both lines (EN + `templates/fr`), and its "genuine no-op"
         carve-out now includes "no skill brought up to date" — else a refresh-only update would
         wrongly skip the restart banner.
-- [ ] **Step 6 — Pre-v3.3.0 tail: DECIDED (2026-07-27) → the message-in-a-bottle (option A).** Carry the
+- [x] **Step 6 — Pre-v3.3.0 tail: DECIDED (2026-07-27) → the message-in-a-bottle (option A).** Carry the
       cohort with `rag/postinstall-restart-notice.mjs`'s proven vector so a pre-v3.3.0 brain converges on
-      its FIRST `/update-engine`, not its second.
-  - [ ] **Why A and not the documented 2-cycle (Thomas, explicitly):** today it is simply the better user
+      its FIRST `/update-engine`, not its second. _(2026-07-27 · `4279fd4` code + `438606d` skill rule)_
+  - [x] **Why A and not the documented 2-cycle (Thomas, explicitly):** today it is simply the better user
         experience, and the goal right now is **market share** — widening the installed base. A newcomer
         on an old engine must not silently keep frozen skills until they happen to update twice.
   - [ ] **Exit condition (do not let this become mystery debt):** the bottle is a *transitional* vector.
         When the pre-v3.3.0 cohort has shrunk, delete it and fall back to option B (2-cycle, already
         documented by ADR 0025). Whoever removes it should find this line, not archaeology.
-  - [ ] Fail-soft is not optional here: the bottle runs inside `npm install`: a throw would abort the
+  - [x] Fail-soft is not optional here: the bottle runs inside `npm install`: a throw would abort the
         install and break the update. Same discipline as the existing restart notice (never throws,
-        swallowed by the CLI wrapper).
-  - [ ] **Design settled BEFORE coding (2026-07-27) — the bottle PRINTS a directive, it does not
+        swallowed by the CLI wrapper). _(inherited: the new banner rides the same try/caught `main()`)_
+  - [x] **Design settled BEFORE coding (2026-07-27) — the bottle PRINTS a directive, it does not
         refresh.** Making the postinstall run the refresh itself looks obvious and does not survive
         contact with the facts:
-    - [ ] **It has no source to refresh FROM.** The merge skills' new content exists only in the
+    - [x] **It has no source to refresh FROM.** The merge skills' new content exists only in the
           orchestrator's temp clone, whose path the postinstall never learns; and the manifest still
           records the OLD `source.ref` at that moment (step 7 writes it AFTER `npm install`), so
           re-fetching from it would pull the version being replaced.
-    - [ ] **The staged base is already gone.** `engine-skills/**` is a `replace` glob copied BEFORE
+    - [x] **The staged base is already gone.** `engine-skills/**` is a `replace` glob copied BEFORE
           `npm install`, so by postinstall time the staging tree holds the NEW content. Comparing
           against it would call every outdated-but-untouched skill "customized" and litter the brain
           with `.new` files: the exact opposite of the promise.
-    - [ ] **A reconcile inside `npm install` recurses.** `reconcileBrain` runs `npm install` itself →
+    - [x] **A reconcile inside `npm install` recurses.** `reconcileBrain` runs `npm install` itself →
           postinstall → reconcile → … Any refresh-from-the-bottle needs a re-entrancy guard that the
           print-only vector does not.
-    - [ ] **Therefore:** the bottle prints a directive addressed to the AGENT ("this brain ran a
+    - [x] **Therefore:** the bottle prints a directive addressed to the AGENT ("this brain ran a
           pre-auto-finalize orchestrator — run `node scripts/update-engine.mjs` once more, now"),
           exactly like `restartNoticeBanner()` does today, and the `update-engine` skill carries the
-          matching rule. The user still asks ONCE and ends up converged in the same interaction (the
-          option-A experience Thomas asked for), with zero new execution path inside npm.
-    - [ ] **Cohort signal (deterministic, no guessing):** auto-finalize shipped in **v3.3.0**, whose
+          matching rule (EN + `templates/fr`, incl. **why it cannot loop**: the first pass records the
+          new versions, so the second postinstall is silent). The user still asks ONCE and ends up
+          converged in the same interaction, with zero new execution path inside npm.
+    - [x] **Cohort signal (deterministic, no guessing):** auto-finalize shipped in **v3.3.0**, whose
           manifest records `engineVersion.scripts: "1.1.0"` (`7105a7a`, released by `423d7e4`). At
           postinstall time the manifest still holds the brain's OLD versions, so
           `recorded scripts < 1.1.0` ⇒ the orchestrator that is running has no auto-finalize. Same
           read-the-stale-manifest trick the restart notice already relies on.
-    - [ ] Testable halves, as for the restart notice: a pure `shouldFinishRefresh({...})` predicate +
+      - [x] **Two refinements the tests pulled out.** (a) An **absent or unparsable** `scripts` version
+            counts as *older* than the floor — a manifest without the key predates it, and one extra
+            converging update is cheaper than a permanently frozen skill set. (b) The cohort test is
+            **conjoined with the update-in-flight signal** (`recorded rag !== package rag`), because the
+            SessionStart self-heal runs `npm install` too: without it, every session start on an old
+            brain would nag the owner to update.
+    - [x] Testable halves, as for the restart notice: a pure `shouldFinishRefresh({...})` predicate +
           a pure banner; the I/O `main()` stays thin glue.
+      - [x] **Side-fix — the bottle's suite was running in NO CI job:** the harness step globs
+            `scripts/**` and rag's `npm test` globs `src/lib/*.test.ts`, so `rag/*.test.mjs` fell
+            between the two. Added to the harness step (dependency-free `.mjs` seams belong there).
+      - [x] The three cohorts were also smoke-run through the real `main()` on fixture brain layouts
+            (old scripts → both banners; modern → restart only; converged → silence).
 - [ ] **Step 7 — ADR:** amend **0026** (the reconciler gains a conditional, provenance-gated overwrite,
       scoped to explicit updates) and cross-note **0025** (its "out of scope, belongs to a future 3-way
       merge" consequence is now partially closed). Keep the `Scope:` field per `CONVENTIONS.md`.

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -250,11 +250,31 @@ explicit guard:
   - [x] **`switch` / `local-mirror` have no FR source: resolved as "fall back to the root", not a gap to
         block on.** The root is exactly what a FR brain received at install, so refreshing from it is a
         same-language update. Writing the FR versions stays a content task, independent of this increment.
-  - [ ] **Finding for Steps 4-5 — `local-mirror` has no provenance base at all:** the manifest's `merge`
-        regime lists 9 skills but NOT `.claude/skills/local-mirror/**` (it ships staged, via
-        `engine-skills/`), so it is never fingerprinted → it would be `preserve: no-provenance` forever.
-        Decide with the reseed step: add it to the `merge` globs (and let the reseed give deployed brains
-        a base on their next update).
+  - [x] **Finding — the STAGED skills have no provenance base at all:** the manifest's `merge` regime
+        lists 9 skills, and provenance is recorded for `merge` files only. A staged skill is never
+        fingerprinted → `preserve: no-provenance` forever.
+    - [x] **It is not just `local-mirror`: 6 skills** are staged (`consolidate`, `file-back`, `lint`,
+          `local-mirror`, `mcp-token-expired`, `open-note`). The drift is already on disk: `engine-skills/**`
+          is `replace`, so every brain's SOURCE copy is updated at each update while the INSTALLED copy
+          under `.claude/skills/` stays frozen.
+    - [x] **Why it was never done (not an oversight):** the sacred scrub strips `.claude/skills/` from
+          `replace` (it is what protects the owner's skills), so a skill bound for EXISTING brains cannot
+          be delivered by copy. Hence the 2026-06-21 relocation to the non-sacred `engine-skills/<name>/`
+          + install-if-absent (ADR 0026 amendment). Provenance follows `merge`, so staged skills got none —
+          invisible until something started refreshing skills at all.
+    - [x] **DECIDED (2026-07-27, Thomas): treat the staged 6 exactly like the other 9.**
+    - [x] **How, without touching the manifest:** the brain's OWN `engine-skills/<name>/` copy, read
+          BEFORE the update overwrites it, is byte-for-byte what the engine last delivered — i.e. a free,
+          retroactive provenance base for the whole deployed fleet (install-if-absent copied that very
+          subtree). Captured ahead of the copy step, `engine-skills/<name>/**` mapped to
+          `.claude/skills/<name>/**`, and the existing verdict applies unchanged.
+          _(2026-07-27 · `readStagedProvenance` + `refreshableSkillPairs`)_
+      - [x] **Self-maintaining, so nothing to re-seed:** `engine-skills/**` is a `replace` glob, so the
+            copy step refreshes the staging tree at every update — the base for the NEXT update writes
+            itself. `reseedProvenance` filters to `merge` files and ignores these paths: correct as is.
+      - [x] The read-before-copy ordering is **locked by the refresh test**, not by a comment: read it
+            one line later and the base is the NEW content, every staged skill reads "customized", and
+            the test fails loudly (mutation-checked).
 - [x] **Step 3 — Wire into `reconcileBrain`** behind the `sourceDir !== brainDir` guard. Assert by test
       that a SessionStart-shaped call (`sourceDir === brainDir`) refreshes **nothing**.
       _(2026-07-27 · `refreshUntouchedSkills` in `engine-skill-refresh.mjs`, step 2.bis-refresh)_
@@ -293,7 +313,18 @@ explicit guard:
   - [x] The `update-engine` skill relays both lines (EN + `templates/fr`), and its "genuine no-op"
         carve-out now includes "no skill brought up to date" — else a refresh-only update would
         wrongly skip the restart banner.
-- [ ] **Step 6 — Pre-v3.3.0 tail:** decide bottle vs documented 2-cycle, then implement the choice.
+- [ ] **Step 6 — Pre-v3.3.0 tail: DECIDED (2026-07-27) → the message-in-a-bottle (option A).** Carry the
+      cohort with `rag/postinstall-restart-notice.mjs`'s proven vector so a pre-v3.3.0 brain converges on
+      its FIRST `/update-engine`, not its second.
+  - [ ] **Why A and not the documented 2-cycle (Thomas, explicitly):** today it is simply the better user
+        experience, and the goal right now is **market share** — widening the installed base. A newcomer
+        on an old engine must not silently keep frozen skills until they happen to update twice.
+  - [ ] **Exit condition (do not let this become mystery debt):** the bottle is a *transitional* vector.
+        When the pre-v3.3.0 cohort has shrunk, delete it and fall back to option B (2-cycle, already
+        documented by ADR 0025). Whoever removes it should find this line, not archaeology.
+  - [ ] Fail-soft is not optional here: the bottle runs inside `npm install`: a throw would abort the
+        install and break the update. Same discipline as the existing restart notice (never throws,
+        swallowed by the CLI wrapper).
 - [ ] **Step 7 — ADR:** amend **0026** (the reconciler gains a conditional, provenance-gated overwrite,
       scoped to explicit updates) and cross-note **0025** (its "out of scope, belongs to a future 3-way
       merge" consequence is now partially closed). Keep the `Scope:` field per `CONVENTIONS.md`.

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -229,10 +229,17 @@ explicit guard:
 
 ### Tracking
 
-- [ ] **Step 1 — Pure core: the refresh verdict** (TDD, injected fs, no side effects). Given the installed
+- [x] **Step 1 — Pure core: the refresh verdict** (TDD, injected fs, no side effects). Given the installed
       file, the recorded provenance base and the candidate new content → `refresh` / `preserve` /
       `absent-install`. Triangulate: no base recorded (pre-provenance brain), base recorded but file
-      missing, identical content already (no-op), CRLF/LF drift.
+      missing, identical content already (no-op), CRLF/LF drift. _(2026-07-27 · `scripts/lib/engine-skill-refresh.mjs`)_
+  - [x] Two refinements the tests pulled out, worth carrying into Step 5's prose: `preserve` carries a
+        **reason** (`customized` vs `no-provenance`) so a pre-provenance brain is never reported as a
+        customizer, and a 4th verdict **`unchanged`** keeps a converged brain byte-identical (no
+        auto-commit churn).
+  - [x] **CRLF decision:** line endings are not authorship. A file matching the base *modulo* EOLs counts
+        as untouched (else the whole Windows fleet freezes as "customized"), and a CRLF copy of the
+        candidate is `unchanged`, not a rewrite-to-LF at every update.
 - [ ] **Step 2 — Locale-aware source resolution** (T2). Pure function: brain locale + skill name +
       source tree → the file to deliver. Test EN and FR, and the no-FR-source case.
 - [ ] **Step 3 — Wire into `reconcileBrain`** behind the `sourceDir !== brainDir` guard. Assert by test

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -255,8 +255,18 @@ explicit guard:
         `engine-skills/`), so it is never fingerprinted → it would be `preserve: no-provenance` forever.
         Decide with the reseed step: add it to the `merge` globs (and let the reseed give deployed brains
         a base on their next update).
-- [ ] **Step 3 — Wire into `reconcileBrain`** behind the `sourceDir !== brainDir` guard. Assert by test
+- [x] **Step 3 — Wire into `reconcileBrain`** behind the `sourceDir !== brainDir` guard. Assert by test
       that a SessionStart-shaped call (`sourceDir === brainDir`) refreshes **nothing**.
+      _(2026-07-27 · `refreshUntouchedSkills` in `engine-skill-refresh.mjs`, step 2.bis-refresh)_
+  - [x] Runs AFTER install-if-absent, so a brand-new skill dir is installed once and then reads as
+        `unchanged` — the two passes compose instead of fighting.
+  - [x] Scope locked by the selector: `merge`-declared files **under `.claude/skills/`** only. The
+        constitution and the engine-owned scripts (also `merge`) stay out — Gate 4 keeps the
+        constitution half.
+  - [x] Reported per SKILL (`skillsRefreshed`, `skillsPreserved: [{skill, reason}]`), not per file.
+  - [x] Self-heal test proves the guard is observable: a customized skill is neither rewritten NOR
+        reported at session start (no nagging), while the same fixture under an explicit update reports
+        it preserved.
 - [ ] **Step 4 — Provenance re-seed for refreshed files** (T1), with the refresh-twice test.
 - [ ] **Step 5 — Report what happened**, in the `update-engine` summary: which skills were refreshed,
       which were **preserved because customized** (naming the `.new` file). Deterministic prose (ADR 0009),

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -487,7 +487,8 @@ explicit guard:
           customized` rewrites the `.new` immediately after, so guarding the clear on the verdict
           cannot change a byte. Clearing **unconditionally** says the same in less code and the
           mutants vanish. Only production change of this step; suite green at 790.
-  - [ ] **`scripts/update-engine.mjs` → 51.52 %, 96 survivors** _(measured 2026-07-27)_. **DECISION
+  - [x] **`scripts/update-engine.mjs` → 98.49 %** (196/200, 3 equivalents), from **51.52 % / 96
+        survivors**. _(2026-07-27 · `5a04fa4` seam + goldens, `a54a0b1` the last 20)_ **DECISION
         (Thomas, 2026-07-27): harden it IN THIS BRANCH**, not as a follow-up. The proposal to fix only
         this increment's own lines and defer the rest was **rejected** — do not re-propose it.
     - [x] **Qualified before acting: this is NOT a regression from this branch.** `update-engine.mjs`
@@ -495,29 +496,75 @@ explicit guard:
           hardened" line covered only the three enumerated worst files (`clear-example-notes`,
           `auto-push`, `auto-commit`) plus `scripts/lib/**`. So the baseline assumption written one
           bullet above is **wrong for this file** — corrected here so nobody re-derives it.
-    - [ ] **(a) This increment's own lines.** `L88 if (skillsRefreshed.length > 0)`: the `true` and
+    - [x] **(a) This increment's own lines.** `L88 if (skillsRefreshed.length > 0)`: the `true` and
           `>= 0` mutants live, so nothing asserts that an EMPTY list writes **no** line. `L289`: this
           branch added the `report.skillsRefreshed?.length > 0` term to the restart-flag condition, and
-          it sits inside the untested `if (isEntryPoint)` block.
-    - [ ] **(b) Dead branch, not a missing test.** `L100`'s `newVersionPath ? … : ""` else-branch is
+          it sits inside the untested `if (isEntryPoint)` block. **Both covered by (c)+(d) below** —
+          the empty-list case by the "quiet no-op" golden, `L289` by `needsRestart`'s own tests.
+    - [x] **(b) Dead branch, not a missing test.** `L100`'s `newVersionPath ? … : ""` else-branch is
           **unreachable by construction**: `refreshUntouchedSkills` only ever emits `reason ===
           "customized"` **with** a `newVersionPath`, and `formatReport` `continue`s on every other
           reason. Delete the ternary rather than test-cover a state the producer cannot emit
-          (mutation lesson #6: an unreachable branch is a design defect, not an exemption).
-    - [ ] **(c) The composition root has no seam.** The whole top-level `if (isEntryPoint)` block
+          (mutation lesson #6: an unreachable branch is a design defect, not an exemption). **Deleted.**
+    - [x] **(c) The composition root has no seam.** The whole top-level `if (isEntryPoint)` block
           (`L278-302`: newCaps arithmetic, the restart-flag write, the stdout/stderr paths) is
           **untested**, which is why ~40 of the 96 survivors cluster there. Extract testable seams
           (at least `needsRestart(report)` and the newCaps computation) instead of leaving it inert.
-    - [ ] **(d) The older prose branches** of `formatReport` (`L47-L143`: hook-name stripping regexes,
+          **Done, and further than asked:** `countNewCapabilities`, `needsRestart`, `armRestartFlag`,
+          `bareHookName`, plus `runUpdateCli(deps)` + `realUpdateDeps` (the `clear-example-notes`
+          idiom) — the entry block is now pure wiring, and its guard is the canonical `isEntrypoint`
+          (Windows paths / spaces, bug B2). `realUpdateDeps` gets its own test: a CLI wired to the
+          wrong folder or a swallowing stream would otherwise run flawlessly against nothing. And the
+          entry point is finally **spawned as a process** — safe because the committed manifest pins no
+          `source` (integrity-tested), so it fails before it can fetch or write.
+    - [x] **(d) The older prose branches** of `formatReport` (`L47-L143`: hook-name stripping regexes,
           the singular/plural `capability/capabilities` pair, the restart banner text, the
           "your notes were left untouched" line). Pre-existing, now in scope by the decision above.
-  - [ ] **`reconcile-brain.mjs` + `engine-source.mjs`: NOT MEASURED YET.** A first attempt passed three
-        separate `--mutate` flags: **they do not accumulate, only the last one applies**, so that run
-        silently measured `update-engine.mjs` alone. Use ONE comma-separated value:
-        `--mutate "scripts/lib/reconcile-brain.mjs,scripts/lib/engine-source.mjs"`. The re-run was
-        still in flight when the session was cleared → **re-run it**.
-  - [ ] Record the run in `maintainers/mutation/RESULTS.md` (before/after table, per CONVENTIONS §5bis),
-        including the honest note that `update-engine.mjs` had never been audited before.
+          **Pinned by 4 golden assertions on the WHOLE report** (quiet no-op / everything-on / steady
+          state / one-capability singular) rather than line-by-line regexes, each list carrying **two**
+          entries so a dropped `, ` separator diverges. The anchored hook-name stripping became
+          `bareHookName`, tested with the mid-path and mid-name decoys the anchors exist for.
+    - [x] **Two honesty fixes the mutants surfaced** (not just tests): a target manifest with no
+          `engineVersion` now reads `rag unknown` instead of `rag undefined` — it is printed **after**
+          the update is done and recorded, so crashing or lying there is the worst option — and a
+          rejection with no reason prints `no reason given` instead of leaving a ❌ over an empty line.
+    - [x] **The 3 survivors left are EQUIVALENT, recorded so nobody re-hunts them.** (1) the
+          `skillsPreserved = []` default mutated to `["Stryker was here"]`: its only use destructures
+          `{ skill, reason }` and `continue`s on `reason !== "customized"`, so a string element yields
+          undefined props and the exact same output. (2)+(3) `readFileSync(…, "utf8")` mutated to `""`:
+          Node hands back a **Buffer**, and both values are only ever `JSON.parse`d or fed to
+          `createHash().update()` — same bytes, same digest, no observable difference.
+  - [x] **`reconcile-brain.mjs` + `engine-source.mjs`: MEASURED** _(2026-07-27)_ — `--mutate` flags **do
+        not accumulate, only the last one applies**; ONE comma-separated value is the fix:
+        `--mutate "scripts/lib/reconcile-brain.mjs,scripts/lib/engine-source.mjs"`.
+        **`reconcile-brain.mjs` 69.14 % (54 survivors)** · **`engine-source.mjs` 81.40 % (8)**. Neither
+        was ever audited before (same correction as `update-engine.mjs` above).
+  - [x] Record the run in `maintainers/mutation/RESULTS.md` (before/after table, per CONVENTIONS §5bis),
+        including the honest note that `update-engine.mjs` had never been audited before. _(2026-07-27)_
+  - [ ] **⏭️ THE OPEN QUESTION — how far to harden `reconcile-brain.mjs` (54) + `engine-source.mjs` (8)
+        in THIS branch. ASK THOMAS FIRST, then execute.** This is **not** the deferral he already
+        rejected: that decision named `update-engine.mjs` (now at 98.49 %, done). These are different
+        files, and only a handful of their survivors sit on lines this increment wrote. The survivor
+        map, so nobody re-measures to answer:
+    - [ ] **In scope by the increment's own rationale** — `L98-101` (install-if-absent: the file-copy
+          loop + `installedFileMap`, which feeds the T1 re-seed) and `L131`
+          (`local?.provenance` — the staged/merge base merge).
+    - [ ] **Pre-existing, untouched by this branch** — `L145-199` the MCP + hook reconcile (~13,
+          `L194` alone has 5) · `L220-242` launchers / install / reindex / count (~6) · **`L269-317`
+          the `runReconcileCli` composition root (~22)**, which extracts exactly like
+          `runUpdateCli(deps)` did — the same seam, the same win, ~40 % of the file's survivors.
+    - [ ] **Finding, mid-flight, do NOT re-derive.** Emptying the `L100-101` copy loop leaves the
+          whole suite GREEN, because Step 8.5's F2 gave the refresh pass an `absent-install` verdict
+          that re-delivers the same bytes one block later. The two paths overlap; what still differs
+          is the **headline** (`installedSkills` = a NEW capability, counted for the restart banner,
+          vs `skillsRefreshed` = "brought up to date"). A first assertion on that contract is committed
+          (`reconcile-brain.test.mjs`, test 1) but it **does not kill the mutant yet** — verified by
+          hand: unmutated, 2.bis writes the file first, so the refresh sees it on disk with no base and
+          returns `preserve: no-provenance`, leaving `skillsRefreshed` empty in BOTH worlds. The
+          discriminator has to be something else (the probe used: `/tmp/probe.mjs` pattern — call
+          `reconcileBrain` directly and print `installedSkills` / `skillsRefreshed` / `skillsPreserved`).
+  - [ ] Re-run the two files after hardening and update the RESULTS.md row (it currently says
+        "not yet hardened" — an honest line that must stop being true or stay true on purpose).
 
 ### Side-finding (2026-07-27) — the schema-bump warning was never wired
 

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -427,10 +427,29 @@ explicit guard:
         a **test fixture** in `engine-skill-refresh.test.mjs`. So F2's field impact was **zero today**,
         strictly latent, which is why `nit` was the right severity: it was fixed for the first release
         that adds a sub-file, not for a brain in the wild.
-- [ ] **Step 9 — Docs:** SETUP / the `update-engine` skill wording ("your customized skills are never
+- [x] **Step 9 — Docs:** SETUP / the `update-engine` skill wording ("your customized skills are never
       overwritten; you are told when a newer version is available"). Includes the stale claim in
       `.claude/skills/update-engine/SKILL.md` §What it touches — "any engine skill you already have" is
       no longer in the untouched column (an *untouched* one is now refreshed; a *customized* one is not).
+      _(2026-07-27)_
+  - [x] **`.claude/skills/update-engine/SKILL.md`** — the §What-it-touches row was the load-bearing lie
+        and is now split in two: *engine skills you never edited* move to the **Updated** column, *any
+        engine skill you tailored* stays in the **NEVER touched** one, with its `.new` sidecar named.
+        Header promise and the Step-1 confirmation script realigned (the refresh is stated as a
+        **benefit** the user is about to get, not a risk), frontmatter description included: it is what
+        the harness reads to decide whether to load the skill at all, so a stale one mis-routes.
+  - [x] **`templates/fr/.claude/skills/update-engine/SKILL.md`** — same three edits, written in French
+        (deliberate product localization, never anglicized). The FR table was **two ADRs behind**, not
+        just one: it still lacked the ADR 0025 install-if-absent rows (missing skills / missing MCP
+        servers), so a French brain's table is realigned with the EN one in the same pass rather than
+        left half-true. Also fixed "identiques **au** octet près" → "à l'octet près".
+  - [x] **`SETUP.md` §10** — the refresh gets its own numbered step in "What it does, step by step"
+        (the list jumped straight from the write-allowlist to `npm install`), phrased around the
+        *proof*: the brain fingerprints what it delivered, so it can prove what you never touched.
+        The "never touches" sentence and the one-line report summary now name the tailored-skill case
+        too, and step 7 says why provenance is re-seeded (it keeps the delivery refreshable next time).
+  - [x] **Left alone on purpose:** SETUP §"Sacred by construction" already said "anything under
+        `.claude/skills/` **you customized**" — accurate as written, so it is not re-touched.
 - [ ] **Step 10 — Mutation testing on the impacted surface, LAST, right before the merge** (asked by
       Thomas, 2026-07-27). The objective signal for this increment is the mutation score, not line
       coverage: the whole feature is a decision tree (`refreshVerdict`), a guard (`sourceDir !==

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -450,14 +450,14 @@ explicit guard:
         too, and step 7 says why provenance is re-seeded (it keeps the delivery refreshable next time).
   - [x] **Left alone on purpose:** SETUP §"Sacred by construction" already said "anything under
         `.claude/skills/` **you customized**" — accurate as written, so it is not re-touched.
-- [ ] **Step 10 — Mutation testing on the impacted surface, LAST, right before the merge** (asked by
+- [x] **Step 10 — Mutation testing on the impacted surface, LAST, right before the merge** (asked by
       Thomas, 2026-07-27). The objective signal for this increment is the mutation score, not line
       coverage: the whole feature is a decision tree (`refreshVerdict`), a guard (`sourceDir !==
       brainDir`), a re-seed and prose branches — precisely where a surviving mutant means a brain
       silently loses its customization or never gets refreshed again.
-  - [ ] Scope: `scripts/lib/engine-skill-refresh.mjs`, the refresh block of `scripts/lib/reconcile-brain.mjs`,
+  - [x] Scope: `scripts/lib/engine-skill-refresh.mjs`, the refresh block of `scripts/lib/reconcile-brain.mjs`,
         `reseedProvenance` + step 7 of `scripts/update-engine.mjs`, and `formatReport`'s new branches.
-  - [ ] Kill every surviving mutant with a test (or record why it is equivalent). Watch specifically:
+  - [x] Kill every surviving mutant with a test (or record why it is equivalent). Watch specifically:
         the `reason` discrimination (`customized` vs `no-provenance`), the EOL normalization, the
         `.new` write/clear conditions, and the guard's equality.
   - [x] **HOW TO RUN IT (re-derived the hard way 2026-07-27, do not lose this).** `mutate:changed`
@@ -541,19 +541,52 @@ explicit guard:
         was ever audited before (same correction as `update-engine.mjs` above).
   - [x] Record the run in `maintainers/mutation/RESULTS.md` (before/after table, per CONVENTIONS §5bis),
         including the honest note that `update-engine.mjs` had never been audited before. _(2026-07-27)_
-  - [ ] **⏭️ THE OPEN QUESTION — how far to harden `reconcile-brain.mjs` (54) + `engine-source.mjs` (8)
-        in THIS branch. ASK THOMAS FIRST, then execute.** This is **not** the deferral he already
-        rejected: that decision named `update-engine.mjs` (now at 98.49 %, done). These are different
-        files, and only a handful of their survivors sit on lines this increment wrote. The survivor
-        map, so nobody re-measures to answer:
-    - [ ] **In scope by the increment's own rationale** — `L98-101` (install-if-absent: the file-copy
-          loop + `installedFileMap`, which feeds the T1 re-seed) and `L131`
-          (`local?.provenance` — the staged/merge base merge).
-    - [ ] **Pre-existing, untouched by this branch** — `L145-199` the MCP + hook reconcile (~13,
-          `L194` alone has 5) · `L220-242` launchers / install / reindex / count (~6) · **`L269-317`
-          the `runReconcileCli` composition root (~22)**, which extracts exactly like
-          `runUpdateCli(deps)` did — the same seam, the same win, ~40 % of the file's survivors.
-    - [ ] **Finding, mid-flight, do NOT re-derive.** Emptying the `L100-101` copy loop leaves the
+  - [x] **✅ ANSWERED (Thomas, 2026-07-27): HARDEN BOTH FILES FULLY, IN THIS BRANCH** — same standard
+        as `update-engine.mjs`, i.e. take `reconcile-brain.mjs` and `engine-source.mjs` to ~100 %
+        (every survivor killed or recorded as equivalent), **including the pre-existing ones this
+        increment never wrote**. The two narrower options (increment-only lines; increment + the
+        composition-root seam) were **put to him and declined** — do not re-propose either. The
+        survivor map below is the work list, not a menu:
+    - [x] **EXACT SURVIVOR MAP re-measured on `31ed87c`** _(2026-07-27, 4 min 28 s)_ —
+          `engine-source.mjs` **81.40 %** (8) · `reconcile-brain.mjs` **71.43 %** (50 + 1 timeout).
+          Recipe: disposable worktree + `--inPlace` + ONE comma-separated `--mutate`; the console
+          output is truncated by the `| tail -N` in the recipe, so read the **HTML report** instead
+          (`new Function`, never `JSON.parse` — the embedded literal is JS).
+    - [x] **`engine-source.mjs` — 5 killable, 3 equivalent.** `L27` optional chaining ×2 (no `merge`
+          regime / no manifest at all → must select nothing, never throw) · `L45` ×2 (`.trim()`
+          dropped → a whitespace-only remote must still read as *no* remote; `?? ""` → a git fact
+          with no `repo` key at all) · `L88` the manifest's trailing newline. Equivalent: `L27`'s
+          `[] → ["Stryker was here"]` (a matcher for a glob no real path can equal) and the two
+          `readFileSync(…, "utf8") → ""` (Node hands back a Buffer; both values are only `JSON.parse`d
+          or `createHash().update()`-ed — same bytes, same digest, as already recorded for
+          `update-engine.mjs`).
+    - [x] **`reconcile-brain.mjs` — in scope by the increment's own rationale.** `L98` the
+          `/\/\*\*?$/` skill-glob regex ×2 (anchor + optional `?`) · `L101` the `installedFileMap`
+          read (Buffer-equivalent) · `L131` `local?.provenance` (a reconcile called with no `local`).
+    - [x] **`reconcile-brain.mjs` — pre-existing, now in scope by the decision above.**
+          **(i) `L145-199` MCP + hooks (~13):** `brainDir.split("\\")` ×2 (nothing asserts the
+          SUBSTITUTED `{{PROJECT_ROOT}}` ever reaches the written files) · the `.mcp.json` / settings
+          trailing newlines · `L194`'s 5 (the write guard: no test isolates *only* a statusLine
+          repair, nor *only* a hook repair, and the converged fixture is already canonically
+          formatted so an unconditional write changes no byte, cf. the `>= 0` survivors) · `L196` ·
+          `L199`'s `["statusLine"]`. **(ii) `L220-242` (~6):** an EMPTY `regenerate` bucket is never
+          exercised · `reindexReason`'s two string literals are never asserted by value · the
+          `countVaultNotes({ brainDir })` argument is never observed (every stub ignores it and
+          returns 0 — make the stub return a distinctive count). **(iii) `L269-317` the composition
+          root (~22):** `flagValue`'s guard/arithmetic, the `--platform` fallback (`??` → `&&` must
+          be caught by passing `--platform win32` and asserting it reaches `regenerateLaunchers`),
+          the missing-flag throw + its message, `seams.x ?? default` (a stub returning a distinctive
+          value discriminates), the `delivered.length > 0` write guard, the manifest newline, and the
+          whole entry block.
+    - [x] **The fix for (iii) is the KNOWN-GOOD pattern, not invention:** extract the entry block's
+          body into an exported `runReconcileCliProcess(deps)` + `realReconcileDeps`, exactly as
+          `runUpdateCli(deps)` / `realUpdateDeps` took `update-engine.mjs` from 51 % to 98 %. It makes
+          the `catch` unit-testable (`throw null` / a bare string / an `Error`) and leaves the entry
+          block as pure wiring, spawned once as a real process. **Also swap the hand-rolled
+          `resolve(process.argv[1]) === fileURLToPath(import.meta.url)` guard for the canonical
+          `isEntrypoint` helper** — every other script already uses it (bug B2); `reconcile-brain.mjs`
+          is the last hold-out.
+    - [x] **Finding, mid-flight, do NOT re-derive.** Emptying the `L100-101` copy loop leaves the
           whole suite GREEN, because Step 8.5's F2 gave the refresh pass an `absent-install` verdict
           that re-delivers the same bytes one block later. The two paths overlap; what still differs
           is the **headline** (`installedSkills` = a NEW capability, counted for the restart banner,
@@ -563,8 +596,20 @@ explicit guard:
           returns `preserve: no-provenance`, leaving `skillsRefreshed` empty in BOTH worlds. The
           discriminator has to be something else (the probe used: `/tmp/probe.mjs` pattern — call
           `reconcileBrain` directly and print `installedSkills` / `skillsRefreshed` / `skillsPreserved`).
-  - [ ] Re-run the two files after hardening and update the RESULTS.md row (it currently says
+  - [x] Re-run the two files after hardening and update the RESULTS.md row (it currently says
         "not yet hardened" — an honest line that must stop being true or stay true on purpose).
+  - [x] **AT THE VERY END — the ROOT-CAUSE retrospective (asked by Thomas, 2026-07-27): HOW did we
+        come to write tests that score this badly, and what changes in the harness's TDD practice?**
+        Not a summary of the survivors (RESULTS.md already holds those), but the *upstream* question:
+        which habits produced them. Raw material is now abundant and concrete — four files audited in
+        one branch (86.72 / 51.52 / 69.14 / 81.40 %) with the survivor causes written down per file.
+        Look for the recurring shapes: one-regex-per-line assertions instead of goldens on the whole
+        output, composition roots left with no seam (the ~40 + ~22 clusters), branches tested through
+        the pure core but never at I/O level, mirror-image cases never triangulated (CRLF), and the
+        "equivalent mutant" reflex used to excuse redundancy. Land it in
+        `maintainers/mutation/RETROSPECTIVE.md` **and** feed whatever generalizes back into the
+        `tdd-discipline` skill (§"Qualité des assertions"), so the lesson reaches every future project
+        and not just this repo.
 
 ### Side-finding (2026-07-27) — the schema-bump warning was never wired
 

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -240,8 +240,21 @@ explicit guard:
   - [x] **CRLF decision:** line endings are not authorship. A file matching the base *modulo* EOLs counts
         as untouched (else the whole Windows fleet freezes as "customized"), and a CRLF copy of the
         candidate is `unchanged`, not a rewrite-to-LF at every update.
-- [ ] **Step 2 — Locale-aware source resolution** (T2). Pure function: brain locale + skill name +
+- [x] **Step 2 — Locale-aware source resolution** (T2). Pure function: brain locale + skill name +
       source tree → the file to deliver. Test EN and FR, and the no-FR-source case.
+      _(2026-07-27 · `resolveLocaleSource` in `engine-copy-select.mjs` + `brain-locale.mjs`)_
+  - [x] The brain's locale is read from **its own** `scripts/lib/demo-locale.mjs` marker
+        (`readBrainLocale`), not from the tree the code runs from — the marker is locale-owned (F2), so
+        an update never overwrites it and it stays truthful for the brain's lifetime. No marker → `en`,
+        never a crash.
+  - [x] **`switch` / `local-mirror` have no FR source: resolved as "fall back to the root", not a gap to
+        block on.** The root is exactly what a FR brain received at install, so refreshing from it is a
+        same-language update. Writing the FR versions stays a content task, independent of this increment.
+  - [ ] **Finding for Steps 4-5 — `local-mirror` has no provenance base at all:** the manifest's `merge`
+        regime lists 9 skills but NOT `.claude/skills/local-mirror/**` (it ships staged, via
+        `engine-skills/`), so it is never fingerprinted → it would be `preserve: no-provenance` forever.
+        Decide with the reseed step: add it to the `merge` globs (and let the reseed give deployed brains
+        a base on their next update).
 - [ ] **Step 3 — Wire into `reconcileBrain`** behind the `sourceDir !== brainDir` guard. Assert by test
       that a SessionStart-shaped call (`sourceDir === brainDir`) refreshes **nothing**.
 - [ ] **Step 4 — Provenance re-seed for refreshed files** (T1), with the refresh-twice test.

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -325,6 +325,32 @@ explicit guard:
   - [ ] Fail-soft is not optional here: the bottle runs inside `npm install`: a throw would abort the
         install and break the update. Same discipline as the existing restart notice (never throws,
         swallowed by the CLI wrapper).
+  - [ ] **Design settled BEFORE coding (2026-07-27) — the bottle PRINTS a directive, it does not
+        refresh.** Making the postinstall run the refresh itself looks obvious and does not survive
+        contact with the facts:
+    - [ ] **It has no source to refresh FROM.** The merge skills' new content exists only in the
+          orchestrator's temp clone, whose path the postinstall never learns; and the manifest still
+          records the OLD `source.ref` at that moment (step 7 writes it AFTER `npm install`), so
+          re-fetching from it would pull the version being replaced.
+    - [ ] **The staged base is already gone.** `engine-skills/**` is a `replace` glob copied BEFORE
+          `npm install`, so by postinstall time the staging tree holds the NEW content. Comparing
+          against it would call every outdated-but-untouched skill "customized" and litter the brain
+          with `.new` files: the exact opposite of the promise.
+    - [ ] **A reconcile inside `npm install` recurses.** `reconcileBrain` runs `npm install` itself →
+          postinstall → reconcile → … Any refresh-from-the-bottle needs a re-entrancy guard that the
+          print-only vector does not.
+    - [ ] **Therefore:** the bottle prints a directive addressed to the AGENT ("this brain ran a
+          pre-auto-finalize orchestrator — run `node scripts/update-engine.mjs` once more, now"),
+          exactly like `restartNoticeBanner()` does today, and the `update-engine` skill carries the
+          matching rule. The user still asks ONCE and ends up converged in the same interaction (the
+          option-A experience Thomas asked for), with zero new execution path inside npm.
+    - [ ] **Cohort signal (deterministic, no guessing):** auto-finalize shipped in **v3.3.0**, whose
+          manifest records `engineVersion.scripts: "1.1.0"` (`7105a7a`, released by `423d7e4`). At
+          postinstall time the manifest still holds the brain's OLD versions, so
+          `recorded scripts < 1.1.0` ⇒ the orchestrator that is running has no auto-finalize. Same
+          read-the-stale-manifest trick the restart notice already relies on.
+    - [ ] Testable halves, as for the restart notice: a pure `shouldFinishRefresh({...})` predicate +
+          a pure banner; the I/O `main()` stays thin glue.
 - [ ] **Step 7 — ADR:** amend **0026** (the reconciler gains a conditional, provenance-gated overwrite,
       scoped to explicit updates) and cross-note **0025** (its "out of scope, belongs to a future 3-way
       merge" consequence is now partially closed). Keep the `Scope:` field per `CONVENTIONS.md`.

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -267,7 +267,16 @@ explicit guard:
   - [x] Self-heal test proves the guard is observable: a customized skill is neither rewritten NOR
         reported at session start (no nagging), while the same fixture under an explicit update reports
         it preserved.
-- [ ] **Step 4 — Provenance re-seed for refreshed files** (T1), with the refresh-twice test.
+- [x] **Step 4 — Provenance re-seed for refreshed files** (T1), with the refresh-twice test.
+      _(2026-07-27 · `runReconcileCli` + `update-engine.mjs` step 7)_
+  - [x] **BOTH writers had to be covered, not one:** the auto-finalize child (`runReconcileCli`) is the
+        last writer of the manifest on the update path, and on the FIRST update carrying this feature
+        the parent still runs the OLD code, so the refresh happens there. It now re-seeds and persists.
+  - [x] The parent's step 7 folds `refreshedFileMap` into `deliveredFileMap`. It rebuilds the manifest
+        from the `local` copy read BEFORE the reconcile, so without this it would silently overwrite the
+        child's re-seed with the stale base.
+  - [x] Locked by the refresh-twice test: the second run reports **neither** a refresh **nor** a
+        `customized` preserve.
 - [ ] **Step 5 — Report what happened**, in the `update-engine` summary: which skills were refreshed,
       which were **preserved because customized** (naming the `.new` file). Deterministic prose (ADR 0009),
       unit-tested, relayed verbatim by the skill.

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -392,6 +392,16 @@ explicit guard:
         in a fixture test (a hand-rolled sha256 silently disagreed with the manifest's `sha256:` prefix
         and turned every untouched skill into "customized"), and simulate the update path with the same
         helpers it uses, or the QA proves something the product never does.
+- [ ] **Step 8.5 — `/code-review` of the whole increment BEFORE going further** (asked by Thomas,
+      2026-07-27, to run right after his `/clear`). Nothing else moves until its findings are triaged:
+      a review is worth most while the branch is still open and the design fresh, not after Step 10
+      has polished the tests around whatever it would have flagged.
+  - [ ] Scope: the branch diff `feat/engine-skill-refresh` vs `main` — the refresh core, its wiring in
+        the reconciler, both manifest re-seed paths, the postinstall bottle, the report prose, and the
+        release-tag QA suite.
+  - [ ] Triage each finding into: fix now (before Step 9), fold into Step 10's mutation pass, or
+        record as deliberate. **Answer every one of them in this plan** — an unanswered review finding
+        is exactly the kind of thing a `/clear` erases.
 - [ ] **Step 9 — Docs:** SETUP / the `update-engine` skill wording ("your customized skills are never
       overwritten; you are told when a newer version is available"). Includes the stale claim in
       `.claude/skills/update-engine/SKILL.md` §What it touches — "any engine skill you already have" is

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -392,16 +392,41 @@ explicit guard:
         in a fixture test (a hand-rolled sha256 silently disagreed with the manifest's `sha256:` prefix
         and turned every untouched skill into "customized"), and simulate the update path with the same
         helpers it uses, or the QA proves something the product never does.
-- [ ] **Step 8.5 — `/code-review` of the whole increment BEFORE going further** (asked by Thomas,
+- [x] **Step 8.5 — `/code-review` of the whole increment BEFORE going further** (asked by Thomas,
       2026-07-27, to run right after his `/clear`). Nothing else moves until its findings are triaged:
       a review is worth most while the branch is still open and the design fresh, not after Step 10
-      has polished the tests around whatever it would have flagged.
-  - [ ] Scope: the branch diff `feat/engine-skill-refresh` vs `main` — the refresh core, its wiring in
+      has polished the tests around whatever it would have flagged. **Ran 2026-07-27** (ultrareview,
+      27 files / +2558 −48): **2 findings, both `nit`, both verified real, both fixed now.**
+  - [x] Scope: the branch diff `feat/engine-skill-refresh` vs `main` — the refresh core, its wiring in
         the reconciler, both manifest re-seed paths, the postinstall bottle, the report prose, and the
         release-tag QA suite.
-  - [ ] Triage each finding into: fix now (before Step 9), fold into Step 10's mutation pass, or
+  - [x] Triage each finding into: fix now (before Step 9), fold into Step 10's mutation pass, or
         record as deliberate. **Answer every one of them in this plan** — an unanswered review finding
         is exactly the kind of thing a `/clear` erases.
+  - [x] **F1 (nit) — ADR 0026 still announced "the two narrow, nominative carve-outs below" while this
+        increment added a third** (the skill-content exception, joining vault + settings). The STATUS
+        line at the top had been updated to "three" in the same amend, the invariant intro had not, so
+        the ADR disagreed with itself. **Verdict: FIX NOW.** _(2026-07-27)_ One word, plus a
+        **`Subtree-complete`** bullet added to the §8 enforced-tests list to record what F2 locked.
+        Amend-in-place (CONVENTIONS §6bis) only pays off if the amended doc reads as one coherent whole.
+  - [x] **F2 (nit) — the `absent-install` verdict was silently dropped by the I/O wrapper.**
+        `refreshUntouchedSkills` dispatched on `refresh` and `preserve` only, so the verdict its own
+        docstring promises ("nothing on disk → deliver it") produced no write, no report, no provenance.
+        Combined with install-if-absent deciding at the **skill-DIR** level (`reconcile-brain.mjs` step
+        2.bis: dir exists → `continue`), a file a release adds **under an already-installed skill**
+        (`.claude/skills/coach/references/…`, well within the `**` merge glob) would reach **no**
+        deployed brain, ever: this increment's own core/skill drift, one level deeper.
+        **Verdict: FIX NOW** _(2026-07-27)_ — TDD, two red-first tests then a one-line branch: the
+        `absent-install` verdict now writes down the same path as `refresh` and folds the file into
+        `refreshedFileMap`, so **both** manifest re-seed paths give it a base and it stays refreshable
+        at the next update (the T1 sibling, third door). Fixed now rather than deferred because the code
+        contradicted its own documented contract, and the fix is smaller than the note explaining it.
+  - [x] **Correction to the review, recorded so it is not re-derived:** F2 claimed "coach has a
+        `references/` folder in HEAD already". **It does not** — all 9 merge skills and all 6 staged
+        ones ship a lone `SKILL.md` (`find` on the branch); the `references/radical-candor.md` it saw is
+        a **test fixture** in `engine-skill-refresh.test.mjs`. So F2's field impact was **zero today**,
+        strictly latent, which is why `nit` was the right severity: it was fixed for the first release
+        that adds a sub-file, not for a brain in the wild.
 - [ ] **Step 9 — Docs:** SETUP / the `update-engine` skill wording ("your customized skills are never
       overwritten; you are told when a newer version is available"). Includes the stale claim in
       `.claude/skills/update-engine/SKILL.md` §What it touches — "any engine skill you already have" is

--- a/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
+++ b/maintainers/plans/prospective/engine-managed-file-merge-strategy.md
@@ -133,9 +133,12 @@ release (the pre-layering, monolithic-constitution line, ~v3.2.x).
         reindex decision** (recorded vs target `indexSchemaVersion`) and shows it before applying: what lands,
         and whether notes will be re-encoded + the rough cost. Today `update-engine` reports reindex only
         *after* (`scripts/update-engine.mjs:15`, `runReindex` IFF the schema moved); expose it *ahead*.
-  - [ ] **Grounded reindex fact:** `indexSchemaVersion` has been **`1` continuously** since before v3.2.1
-        (introduced 2026-06-14, never changed) through today → a **v3.2.x → current jump triggers NO reindex**.
-        A reindex only ever fires if the index format changes in the future — exactly when (C) earns its keep.
+  - [ ] **Grounded reindex fact (CORRECTED 2026-07-27, was stale).** `indexSchemaVersion` was `1`
+        continuously from 2026-06-14 until the **universes** commit `3d85060` (v3.6.0), which moved the
+        **engine constant** to `2` (`rag/src/lib/vector-store.ts:63`). The **manifest was never bumped**
+        (still `1`), so `update-engine` today triggers neither a reindex nor a warning, and a stamped-`1`
+        brain instead hits the runtime stale-schema gate on its first search. See §"Side-finding" below:
+        this is exactly the case (C) was meant to make honest, and it is now live, not hypothetical.
   - [ ] **QA fixtures:** reproduce legacy brains from the release **tag(s)** (checkout the deployed version, run
         the installer) + **synthetic** personal edits to exercise the nasty boundary cases. Never use real
         deployed brains' private content. First step: **enumerate the versions actually deployed** so QA covers
@@ -144,6 +147,127 @@ release (the pre-layering, monolithic-constitution line, ~v3.2.x).
       fleet") when picked up; F-B7e (constitution re-layering) becomes one component of it.
 
 > Cross-ref: the reciprocal prerequisite note lives in the migration plan's Track D.
+
+## Increment 2.5 (decided 2026-07-27) — refresh an UNTOUCHED engine skill, pulled forward from Gate 4(A)
+
+> **Status:** 🟠 NEXT TO EXECUTE (ROADMAP Gate 2.5). Owns the *skills* half of Gate 4(A) only; the
+> constitution half (`CLAUDE.engine.md` propagation) stays in Gate 4.
+> **Why it jumped the queue:** the propagation gap is no longer theoretical, and the fleet is growing.
+
+### The trigger (evidence, 2026-07-27)
+
+The gap this plan describes is **already biting, in the field, on shipped releases**:
+
+- **12 commits** have touched `.claude/skills/**` since `v3.2.2`. **None** of them reached a brain that
+  already had the skill.
+- Concretely: `4e43e70` (shipped in **v3.6.2**) added 22 lines to `.claude/skills/switch/SKILL.md` (the
+  single-account native-connectors reminder). A brain installed at **v3.6.0 / v3.6.1 will never receive
+  it**, even after `/update-engine`, because its skill directory exists. Meanwhile the matching
+  deterministic core (`scripts/lib/universes.mjs`, a `replace` glob) **is** refreshed → a live
+  **core/skill drift**.
+- The installed base is growing (public communication started), so the share of the fleet frozen on old
+  skills grows monotonically. Every skill improvement shipped before this increment is invisible to it.
+
+### The decision
+
+**Refresh an engine skill if, and only if, we can PROVE nobody touched it.** The proof already exists on
+every deployed brain: the installer records a **sha256 provenance base per `merge` file** in
+`engine-manifest.json` (`installer.mjs` / `engine-source.mjs`, `fingerprint()`), and `reseedProvenance()`
+refreshes it after each update.
+
+- **Hash matches the recorded base** → the file is byte-identical to what the engine last delivered →
+  **overwrite it**. This is the overwhelming majority of users.
+- **Hash differs** → the owner customized it (the documented `prepare-1-1` "refine to your own KPIs" case)
+  → **touch nothing**, drop the new version alongside (`SKILL.md.new`, option 1 "conffile fallback" above)
+  and **say so**.
+
+This does not weaken ADR 0012's write-allowlist: we only ever overwrite a file we can prove is untouched,
+which is strictly safer than what `update-engine` already does daily on `rag/src/**`.
+
+### Where it lives, and why one pass is enough
+
+The home is **`reconcileBrain`** (it already does the install-if-absent of engine skills), behind an
+explicit guard:
+
+- [ ] **Guard: `sourceDir !== brainDir`.** The reconciler has three callers and they do not share a
+      contract:
+  - **`auto-finalize`** (ADR 0026 Layer A, `scripts/update-engine.mjs` step 8) re-execs the
+    **freshly-written** reconciler in a child process with the **fetched** `sourceDir`
+    (`scripts/lib/auto-finalize.mjs:28`) → new skill content is available → **refresh here**.
+  - **SessionStart self-heal** passes `sourceDir === brainDir` (`scripts/session-self-heal.mjs:161`,
+    local converge, no network) → no new content, and no user asked for anything → **never refresh**.
+  - The parent `update-engine` process itself runs the OLD code; it does not matter, because
+    auto-finalize re-runs the NEW reconciler from disk.
+- [ ] **Rule to hold, stated once:** *a skill is only ever overwritten during an update the owner
+      explicitly asked for, never silently at session start.* ADR 0026's "additive" invariant keeps
+      holding exactly where it matters.
+- [ ] **Convergence is ONE pass** for every brain at **v3.3.0+**, because auto-finalize already
+      "collaps[es] the historical 2-cycle into a single invocation". No second `/update-engine`.
+- [ ] **Pre-v3.3.0 tail** (no auto-finalize in their installed orchestrator): decide whether to carry
+      them with the proven **message-in-a-bottle** vector (`rag/postinstall-restart-notice.mjs`, commit
+      `2ce1556`) — the old orchestrator always runs `npm install` with `stdio:"inherit"`, and npm runs the
+      **new** `postinstall` already on disk, so new code executes under the old orchestrator on the FIRST
+      update. ADR 0025 already documents this cohort as "heals on its next update", so a 2-cycle fallback
+      is an acceptable answer too. **Decide, do not drift.**
+
+### The two real traps (neither is about the delivery mechanism)
+
+- [ ] **T1 — Provenance re-seed, or the feature silently dies after one use.** After refreshing a file we
+      MUST rewrite its provenance entry. Otherwise, at the next update, the refreshed file no longer
+      matches the recorded base, gets classified "user-modified", and is **never refreshed again**. Today
+      `reseedProvenance` only covers the `copied` bucket (`scripts/update-engine.mjs` step 7); refreshed
+      skills must be folded in. **A test must lock this** (refresh twice in a row, second run is a clean
+      no-op, not a "user-modified" verdict).
+- [ ] **T2 — Locale, or we re-anglicize French brains.** 8 of 9 shipped skills have a French source under
+      `templates/fr/.claude/skills/<name>/SKILL.md`. Refreshing from the repo root would replace a FR
+      brain's skills with EN ones. This is the exact trap that kept `CLAUDE.engine.md` out of `replace`
+      (see the Gate 1 refinement above). The machinery exists but points the other way:
+      `engine-copy-select.mjs` **excludes** locale-owned paths from the copy; here we must instead
+      **resolve the source per locale**. The brain records its locale (`scripts/lib/demo-locale.mjs`).
+      `switch` and `local-mirror` have no FR source today: decide whether that is a gap to fix or a
+      deliberate EN-only surface.
+
+### Tracking
+
+- [ ] **Step 1 — Pure core: the refresh verdict** (TDD, injected fs, no side effects). Given the installed
+      file, the recorded provenance base and the candidate new content → `refresh` / `preserve` /
+      `absent-install`. Triangulate: no base recorded (pre-provenance brain), base recorded but file
+      missing, identical content already (no-op), CRLF/LF drift.
+- [ ] **Step 2 — Locale-aware source resolution** (T2). Pure function: brain locale + skill name +
+      source tree → the file to deliver. Test EN and FR, and the no-FR-source case.
+- [ ] **Step 3 — Wire into `reconcileBrain`** behind the `sourceDir !== brainDir` guard. Assert by test
+      that a SessionStart-shaped call (`sourceDir === brainDir`) refreshes **nothing**.
+- [ ] **Step 4 — Provenance re-seed for refreshed files** (T1), with the refresh-twice test.
+- [ ] **Step 5 — Report what happened**, in the `update-engine` summary: which skills were refreshed,
+      which were **preserved because customized** (naming the `.new` file). Deterministic prose (ADR 0009),
+      unit-tested, relayed verbatim by the skill.
+- [ ] **Step 6 — Pre-v3.3.0 tail:** decide bottle vs documented 2-cycle, then implement the choice.
+- [ ] **Step 7 — ADR:** amend **0026** (the reconciler gains a conditional, provenance-gated overwrite,
+      scoped to explicit updates) and cross-note **0025** (its "out of scope, belongs to a future 3-way
+      merge" consequence is now partially closed). Keep the `Scope:` field per `CONVENTIONS.md`.
+- [ ] **Step 8 — QA on fixtures** reproduced from real release tags (v3.2.2 / v3.6.0 / v3.6.2), with
+      synthetic personal edits. Never use real deployed brains' content. Verify the `4e43e70` case
+      end-to-end: a v3.6.0 fixture must end up with the v3.6.2 `switch` skill.
+- [ ] **Step 9 — Docs:** SETUP / the `update-engine` skill wording ("your customized skills are never
+      overwritten; you are told when a newer version is available").
+
+### Side-finding (2026-07-27) — the schema-bump warning was never wired
+
+Independent of the above, found while auditing the fleet path. **Do NOT fix it inside increment 2.5**
+(bumping the manifest triggers a fleet-wide reindex; keep that as its own deliberate change).
+
+- `rag/src/lib/vector-store.ts:63` has `INDEX_SCHEMA_VERSION = 2` (moved by the universes commit
+  `3d85060`), but `engine-manifest.json` still declares `"indexSchemaVersion": 1`.
+- `scripts/lib/reindex-trigger.mjs:15` compares those two manifests → `update-engine` **neither reindexes
+  nor warns**, contrary to what ADR 0034's Consequences and the ROADMAP invariant both claim.
+- **Not a corruption, and not silent:** brains whose index was stamped `1` (i.e. indexed under v3.0.0 →
+  v3.5.x) get `staleSchemaMessage()` on their **first search** after upgrading, and the forced full
+  re-encode restamps correctly. An index predating schema versioning (stamp `null`) is grandfathered.
+  The SQLite side is clean too: `applySchema` adds `documents.universe` out of band with
+  `NOT NULL DEFAULT 'default'`, so an old index never errors.
+- [ ] Decide: bump the manifest to `2` (proactive, one fleet-wide reindex, honest warning up front) vs
+      leave the runtime gate to handle it (status quo, surprise at first search). Then align ADR 0034's
+      Consequences and the ROADMAP invariant with whatever is true.
 
 ## Next steps (post-demo)
 

--- a/maintainers/plans/prospective/universes-profiles-lifecycle-action.md
+++ b/maintainers/plans/prospective/universes-profiles-lifecycle-action.md
@@ -5,10 +5,14 @@
 > `universes-progressive-disclosure-action.md` (shipped). This is the next small increment on
 > universes.
 >
-> **Handoff note (why this file exists):** it was written by Opus 4.8 at the end of an exploration
-> session to carry the full context forward to Opus 5 (pointers, not copies). Opus 5: read the
-> "Context carried over" section first, then resolve the three open decisions WITH Thomas, then work
-> the Tracking list from the first unchecked `- [ ]`.
+> **Handoff note (why this file exists):** written by Opus 4.8 at the end of an exploration session to
+> carry context forward across a model switch (pointers, not copies).
+>
+> ⛔ **BLOCKED — do NOT start coding this plan yet (decided 2026-07-27).** It is **ROADMAP Gate 2.6**,
+> and it **depends on Gate 2.5** (`engine-managed-file-merge-strategy.md` → §"Increment 2.5"). Reason
+> below in §"Fleet constraints" (F1): this plan's user-facing surface is the `/switch` skill, and an
+> already-installed skill is **never** updated today, so shipping it first would deliver the feature to
+> nobody but fresh installs. Go work Gate 2.5 first; come back here when it is green.
 
 ## Goal (Thomas' request, verbatim intent)
 
@@ -61,83 +65,192 @@
   entry and the active pointer are NOT self-healing (orphan risk). => a real `delete-universe` script
   must also prune the registry, reset the pointer, and trigger a reindex.
 
-## Open decisions — RESOLVE WITH THOMAS before coding
+## Design review (2026-07-27, Opus 5) — what changed
 
-- [ ] **D1 — Where does a universe "profile" live?**
-      **Recommendation: as a Markdown note in the vault**, e.g. `vault/<slug>/_universe.md` for a
-      created universe (stamped `universe: <slug>` so it surfaces when that universe is active), and
-      `vault/_universe.md` for the default one. Rationale: versioned, editable in Obsidian, and
-      **indexed by the RAG** so the universe description becomes retrievable grounding context.
-      Structured frontmatter (`displayName`, `kind: employer|client|project|personal`, `people`,
-      `role`, `period`) + free-text body. Fits "everything is a note" + "pointers not copies".
-      Alternative (rejected unless Thomas prefers): grow `universes.json` entries from strings to
-      objects — but that is a shape migration touching every pure fn + test, and the data would not
-      be RAG-searchable. Decision needed: note-based (recommended) vs registry-based vs both.
+The plan was reviewed against the actual code before any implementation. Four corrections, kept here so
+they are not re-derived:
+
+- [x] **The plan optimized the wrong axis on D1.** It asked *where the profile is stored* but never *who
+      reads it, and when*. A profile is **ambient** context ("here you are Head of Eng, your people are X
+      and Y"). Indexed-only, it surfaces on *"what is Acme?"* and **not** on *"prepare my 1-1 with
+      Jean-Kevin"*, i.e. precisely when it was needed. → **D1 resolved below: note AND deterministic
+      injection.** The channel already exists (`scripts/session-universe.mjs` emits `additionalContext`
+      past the gate) and is refreshed on the fleet (a `replace` glob).
+- [x] **`_universe.md` is a bad name and would be flagged by the brain's own linter.** (a) The `_`
+      prefix means "not a note" here: `document-scanner.ts:32` excludes `_template.md` **by name**.
+      (b) A vault-root note matches no `TYPE_BY_PREFIX` entry (`frontmatter-parser.ts:25`) → `type:
+      "other"`. (c) `wiki-lint.mjs` would flag it **orphan forever** (nothing links to it, and the root
+      is in no exclusion zone) and **frontmatter-incomplete** (`type/created/updated/tags` required,
+      `wiki-lint.mjs:101`). (d) Giving it `type: topic` to dodge (b) makes it an *entity page* subject
+      to the **90-day stale rule**. → Use `universe.md` (no underscore) with an **explicit `type:
+      universe`** in frontmatter (`detectType` prefers `fm.type`, so the folder problem disappears),
+      plus **one orphan-exclusion line** in `wiki-lint.mjs`. Non-entity type → no stale rule.
+- [x] **A latent bug class that rename/delete would make reachable: the orphan active pointer.**
+      Neither reader validates the pointer against the registry (`scripts/lib/universes.mjs:203`,
+      `rag/src/lib/active-universe.ts:26`). The pointer is **per-machine and gitignored**; the registry
+      is **committed**. So: rename `acme` → `acme-corp` on machine A, commit, pull on machine B whose
+      pointer still says `acme` → the engine filters `WHERE universe='acme'` → **zero hits from that
+      universe, silently, with no error**. Same after a delete. → **Step 0 below is now a prerequisite
+      of Steps 3 and 4**, not an afterthought.
+- [x] **The "dangerous delete" framing was miscalibrated.** The vault is a git repo with auto-commit, so
+      `rm -rf vault/<slug>` + commit is **recoverable by git**. The real risks are: deleting the wrong
+      thing, leaving index/registry/pointer inconsistent, and dangling `[[links]]` from surviving default
+      notes (which `lint-vault` will report, and that is healthy). Also: the failure mode of "hidden and
+      documented only" is that someone improvises `rm -rf` by hand and orphans the registry. → Keep the
+      guarded script + doc, but `/switch` must **know it exists** and point at the procedure.
+
+## Fleet constraints (2026-07-27) — verified against the update path, do not re-derive
+
+Nothing in this plan can break an installed brain (the vault is in `SACRED_TREES`, so `update-engine`
+can never write a note; the universes v1 SQLite migration is already handled out of band by
+`applySchema`). The real risks are all **"the feature never arrives"**:
+
+- [ ] **F1 — A skill already installed is NEVER updated.** By design (ADR 0025/0026), install-if-absent
+      at the **directory** level in all three paths (`engine-apply-plan.mjs:60`, `staged-skills.mjs:29`,
+      the SessionStart self-heal). So enriching `.claude/skills/switch/SKILL.md` reaches **no existing
+      brain**, while the core (`scripts/lib/**`, a `replace` glob) **is** refreshed → core/skill drift.
+      **→ This is why the plan is blocked on ROADMAP Gate 2.5.** Once 2.5 ships, the answer is simply
+      "enrich `/switch`", and the workaround considered here (ship a new skill name via `engine-skills/`
+      staging, which IS delivered because absent) becomes unnecessary.
+- [ ] **F2 — A new top-level script must be added to `engine-manifest.json` by hand.** The `replace`
+      list enumerates `scripts/*.mjs` **one by one**; only `scripts/lib/**` is a glob. A forgotten
+      `scripts/delete-universe.mjs` would reach nobody, and **no test catches it**
+      (`engine-manifest-integrity.test.mjs` guards the reverse direction plus SessionStart hooks).
+      Add a checkbox per new script, and consider extending that guard.
+- [ ] **F3 — Core/skill compatibility contract.** The core is refreshed on the fleet while the OLD
+      `switch/SKILL.md` stays in place and **relays the core's output verbatim**. So: **add verbs only**;
+      never change the semantics or the message format of an existing verb. Otherwise an old skill relays
+      incoherent text.
+- [ ] **F4 — No index schema bump.** A profile is a note, not a column. Keep it that way: bumping
+      `indexSchemaVersion` would force a fleet-wide reindex. (Unrelated pre-existing side-finding about
+      that field: see `engine-managed-file-merge-strategy.md` → §"Side-finding".)
+
+## Open decisions
+
+- [x] **D1 — Where does a universe "profile" live? RESOLVED 2026-07-27 (Thomas): note + injection.**
+      A Markdown note in the vault, **and** a short digest injected deterministically.
+      - **Storage:** `vault/<slug>/universe.md` for a created universe (stamped `universe: <slug>`),
+        `vault/universe.md` for the default one. Explicit `type: universe` frontmatter, plus
+        `displayName`, `kind: employer|client|project|personal`, `role`, `period`, `people`, and the
+        accounts each native connector uses in this universe. Free-text body. Versioned, editable in
+        Obsidian, indexed by the RAG.
+      - **Consumption:** a **short digest** (hard cap, target 10-15 lines) injected at SessionStart and
+        on `/switch`, through the existing `session-universe.mjs` channel, past the progressive-disclosure
+        gate. The cap is a design constraint, not a nicety: this rides in every session.
+      - **Rejected:** growing `universes.json` entries from strings to objects (shape migration across
+        every pure fn + test, and not RAG-searchable); and injection-only with no note (not editable,
+        not versioned, against "everything is a note").
+      - [ ] Bonus unlocked by this: `nativeConnectorsReminder` (`universes.mjs:155`) currently emits a
+            **generic** line. With a profile it can name the actual accounts ("acme uses the acme Slack
+            workspace"). Cheap, and it makes the reminder actionable.
+      - [ ] Boundary to state explicitly in the ADR: **constitution vs profile.** The constitution says
+            who the owner is and how the brain behaves (sacred surface, untouched per ADR 0034); the
+            profile says what **this sphere** is. Without that line, the default universe's profile and
+            the `CLAUDE.md` owner section will drift and contradict each other.
 - [ ] **D2 — Where/how are the profile questions triggered at INSTALL for the default universe?**
-      Options: (a) light optional question in the installer flow (risks bloating an already heavy
-      installer); (b) seed an empty/stub `_universe.md` at install and let an early-session opt-in
-      nudge offer to fill it; (c) pure backfill (no install change). Recommendation: (b) or (c) to
-      keep the installer lean. Decision needed.
-- [ ] **D3 — Delete UX (must stay "not one-click").**
-      Recommendation: NO easy `/switch delete`. Provide `scripts/delete-universe.mjs <slug>` guarded
-      by an explicit confirmation (e.g. must retype the slug, or `--yes-delete <slug>`), and
-      **document the procedure** in SETUP.md (or a maintainers doc). It refuses `default`, does
-      `rm -rf vault/<slug>/`, prunes the registry, resets the active pointer to `default` if needed,
-      then reindexes. Decision needed: script + doc only (recommended) vs a guarded skill command.
+      **STILL OPEN.** Reframed 2026-07-27: as originally worded this decision **contradicts ADR 0034**.
+      At install there is exactly ONE universe, and progressive disclosure says the word "universe" must
+      stay **invisible** until a second one exists. The *value* Thomas wants (the brain knows his context
+      from day one) is legitimate; only the label is wrong.
+      - **(a) First session / on demand (recommended).** Installer untouched. One skippable offer in an
+        early session, plus the command any time. Needs a **"do not ask again" marker**, else the nudge
+        returns every session. Also the only option that reaches **existing** brains.
+      - **(b) At install, phrased as "your context", never "universe".** Keeps day-one value and respects
+        ADR 0034, but adds questions to an already heavy installer and only ever helps **future** installs.
+      - **(c) At install, phrased as "universe".** Rejected: frontally contradicts progressive disclosure.
+- [ ] **D3 — Delete UX (must stay "not one-click"). Near-settled, confirm the last point.**
+      NO easy `/switch delete`. Provide `scripts/delete-universe.mjs <slug>` (add it to the manifest, cf.
+      F2) refusing `default`, requiring the slug to be retyped, **printing how many notes will go before
+      confirming**, then: `rm -rf vault/<slug>/`, prune the registry, reset the pointer if needed, reindex.
+      Document the procedure in SETUP.md, **including the git recovery command** (the deletion is
+      committed, so git is the undo).
+      - [ ] Confirm the 2026-07-27 addition: `/switch` (or its successor surface) must **know the
+            procedure exists** and point at it when asked to delete, so nobody improvises a raw `rm -rf`
+            and orphans the registry. "Hidden" must not mean "undiscoverable".
+- [ ] **D4 — Rename scope (NEW, opened 2026-07-27). Decision needed.**
+      Rename is the **riskiest** item of this plan for the **rarest** use (you name a client once): it
+      moves the whole subtree, rewrites `universe:` frontmatter in **every** note under it, re-embeds the
+      universe (paths change), produces a large git diff, and is exposed to the orphan-pointer bug (Step 0).
+      - **(a) Display name + slug-only-while-empty (recommended).** Renaming changes the profile's
+        `displayName`; the slug (folder) only moves while the universe has no notes yet. Zero frontmatter
+        rewrite, zero re-embedding, tiny diff. Cost: the folder keeps its old name in Obsidian.
+      - **(b) Full rename.** Visually coherent, at the cost above.
+      - **(c) Defer rename entirely**, ship profile + delete first.
 
 ## Tracking
 
-- [ ] **Step 0 — Resolve open decisions D1/D2/D3 with Thomas** (blocks the rest).
-- [ ] **Step 1 — Universe profile: data + write core** (pure, TDD, tested).
-- [ ] **Step 2 — Universe profile: capture questions (conversational triggers)**.
-- [ ] **Step 3 — Rename a universe** (core + skill).
-- [ ] **Step 4 — Delete a universe** (guarded script + documentation).
-- [ ] **Step 5 — Docs + ADR update** (SETUP, switch SKILL.md, ADR 0034 addendum or a new ADR).
-- [ ] **Step 6 — Fleet / migration note** (existing brains: profiles are opt-in backfill, no forced reindex beyond what rename/delete need).
+> Order revised 2026-07-27. **Prerequisite: ROADMAP Gate 2.5 is green** (see the blocked note at the
+> top). Then work from the first unchecked box below.
 
-### Step 1 — Universe profile: data + write core
-- [ ] Decide the profile note path + frontmatter schema (per D1).
+- [x] **Step -1 — Design review + fleet audit** _(2026-07-27 · this commit)_ → §"Design review",
+      §"Fleet constraints", D1 resolved, D4 opened.
+- [ ] **Step 0 — Self-heal the active-universe pointer** (prerequisite of Steps 3 and 4, small, testable).
+  - [ ] Pure core: a pointer naming a universe absent from the registry is invalid → fall back to
+        `default`. TDD, injected fs.
+  - [ ] Surface it through `session-self-heal.mjs` (already a SessionStart hook): repair, **say it in one
+        line**, fail-open, always exit 0. Never silently wrong, never blocking.
+  - [ ] Test the cross-machine scenario from §"Design review" (committed registry vs gitignored pointer).
+- [ ] **Step 1 — Resolve the remaining decisions D2 / D3-confirm / D4 with Thomas** (blocks Steps 3-5,
+      not Step 2).
+- [ ] **Step 2 — Universe profile: data + write core** (pure, TDD, tested).
+- [ ] **Step 3 — Universe profile: capture + inject** (conversational triggers + the SessionStart digest).
+- [ ] **Step 4 — Delete a universe** (guarded script + documentation) — per D3.
+- [ ] **Step 5 — Rename a universe** — per D4, scope depends on that decision. Last, deliberately.
+- [ ] **Step 6 — Docs + ADR update** (SETUP, the `/switch` surface, ADR 0034 addendum or a new ADR).
+- [ ] **Step 7 — Fleet / migration note** (profiles are opt-in backfill; re-check F1-F4 before shipping).
+
+### Step 2 — Universe profile: data + write core
+- [ ] Profile note path + frontmatter schema per **D1 (resolved)**: `vault/<slug>/universe.md` (and
+      `vault/universe.md` for default), explicit `type: universe`. **No leading underscore**, and add the
+      path to `wiki-lint.mjs`'s orphan exclusions (see §"Design review" for why both are required).
 - [ ] Add pure functions in `scripts/lib/` (new module, e.g. `universe-profile.mjs`): build the
       profile note content from answers, resolve its path from a slug, detect "has no profile yet".
       Injected fs, no side effects in the pure layer (ADR 0009). TDD, one baby-step at a time.
+- [ ] The **digest renderer** is part of this core, not an afterthought: profile → the short block that
+      gets injected. Enforce the length cap **in the pure function**, with a test.
 - [ ] Wire a CLI entry (e.g. `scripts/set-universe-profile.mjs`) that writes the note and triggers a
-      reindex so the profile becomes searchable.
+      reindex so the profile becomes searchable. **Declare it in `engine-manifest.json`** (cf. F2).
 - [ ] Tests first (fail-first), assertions on the whole object/content, triangulate slug edge cases.
 
-### Step 2 — Universe profile: capture questions (conversational triggers)
-- [ ] In `.claude/skills/switch/SKILL.md`: after a `create`, offer (opt-in, skippable) to capture the
-      new universe's profile via a few questions, then call the Step-1 CLI. Relay deterministic core
-      messages verbatim (ADR 0009 — skill holds no logic).
-- [ ] Backfill path: when a universe has no profile note, the `/switch` menu can flag it and offer to
-      fill it (covers Thomas' default / memory-palace case).
-- [ ] Install path per D2 (only if D2 chooses an installer change).
-
-### Step 3 — Rename a universe
-- [ ] Pure core in `universes.mjs` (or a sibling): validate new slug (non-empty, not `default`, not
-      already existing), compute the registry transform (remove old, add new).
-- [ ] `scripts/rename-universe.mjs <old> <new>`: move `vault/<old>/` -> `vault/<new>/`, rewrite
-      `universe:` frontmatter in every note under it (old -> new), update the registry, update the
-      active pointer if it was `old`, then reindex. Refuse renaming `default`.
-- [ ] Expose via `/switch rename <old> <new>` (+ natural language) in the skill. TDD on the core;
-      the fs-moving CLI gets a focused test with injected fs.
+### Step 3 — Universe profile: capture + inject
+- [ ] **Inject** the digest via `scripts/session-universe.mjs` (already a `replace` glob, so it reaches
+      the fleet) and on switch, past the progressive-disclosure gate. Fail-open, never blocking.
+- [ ] After a `create`, offer (opt-in, skippable) to capture the new universe's profile via a few
+      questions, then call the Step-2 CLI. Relay deterministic core messages verbatim (ADR 0009).
+- [ ] Backfill path: when a universe has no profile note, flag it once and offer to fill it (covers
+      Thomas' default / memory-palace case). **Needs a "do not ask again" marker** (cf. D2).
+- [ ] Install path per D2, only if D2 picks an installer change.
+- [ ] Draft the actual questions (the plan never did): displayName, kind, role, period, key people, key
+      topics, **and which accounts each native connector uses here** (feeds the D1 bonus).
 
 ### Step 4 — Delete a universe (guarded)
 - [ ] Pure core: validate slug is a real created universe (not `default`), compute the pruned
       registry, decide whether the active pointer must fall back to `default`.
-- [ ] `scripts/delete-universe.mjs <slug>` with an explicit confirmation gate (per D3): `rm -rf`
-      `vault/<slug>/`, prune registry, reset pointer if needed, reindex.
-- [ ] Document the procedure (per D3) — this is the "documented, not one-click" requirement.
+- [ ] `scripts/delete-universe.mjs <slug>` with an explicit confirmation gate (per D3): print the note
+      count first, retype-the-slug confirmation, `rm -rf vault/<slug>/`, prune registry, reset pointer if
+      needed, reindex. **Declare it in `engine-manifest.json`** (cf. F2).
+- [ ] Document the procedure (per D3), **including the git recovery command**. This is the "documented,
+      not one-click" requirement.
+- [ ] Make the procedure discoverable from `/switch` without making it easy (cf. D3 sub-checkbox).
 
-### Step 5 — Docs + ADR
-- [ ] Update `.claude/skills/switch/SKILL.md` ("What it does NOT do" currently says delete/rename are
-      not built — update once they are).
+### Step 5 — Rename a universe (scope per D4)
+- [ ] Pure core: validate new name/slug (non-empty, not `default`, not already existing), compute the
+      registry transform.
+- [ ] Implement the scope D4 selected. If (b) full rename: move `vault/<old>/` to `vault/<new>/`, rewrite
+      `universe:` frontmatter in every note under it, update the registry, update the active pointer if it
+      was `old`, then reindex. Refuse renaming `default`. **Declare the script in the manifest** (cf. F2).
+- [ ] TDD on the core; the fs-moving CLI gets a focused test with injected fs.
+
+### Step 6 — Docs + ADR
+- [ ] Update the `/switch` surface ("What it does NOT do" currently says delete/rename are not built).
+      Respect **F3**: add verbs, never change existing verbs' semantics or message format.
 - [ ] SETUP.md: "How to rename / delete a universe" + the RAG self-heal behaviour on deletion.
 - [ ] ADR: either an addendum to ADR 0034 or a small new ADR for profiles + lifecycle (keep the
-      `Scope:` field per repo convention).
+      `Scope:` field per repo convention). State the **constitution vs profile boundary** (cf. D1).
 
-### Step 6 — Fleet / migration
-- [ ] Confirm no forced global reindex for existing brains beyond what rename/delete inherently need;
-      profiles are pure opt-in backfill.
+### Step 7 — Fleet / migration
+- [ ] Re-check **F1-F4** before shipping. Confirm no forced global reindex for existing brains beyond
+      what delete/rename inherently need; profiles are pure opt-in backfill.
 
 ## Conventions reminder (repo rules)
 - Artifacts in English (this file, code, commits, PR). TDD baby-steps, green-only commits. Deterministic

--- a/maintainers/plans/prospective/universes-profiles-lifecycle-action.md
+++ b/maintainers/plans/prospective/universes-profiles-lifecycle-action.md
@@ -1,0 +1,145 @@
+# Universes v2 — per-universe profiles + lifecycle (rename / delete)
+
+> **Status:** DRAFT / prospective. Branch: `feat/universe-profiles-lifecycle`.
+> **Follows:** ADR 0034 (universes as a soft retrieval scope) and its plan
+> `universes-progressive-disclosure-action.md` (shipped). This is the next small increment on
+> universes.
+>
+> **Handoff note (why this file exists):** it was written by Opus 4.8 at the end of an exploration
+> session to carry the full context forward to Opus 5 (pointers, not copies). Opus 5: read the
+> "Context carried over" section first, then resolve the three open decisions WITH Thomas, then work
+> the Tracking list from the first unchecked `- [ ]`.
+
+## Goal (Thomas' request, verbatim intent)
+
+1. Kenjaku should **ask a few questions about each universe** to learn what it is (a "profile").
+   Triggers wanted:
+   - at the very first **install**, for the **default** universe;
+   - when **creating** a universe (`/switch create ...`);
+   - as a **backfill** when a universe already exists but has no info yet (e.g. Thomas' current
+     memory palace / the default universe today).
+2. Ability to **rename** a universe.
+3. Ability to **delete** a universe, but deletion must be **dangerous / not one-click**: a
+   **documented** procedure somewhere, not an easy skill command.
+4. Answered already (see below): does deleting a universe folder make the RAG update? Yes, on the
+   next reindex.
+
+## Context carried over (from the exploration — do not re-discover)
+
+### Current universe data model (ADR 0034, already shipped)
+- A universe is a **soft, engine-enforced retrieval scope** over ONE shared vault + ONE shared index.
+  Not an isolation wall.
+- **Active pointer (per-machine, gitignored):** `.vault-rag/active-universe` (plain text, one line).
+  Absent/blank reads as `default`.
+- **Registry (committed):** `.vault-rag/universes.json` = `{ "universes": ["slug-a", "slug-b"] }`.
+  **Names only, today.** The implicit `default` is never stored (its absence IS "default").
+- **File layout:** default universe lives at the **vault root** (`daily/`, `topics/`, ...); a created
+  universe lives in its own subtree `vault/<slug>/daily/`, `vault/<slug>/topics/`, ...
+- **Frontmatter:** notes carry `universe: <slug>` **only when non-default** (absence = default).
+- **DB:** `documents.universe TEXT NOT NULL DEFAULT 'default'` (schema v2). Search applies
+  `WHERE d.universe = <active> OR d.universe = 'default'` unless `allUniverses=true`.
+- **Progressive disclosure gate:** the feature stays invisible until a **2nd** universe exists
+  (registry length >= 1). Below the gate, the brain behaves exactly as a single-universe brain.
+
+### Key source locations
+- Skill: `.claude/skills/switch/SKILL.md` (thin conversational driver).
+- Deterministic core: `scripts/lib/universes.mjs` (pure logic + injected fs, tested in
+  `scripts/lib/universes.test.mjs`) and CLI `scripts/set-active-universe.mjs`.
+- Engine scope: `rag/src/lib/vector-store.ts` (`searchSimilarIn`, and `removeDeletedDocs` ~L456-475).
+- Frontmatter: `rag/src/lib/frontmatter-parser.ts` (extracts `universe`).
+- Scanner: `rag/src/lib/document-scanner.ts` (walks whole vault; excludes `.obsidian/` and exactly
+  `_template.md`). NB: a `_universe.md` file would NOT be excluded, so it would be indexed.
+- Filing: `scripts/file-back-note.mjs` reads active universe, stamps frontmatter, files under
+  `vault/<slug>/...`.
+- Reindex triggers: MCP server startup auto-reindex + live watcher on every vault write + manual
+  `cd rag && npm run reindex` (`rag/src/index.ts`).
+
+### The RAG-deletion answer (Thomas asked this directly)
+- `removeDeletedDocs()` deletes every indexed doc whose path is no longer on disk (chunks +
+  documents), no tombstones. So `rm -rf vault/<slug>/` + reindex = clean index.
+- BUT: (a) it only happens on the next reindex event, not at the instant of `rm`; (b) the registry
+  entry and the active pointer are NOT self-healing (orphan risk). => a real `delete-universe` script
+  must also prune the registry, reset the pointer, and trigger a reindex.
+
+## Open decisions — RESOLVE WITH THOMAS before coding
+
+- [ ] **D1 — Where does a universe "profile" live?**
+      **Recommendation: as a Markdown note in the vault**, e.g. `vault/<slug>/_universe.md` for a
+      created universe (stamped `universe: <slug>` so it surfaces when that universe is active), and
+      `vault/_universe.md` for the default one. Rationale: versioned, editable in Obsidian, and
+      **indexed by the RAG** so the universe description becomes retrievable grounding context.
+      Structured frontmatter (`displayName`, `kind: employer|client|project|personal`, `people`,
+      `role`, `period`) + free-text body. Fits "everything is a note" + "pointers not copies".
+      Alternative (rejected unless Thomas prefers): grow `universes.json` entries from strings to
+      objects — but that is a shape migration touching every pure fn + test, and the data would not
+      be RAG-searchable. Decision needed: note-based (recommended) vs registry-based vs both.
+- [ ] **D2 — Where/how are the profile questions triggered at INSTALL for the default universe?**
+      Options: (a) light optional question in the installer flow (risks bloating an already heavy
+      installer); (b) seed an empty/stub `_universe.md` at install and let an early-session opt-in
+      nudge offer to fill it; (c) pure backfill (no install change). Recommendation: (b) or (c) to
+      keep the installer lean. Decision needed.
+- [ ] **D3 — Delete UX (must stay "not one-click").**
+      Recommendation: NO easy `/switch delete`. Provide `scripts/delete-universe.mjs <slug>` guarded
+      by an explicit confirmation (e.g. must retype the slug, or `--yes-delete <slug>`), and
+      **document the procedure** in SETUP.md (or a maintainers doc). It refuses `default`, does
+      `rm -rf vault/<slug>/`, prunes the registry, resets the active pointer to `default` if needed,
+      then reindexes. Decision needed: script + doc only (recommended) vs a guarded skill command.
+
+## Tracking
+
+- [ ] **Step 0 — Resolve open decisions D1/D2/D3 with Thomas** (blocks the rest).
+- [ ] **Step 1 — Universe profile: data + write core** (pure, TDD, tested).
+- [ ] **Step 2 — Universe profile: capture questions (conversational triggers)**.
+- [ ] **Step 3 — Rename a universe** (core + skill).
+- [ ] **Step 4 — Delete a universe** (guarded script + documentation).
+- [ ] **Step 5 — Docs + ADR update** (SETUP, switch SKILL.md, ADR 0034 addendum or a new ADR).
+- [ ] **Step 6 — Fleet / migration note** (existing brains: profiles are opt-in backfill, no forced reindex beyond what rename/delete need).
+
+### Step 1 — Universe profile: data + write core
+- [ ] Decide the profile note path + frontmatter schema (per D1).
+- [ ] Add pure functions in `scripts/lib/` (new module, e.g. `universe-profile.mjs`): build the
+      profile note content from answers, resolve its path from a slug, detect "has no profile yet".
+      Injected fs, no side effects in the pure layer (ADR 0009). TDD, one baby-step at a time.
+- [ ] Wire a CLI entry (e.g. `scripts/set-universe-profile.mjs`) that writes the note and triggers a
+      reindex so the profile becomes searchable.
+- [ ] Tests first (fail-first), assertions on the whole object/content, triangulate slug edge cases.
+
+### Step 2 — Universe profile: capture questions (conversational triggers)
+- [ ] In `.claude/skills/switch/SKILL.md`: after a `create`, offer (opt-in, skippable) to capture the
+      new universe's profile via a few questions, then call the Step-1 CLI. Relay deterministic core
+      messages verbatim (ADR 0009 — skill holds no logic).
+- [ ] Backfill path: when a universe has no profile note, the `/switch` menu can flag it and offer to
+      fill it (covers Thomas' default / memory-palace case).
+- [ ] Install path per D2 (only if D2 chooses an installer change).
+
+### Step 3 — Rename a universe
+- [ ] Pure core in `universes.mjs` (or a sibling): validate new slug (non-empty, not `default`, not
+      already existing), compute the registry transform (remove old, add new).
+- [ ] `scripts/rename-universe.mjs <old> <new>`: move `vault/<old>/` -> `vault/<new>/`, rewrite
+      `universe:` frontmatter in every note under it (old -> new), update the registry, update the
+      active pointer if it was `old`, then reindex. Refuse renaming `default`.
+- [ ] Expose via `/switch rename <old> <new>` (+ natural language) in the skill. TDD on the core;
+      the fs-moving CLI gets a focused test with injected fs.
+
+### Step 4 — Delete a universe (guarded)
+- [ ] Pure core: validate slug is a real created universe (not `default`), compute the pruned
+      registry, decide whether the active pointer must fall back to `default`.
+- [ ] `scripts/delete-universe.mjs <slug>` with an explicit confirmation gate (per D3): `rm -rf`
+      `vault/<slug>/`, prune registry, reset pointer if needed, reindex.
+- [ ] Document the procedure (per D3) — this is the "documented, not one-click" requirement.
+
+### Step 5 — Docs + ADR
+- [ ] Update `.claude/skills/switch/SKILL.md` ("What it does NOT do" currently says delete/rename are
+      not built — update once they are).
+- [ ] SETUP.md: "How to rename / delete a universe" + the RAG self-heal behaviour on deletion.
+- [ ] ADR: either an addendum to ADR 0034 or a small new ADR for profiles + lifecycle (keep the
+      `Scope:` field per repo convention).
+
+### Step 6 — Fleet / migration
+- [ ] Confirm no forced global reindex for existing brains beyond what rename/delete inherently need;
+      profiles are pure opt-in backfill.
+
+## Conventions reminder (repo rules)
+- Artifacts in English (this file, code, commits, PR). TDD baby-steps, green-only commits. Deterministic
+  core owns logic; skills are thin drivers (ADR 0009). Checkboxes on every step (this file). No em dashes.
+- When a step is done: check `- [x]` and note _(date · commit)_.

--- a/maintainers/qa/release-fixtures/v3.2.2/.claude/skills/import/SKILL.md
+++ b/maintainers/qa/release-fixtures/v3.2.2/.claude/skills/import/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: import
+description: "Imports / migrates the notes from a PREVIOUS second brain (or any external vault) into THIS brain — recover, transport, bring over, re-home, transfer your old notes / anciennes notes from another folder. Use when the user wants to import / importer, migrate / migrer, transport / transporter, recover / récupérer, or bring in the content of an old / previous second brain — e.g. 'importe mes anciennes notes depuis <chemin>' or 'migrate my old brain'. Safe + opt-in: shows a plan, confirms, copies the vault content only, never overwrites, skips demo notes, then reindexes."
+version: 1.0.0
+---
+
+# /import — Re-home a previous brain's notes into this one (opt-in, non-destructive)
+
+> Brain-side skill. It brings the **notes (and attachments)** of a *previous* second brain —
+> or any external Obsidian-style vault — **into this brain's `vault/`**, safely. It copies
+> only your **content**, never the old engine, `.git` or `.claude`.
+>
+> ⚠️ **This is a thin conversational driver.** All the real, testable work lives in the
+> deterministic core `scripts/import-brain.mjs` + `scripts/lib/import-vault.mjs` (ADR 0009/0019).
+> This skill only **asks for the source, shows the plan, confirms, runs the core, reindexes,
+> and reports** — it holds no logic of its own.
+
+## When to use it
+
+Load this whenever the user wants to bring in notes from elsewhere, in plain language and in
+any language — **no special vocabulary required**:
+
+- *"importe / migre / rapatrie / récupère mes anciennes notes depuis `<chemin>`"*
+- *"import / migrate / transport / recover my old (or previous) second brain"*
+- *"I had a brain before v3 — bring its notes over"*
+
+> 🧬 **Flavour, not a trigger (you never need to say it):** we nickname this the **Kenjaku**
+> move — *transplanting a mind into a new vessel*. It is pure lore for the README/prose. **A
+> user who has never heard of it must trigger the import with ordinary words** — and they do.
+
+## Golden rule — OPT-IN, confirm before any write
+
+The core's **plan** phase performs **zero writes**. Show the plan, then get an explicit **yes**
+before the **apply** phase copies anything. Importing other people's old notes into a brain is a
+conscious, accepted action.
+
+## What it touches vs NEVER touches
+
+| Imported (your content) | **NEVER touched** |
+| --- | --- |
+| the source vault's notes (`.md`) | the old engine (`rag/`, launchers, scripts) |
+| attachments (images/PDFs) travelling with them | the source's `.git`, `.claude`, `.obsidian`, dotfiles |
+| subfolder structure + accented names (preserved) | **your existing notes** — a name collision is **skipped**, never overwritten |
+|  | demo / example notes (`tags: [exemple]`) — left behind |
+|  | this brain's `.env`, `CLAUDE.md`, settings, skills |
+
+## Procedure
+
+### Step 1 — Get the source path (native picker first, copy-paste fallback)
+**Try the native folder picker first** — typing a path is a wall for non-dev users. From the
+**brain folder**, run:
+```bash
+node scripts/pick-folder.mjs "Choose the folder of your previous brain"
+```
+- **It prints a path (exit 0)** → use that path as `<source>` for Steps 2–3 (reuse it for both,
+  don't pop the dialog twice).
+- **It exits non-zero** (the user cancelled, or there's no GUI — headless / CI) → **fall back** to
+  asking the user to type / paste the folder of their **old brain**.
+
+The core accepts **either** a brain root (it resolves to `<root>/vault`) **or** a `vault/` folder
+directly.
+
+> ⚠️ **The footgun, say it plainly:** they want to point at their **old brain folder**, not copy
+> the whole folder by hand. The skill copies the *vault content only* — pointing at the brain root
+> is fine and safe.
+
+### Step 2 — Show the plan (no writes)
+From the **brain folder**, run:
+```bash
+node scripts/import-brain.mjs "<source>"
+```
+Relay the printed plan: how many notes/attachments would be imported, how many **collisions** (will
+be skipped, never overwritten), how many **example** notes skipped. Then ask for an explicit **yes**.
+
+### Step 3 — Apply (only after confirmation)
+```bash
+node scripts/import-brain.mjs "<source>" --apply
+```
+It copies the planned files into `vault/`, preserving subfolders, **never overwriting** a collision.
+
+### Step 4 — Reindex (so the imported notes are searchable)
+The new notes must be indexed before the RAG can find them. Incremental indexing is enough — we only
+**added** files:
+```bash
+npm run index --prefix rag
+```
+*(On a large vault the first pass can take a few minutes; nothing is lost — the notes are encoded.)*
+
+### Step 5 — Report (don't pretend)
+- **`exit 0`** → relay the summary (copied / skipped counts). Confirm their existing notes were left
+  untouched, and that demo notes did not travel.
+- **`exit 1`** → **relay the error as-is** (e.g. "source not found", "nothing to import — wrong
+  folder?", "cannot import a brain into itself"). **Never claim success when it failed.**
+
+## After the import — manual follow-ups (mention these)
+- **Constitution not merged (v1).** If the old brain had a personalised `CLAUDE.md`, this skill does
+  **not** auto-merge it. Offer to help fold any wanted personalisations in by hand.
+- **`.env` and connectors** belong to the *new* brain — they were set up at install; the import does
+  not touch them. If the old brain used different keys/connectors, wire them here separately.
+
+## Edge cases
+- **Source not found / empty** → the core fails loud ("is this the right folder?"); relay it.
+- **`source === dest`** (pointing at this same brain) → the core refuses; you can't import a brain
+  into itself.
+- **All collisions** (re-importing the same notes) → 0 copied, everything skipped; nothing overwritten.

--- a/maintainers/qa/release-fixtures/v3.2.2/engine-manifest.json
+++ b/maintainers/qa/release-fixtures/v3.2.2/engine-manifest.json
@@ -1,0 +1,48 @@
+{
+  "manifestVersion": 1,
+  "engineVersion": { "rag": "1.1.2", "local-mirror": "0.1.1", "constitutionTemplate": "1.0.0", "scripts": "1.0.0" },
+  "indexSchemaVersion": 1,
+  "regimes": {
+    "replace": [
+      "rag/src/**",
+      "rag/package.json",
+      "rag/package-lock.json",
+      "rag/tsconfig.json",
+      "local-mirror/src/**",
+      "local-mirror/package.json",
+      "local-mirror/package-lock.json",
+      "local-mirror/tsconfig.json",
+      "scripts/update-engine.mjs",
+      "scripts/import-brain.mjs",
+      "scripts/open-env.mjs",
+      "scripts/lib/**"
+    ],
+    "regenerate": [
+      "rag/launch.sh",
+      "rag/launch.cmd",
+      "local-mirror/launch.sh",
+      "local-mirror/launch.cmd",
+      "scripts/run-node.sh",
+      "scripts/run-node.cmd"
+    ],
+    "merge": [
+      "CLAUDE.md",
+      ".claude/settings.json",
+      ".claude/skills/coach/**",
+      ".claude/skills/sync/**",
+      ".claude/skills/sync-sources/**",
+      ".claude/skills/improve/**",
+      ".claude/skills/prepare-1-1/**",
+      ".claude/skills/tdd-discipline/**",
+      ".claude/skills/update-engine/**",
+      ".claude/skills/import/**",
+      ".claude/skills/local-mirror/**",
+      "scripts/auto-commit.mjs",
+      "scripts/auto-push.mjs",
+      "scripts/status-line.mjs",
+      "scripts/verify-rag.mjs"
+    ]
+  },
+  "engineMcpServers": ["vault-rag", "local-mirror"],
+  "provenance": {}
+}

--- a/maintainers/qa/release-fixtures/v3.6.0/.claude/skills/prepare-1-1/SKILL.md
+++ b/maintainers/qa/release-fixtures/v3.6.0/.claude/skills/prepare-1-1/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: prepare-1-1
+description: "Prepare a 1-1 with anyone, in both directions: with YOUR manager (the topics you want to raise, what has changed since last time) or with someone YOU manage (commitments made/delegated, operational topics, KPI review). Takes a name/alias, cross-references the person's profile, the last 1-1 and the delta of recent signals (via sync-sources, READ-ONLY). Meta skill: a structure that gives you ideas, to be refined to your own focus areas and KPIs (with /improve if needed)."
+version: 1.0.0
+---
+
+# /prepare-1-1 — Prepare a 1-1 (meta version)
+
+Produces a **briefing** scannable in 2 minutes before your next 1-1. This is a **meta skill**:
+it lays out a **structure** that gives you ideas; you then **refine** it to your own focus areas,
+your KPIs and the way you run your 1-1s (edit this file, or ask `/improve` to help you).
+
+## Parameter
+
+A **name or alias** of a person in `$ARGUMENTS` (e.g. `/prepare-1-1 jane`). Used to find
+`vault/people/<firstname-lastname>.md` (kebab-case, no accents) and the cache `vault/backlog/<name>.md`.
+If no profile matches, suggest the closest profiles from `vault/people/` and stop.
+
+## Absolute constraint
+
+**READ-ONLY.** Never send a message, email or reaction, never post anywhere.
+Produce only a local markdown file in the vault.
+
+## Step 0 — Direction of the 1-1 (determines the output structure)
+
+Two cases, depending on your relationship with the person (infer it from their role in `vault/people/<name>.md`;
+when in doubt, ask):
+
+- **A · 1-1 with YOUR manager** (you are the managee) → "**what I want to raise**" structure.
+- **B · 1-1 with someone YOU manage** (a report, or a peer you coach) → "**follow-up + operational + KPI**"
+  structure.
+
+## Step 1 — Collection (fan-out, READ-ONLY)
+
+In parallel ([`sync-sources`](../sync-sources/SKILL.md) architecture, ~500-token summaries):
+
+- **Backlog cache**: `vault/backlog/<name>.md` — open / recurring actions (a point raised
+  2+ times without closure is a priority).
+- **Last 1-1**: the note in `vault/meetings/` (or via your Calendar connector) — transcript read
+  by an isolated sub-agent (never raw transcript in the main context). Also note the
+  **next** 1-1 (date of the output file; otherwise today's date).
+- **Delta since the last 1-1**: messaging, email, shared meetings — depending on your connectors.
+
+## Step 2 — Writing the briefing
+
+Write to `vault/prep-1-1/YYYY-MM-DD-prep-1-1-<name>.md` (date of the next 1-1; create the folder
+if needed), according to the case detected in step 0.
+
+### Case A — 1-1 with your manager (you carry the topics)
+
+```markdown
+# Prep 1-1 — [First name] (my manager) — [date]
+
+## What I want to raise (Top 3)
+The topics not to miss, by impact. For each: where we stand, what I expect from them
+(decision, support, info, unblocking).
+1. **[Title]** — [1-line context] → I expect: [decision / support / arbitration]
+
+## Since last time
+What has moved and is worth reporting or sharing (progress, risks, signals). Enough to have
+"something to chew on" instead of arriving empty-handed.
+
+## Questions / requests
+What I want to clarify or obtain (priorities, resources, feedback on me).
+
+## My commitments in progress
+What I had committed to do — status kept / in progress / at risk.
+```
+
+### Case B — 1-1 with someone you manage (follow-up + operational + KPI)
+
+```markdown
+# Prep 1-1 — [First name] — [date]
+
+## Commitment follow-up
+- **What the other person committed to do** (since the last 1-1): status kept / in progress / not done.
+- **What I want to delegate to them** (new delegations, responsibilities).
+(Draws on the backlog `vault/backlog/<name>.md`, sorted by age.)
+
+## Important operational topics
+The 2-3 hot topics in the scope to address, with the concrete question to ask.
+
+## KPI review            # 🔧 TO REFINE: define YOUR metrics here
+Collection + review of the metrics that matter for you. Possible examples (replace with your
+own): DORA (lead time, deployment frequency, MTTR, change-fail rate), quality, delivery,
+satisfaction, capacity… For each KPI: value / trend / question to dig into.
+| KPI | Value / trend | Question |
+|---|---|---|
+| [your KPI] | [↑/↓/→] | [what you want to understand] |
+
+## Weak signals
+Tensions, frustrations, overload, dodged topics — with tact, no beating around the bush. (Omit if nothing.)
+
+## Recurring focus areas          # 🔧 TO REFINE: the 3-5 themes you track with each report
+| Focus area | Detected signal | Default question |
+|---|---|---|
+| [your focus area] | [signal or "none"] | [question] |
+
+## Checklist (before/during the 1-1)
+- [ ] …
+```
+
+In both cases, end with a collapsible **"Full context"** block (summary of the last 1-1,
+decisions, follow-up actions `| # | Action | Who | When | Status |`, verbatims, messaging/email/meeting
+activity with links, source quality).
+
+## Step 3 — Update the backlog
+In `vault/backlog/<name>.md`: **add** the new actions, **check off** those with proof
+of completion, **update** the `updated:` date. Append-only on facts already recorded.
+
+## Writing rules
+- English, direct and ultra-concise tone; bullet lists rather than paragraphs.
+- Do not make things up; flag a partial or low-quality source.
+- No empty section — omit it (except "KPI review" and "Recurring focus areas" in case B, to keep
+  as a reminder even when empty, since these are the sections you must make your own).
+- Never a bare URL: `[text](url)`. Backlinks `[[people/firstname-lastname]]` (never a first name alone).
+
+## Refining this skill (that's the point of a meta skill)
+The structure above is a **starting point**. Make it yours: replace the example KPIs with
+your own, add/remove recurring focus areas, adjust the sections to the type of 1-1 you run.
+You can do it by hand (edit this file) or ask **`/improve`** to assist you.
+
+## Success criterion
+In < 2 minutes of reading, you know what to address, why, with which opening question — and,
+on the manager side, where the commitments and the KPIs that matter stand.

--- a/maintainers/qa/release-fixtures/v3.6.0/.claude/skills/switch/SKILL.md
+++ b/maintainers/qa/release-fixtures/v3.6.0/.claude/skills/switch/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: switch
+description: "Switch the ACTIVE UNIVERSE of this brain, or create a new one (ADR 0034). A universe is a soft retrieval scope (e.g. successive employers, clients, spheres): when you work one universe, searches default to its notes plus your cross-cutting ones. Use when the user wants to switch / change / set the current universe / context / scope, list their universes, or create / add a new universe / context (e.g. 'switch to the acme universe', 'change de contexte', 'crée un univers Blue Team', 'in which universe am I?', 'liste mes univers'). This is invisible until a second universe exists. It does NOT touch notes and needs no reindex — it only re-points which universe is active."
+version: 1.0.0
+---
+
+# /switch — Change or create the active universe (opt-in, no reindex)
+
+> Brain-side skill. A **universe** (ADR 0034) is a **soft, engine-enforced retrieval scope** over
+> the one shared vault: while a universe is active, `search_vault` returns that universe's notes
+> **plus** your cross-cutting (default) notes, and nothing from the others, unless you explicitly
+> ask for "all universes". It is a **relevance** feature, never an isolation wall (a bug, Obsidian,
+> git or grep can cross it, and for a private brain that is fine).
+>
+> ⚠️ **This is a thin conversational driver.** All the real, testable logic lives in the
+> deterministic core `scripts/set-active-universe.mjs` + `scripts/lib/universes.mjs` (ADR 0009).
+> This skill only **reads the current state, runs that core, and reports** — it holds no logic and
+> makes no scope decision of its own (the engine reads the active pointer itself, per search).
+
+## When to use it
+
+Load this whenever the user wants to change context or manage universes, in plain language, any
+language:
+
+- *"switch to the acme universe"* · *"passe sur l'univers acme"* · *"change de contexte"*
+- *"create a universe Blue Team"* · *"crée un univers Blue Team"* · *"add a new context"*
+- *"which universe am I in?"* · *"dans quel univers je suis ?"* · *"liste mes univers"*
+
+> 🧭 **Progressive disclosure.** Below two universes there is nothing to manage: a brain with a
+> single (default) universe behaves exactly as today. Do **not** volunteer universes to a
+> single-universe user. But if they explicitly ask to create one, this skill is the way in.
+
+## Golden rules
+
+- **No writes to notes, no reindex.** Switching only re-points the active-universe pointer under
+  `<brain>/.vault-rag/`. The engine reads it live on the next search. Never offer a reindex here.
+- **The core is the single surface.** Natural language ("create a universe X") and `/switch X`
+  route to the **same** script, so there is never a diverging path (ADR 0009).
+- **Creating a universe is create-and-switch** (git `switch -c` ergonomics): register the name and
+  make it active in one move. The name is normalized to a safe kebab slug (e.g. "Blue Team" →
+  `blue-team`); the reserved name `default` cannot be created.
+
+## Procedure
+
+### Fast path — `/switch <name>` or "switch to <name>"
+
+Run, from the brain folder:
+```bash
+node scripts/set-active-universe.mjs "<name>"
+```
+- **exit 0** → relay the confirmation ("switched to '<name>'") and remind, in one line, that
+  searches now stay in that universe plus your cross-cutting notes (say *"search all universes"* to
+  span them).
+- **exit 1, "unknown universe"** → the name is not registered. Show the `available:` list the core
+  printed, and **offer to create it** (create-and-switch) or pick an existing one. Do not create
+  silently.
+
+### No-argument menu — `/switch` alone
+
+1. Read the state (no writes):
+   ```bash
+   node scripts/set-active-universe.mjs current   # the active universe
+   node scripts/set-active-universe.mjs list      # all universes, * marks the active one
+   ```
+2. Present the menu in chat: **remind** the current universe, **list** the available ones, and offer
+   - **switch** to one of them → fast path above,
+   - **➕ create a new universe** (create-and-switch) → `create` below,
+   - **✖️ cancel** (stay put) → do nothing.
+
+### Create a new universe — "create a universe <name>"
+
+Run:
+```bash
+node scripts/set-active-universe.mjs create "<name>"
+```
+- **exit 0** → **relay the core's message verbatim** (in the user's language). When this create is the
+  one that crosses the brain from one to two universes, the core **already appends** the one-time
+  onboarding line ("You now have two universes. Searches stay in the active one plus your cross-cutting
+  notes; say 'search all universes' to span them. New notes will file under `vault/<slug>/`."). You do
+  **not** decide when to show it and **never count universes yourself** (ADR 0009): the deterministic
+  core (`openedGate`) owns that call, you only surface what it prints.
+- **exit 1** → relay the reason as-is (`reserved` = `default` is not creatable; `empty` = the name
+  had no usable characters), and ask for another name.
+
+## What it does NOT do
+
+- It does **not** move or re-stamp existing notes (that is `/import --universe` at import time, or a
+  future one-shot re-stamp). Switching is only about *where new work and default searches point*.
+- It does **not** delete a universe. A created universe is a self-contained `vault/<slug>/` subtree,
+  so a future "delete this universe" stays a trivial `rm -rf` + prune + reindex — not built here.

--- a/maintainers/qa/release-fixtures/v3.6.0/engine-manifest.json
+++ b/maintainers/qa/release-fixtures/v3.6.0/engine-manifest.json
@@ -1,0 +1,77 @@
+{
+  "manifestVersion": 1,
+  "engineVersion": {
+    "rag": "1.1.5",
+    "local-mirror": "0.2.0",
+    "constitutionTemplate": "1.0.0",
+    "scripts": "1.7.0"
+  },
+  "indexSchemaVersion": 1,
+  "regimes": {
+    "replace": [
+      "rag/src/**",
+      "rag/package.json",
+      "rag/package-lock.json",
+      "rag/tsconfig.json",
+      "rag/postinstall-restart-notice.mjs",
+      "local-mirror/src/**",
+      "local-mirror/package.json",
+      "local-mirror/package-lock.json",
+      "local-mirror/tsconfig.json",
+      "scripts/update-engine.mjs",
+      "scripts/import-brain.mjs",
+      "scripts/set-active-universe.mjs",
+      "scripts/open-env.mjs",
+      "scripts/session-self-heal.mjs",
+      "scripts/session-status.mjs",
+      "scripts/session-health.mjs",
+      "scripts/session-obsidian-hint.mjs",
+      "scripts/session-wiki-health.mjs",
+      "scripts/session-universe.mjs",
+      "scripts/session-actions-log.mjs",
+      "scripts/health-probe-run.mjs",
+      "scripts/lint-vault.mjs",
+      "scripts/file-back-note.mjs",
+      "scripts/consolidate-scan.mjs",
+      "scripts/lib/**",
+      ".claude/settings.json.template",
+      ".mcp.json.template",
+      "engine-skills/**",
+      "engine-health/**"
+    ],
+    "regenerate": [
+      "rag/launch.sh",
+      "rag/launch.cmd",
+      "local-mirror/launch.sh",
+      "local-mirror/launch.cmd",
+      "scripts/run-node.sh",
+      "scripts/run-node.cmd"
+    ],
+    "merge": [
+      "CLAUDE.md",
+      ".claude/settings.json",
+      ".claude/skills/coach/**",
+      ".claude/skills/sync/**",
+      ".claude/skills/sync-sources/**",
+      ".claude/skills/improve/**",
+      ".claude/skills/prepare-1-1/**",
+      ".claude/skills/tdd-discipline/**",
+      ".claude/skills/update-engine/**",
+      ".claude/skills/import/**",
+      ".claude/skills/switch/**",
+      "scripts/auto-commit.mjs",
+      "scripts/auto-push.mjs",
+      "scripts/status-line.mjs",
+      "scripts/verify-rag.mjs"
+    ]
+  },
+  "engineMcpServers": [
+    "vault-rag",
+    "local-mirror"
+  ],
+  "engineModuleRequirements": {
+    "vault-rag": "mandatory",
+    "local-mirror": "optional"
+  },
+  "provenance": {}
+}

--- a/rag/postinstall-restart-notice.mjs
+++ b/rag/postinstall-restart-notice.mjs
@@ -17,6 +17,14 @@
 // OLD version (the orchestrator rewrites the manifest AFTER npm install). So recorded != package
 // ⇒ an update is mid-flight. On a fresh install both equal the shipped version ⇒ silent.
 //
+// TWO BOTTLES RIDE THIS VECTOR TODAY. (1) the restart nudge, below; (2) the "finish the skill
+// refresh" directive for the pre-v3.3.0 cohort, whose orchestrator has no auto-finalize and
+// therefore never re-runs the freshly-written reconciler that refreshes untouched engine skills.
+// Both PRINT a directive and change nothing: at postinstall time there is no source to refresh
+// from (the new skills live in the orchestrator's temp clone, and the manifest still records the
+// OLD source.ref), the staged `engine-skills/**` base has already been overwritten (it is a
+// `replace` glob copied BEFORE npm install), and reconciling here would recurse into npm install.
+//
 // FAIL-SOFT: a postinstall that throws would abort `npm install` and break the update. The CLI
 // wrapper swallows everything (dynamic import + .catch in package.json) and this module never
 // throws — printing a nudge is a convenience, never a blocker.
@@ -26,8 +34,34 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const bar = "═".repeat(74);
+
 export function shouldNudgeRestart({ manifestExists, recordedRagVersion, packageRagVersion }) {
   return manifestExists && recordedRagVersion !== packageRagVersion;
+}
+
+// Auto-finalize (ADR 0026 Layer A) shipped in v3.3.0, whose manifest records this scripts version.
+const AUTO_FINALIZE_SCRIPTS_VERSION = [1, 1, 0];
+
+// Unreadable or absent ⇒ BEFORE the floor: a manifest without a recorded `scripts` version
+// predates the key, and an unparsable one cannot prove it has auto-finalize. Erring toward "fire"
+// costs one converging update; erring the other way leaves the brain's skills frozen for good.
+function isBefore(version, floor) {
+  const parts = String(version).split(".").map(Number);
+  if (parts.some((part) => !Number.isFinite(part))) return true;
+  for (let i = 0; i < floor.length; i += 1) {
+    const part = parts[i] ?? 0;
+    if (part !== floor[i]) return part < floor[i];
+  }
+  return false;
+}
+
+// Fires ONLY on an update in flight (same signal as the restart nudge — the SessionStart self-heal
+// runs `npm install` too, and a converged brain has nothing to finish) AND only for the cohort whose
+// orchestrator predates auto-finalize.
+export function shouldFinishRefresh(signals) {
+  if (!shouldNudgeRestart(signals)) return false;
+  return isBefore(signals.recordedScriptsVersion, AUTO_FINALIZE_SCRIPTS_VERSION);
 }
 
 // Phrased as a DIRECTIVE to the AGENT (the only renderer of the Desktop chat), not as raw user
@@ -35,7 +69,6 @@ export function shouldNudgeRestart({ manifestExists, recordedRagVersion, package
 // it while reporting the update and surfaces the restart to the user — even on a pre-3.3 brain
 // whose OLD skill/core would otherwise stay silent.
 export function restartNoticeBanner() {
-  const bar = "═".repeat(74);
   return [
     "",
     bar,
@@ -55,7 +88,33 @@ export function restartNoticeBanner() {
   ].join("\n");
 }
 
-// Thin I/O glue (NOT unit-tested — the testable logic is shouldNudgeRestart + restartNoticeBanner).
+// The second directive, same vector and same phrasing discipline: addressed to the AGENT, which is
+// the only renderer of the Desktop chat. It asks for the second pass to be run NOW, inside the same
+// interaction, so the owner still only ever asked once.
+export function finishRefreshBanner() {
+  return [
+    "",
+    bar,
+    "⚠️ ⚠️ ⚠️  ENGINE UPDATE UNFINISHED — AGENT, RUN THE UPDATE ONCE MORE  ⚠️ ⚠️ ⚠️",
+    bar,
+    "This brain was running an engine older than v3.3.0, whose update orchestrator",
+    "does not re-run the freshly-written reconciler. The new engine code is now on",
+    "disk, but this brain's engine SKILLS have NOT been brought up to date yet —",
+    "they stay frozen on their old versions until the new orchestrator runs.",
+    "",
+    "👉 YOU MUST now run this command once more, immediately, from the brain folder,",
+    "   without asking the user again (they already asked for this update):",
+    "",
+    "       node scripts/update-engine.mjs",
+    "",
+    "   That second pass is the one that refreshes the untouched engine skills. Report",
+    "   ITS summary (and its restart instruction) to the user, not this one's.",
+    bar,
+    "",
+  ].join("\n");
+}
+
+// Thin I/O glue (NOT unit-tested — the testable logic is the two predicates + the two banners).
 // Paths are resolved from THIS file, not cwd, so it works whoever invokes npm. NEVER called at
 // import time (so tests stay side-effect-free) — only the package.json `postinstall` wrapper calls
 // it, inside a .catch, and this body is itself try/caught: a hiccup must never abort `npm install`.
@@ -65,11 +124,20 @@ export function main() {
     const pkg = JSON.parse(readFileSync(join(ragDir, "package.json"), "utf8"));
     const manifestPath = resolve(ragDir, "..", "engine-manifest.json");
     const manifestExists = existsSync(manifestPath);
-    const recordedRagVersion = manifestExists
-      ? JSON.parse(readFileSync(manifestPath, "utf8"))?.engineVersion?.rag
-      : undefined;
-    if (shouldNudgeRestart({ manifestExists, recordedRagVersion, packageRagVersion: pkg.version })) {
+    const manifest = manifestExists ? JSON.parse(readFileSync(manifestPath, "utf8")) : undefined;
+    const signals = {
+      manifestExists,
+      recordedRagVersion: manifest?.engineVersion?.rag,
+      recordedScriptsVersion: manifest?.engineVersion?.scripts,
+      packageRagVersion: pkg.version,
+    };
+    if (shouldNudgeRestart(signals)) {
       process.stdout.write(restartNoticeBanner() + "\n");
+    }
+    // Printed LAST on purpose: it is the actionable one, and the agent acts on what it read last.
+    // The second pass it triggers prints its own (new, loud) report and restart instruction.
+    if (shouldFinishRefresh(signals)) {
+      process.stdout.write(finishRefreshBanner() + "\n");
     }
   } catch {
     // fail-soft: printing the nudge is a convenience, never a blocker for npm install.

--- a/rag/postinstall-restart-notice.test.mjs
+++ b/rag/postinstall-restart-notice.test.mjs
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { shouldNudgeRestart, restartNoticeBanner } from "./postinstall-restart-notice.mjs";
+import {
+  shouldNudgeRestart,
+  restartNoticeBanner,
+  shouldFinishRefresh,
+  finishRefreshBanner,
+} from "./postinstall-restart-notice.mjs";
 
 // ⛔ The "message in a bottle" (Thomas, 2026-06-21). The OLD update orchestrator (frozen on a
 // pre-3.3 brain) ALWAYS runs `npm install` in rag/ with stdio:"inherit", and npm ALWAYS runs the
@@ -44,4 +49,80 @@ test("restartNoticeBanner — directs the AGENT to tell the user to restart, lou
   assert.match(b, /⚠️/);                               // unmissable
   // It must NOT undercut itself with an "optional / nothing to do" framing.
   assert.doesNotMatch(b, /nothing to do|optional|rien à faire/i);
+});
+
+// ── The SECOND bottle: finish the skill refresh on a pre-v3.3.0 brain ────────────
+// Auto-finalize shipped in v3.3.0, whose manifest records engineVersion.scripts "1.1.0". An
+// older brain's orchestrator never re-execs the freshly-written reconciler, so the untouched
+// engine skills stay frozen until a SECOND update. At postinstall time the manifest still
+// holds the brain's OLD versions → `recorded scripts < 1.1.0` names that cohort deterministically.
+
+test("shouldFinishRefresh — pre-v3.3.0 orchestrator mid-update (scripts 1.0.0 < 1.1.0) → true", () => {
+  assert.equal(
+    shouldFinishRefresh({
+      manifestExists: true,
+      recordedRagVersion: "1.1.0",
+      packageRagVersion: "1.1.5",
+      recordedScriptsVersion: "1.0.0",
+    }),
+    true,
+  );
+});
+
+// On the boundary: v3.3.0 itself HAS auto-finalize → one pass converges → no second run to ask for.
+test("shouldFinishRefresh — exactly v3.3.0 (scripts 1.1.0) → false (auto-finalize is there)", () => {
+  assert.equal(
+    shouldFinishRefresh({
+      manifestExists: true,
+      recordedRagVersion: "1.1.0",
+      packageRagVersion: "1.1.5",
+      recordedScriptsVersion: "1.1.0",
+    }),
+    false,
+  );
+});
+
+// A manifest with NO recorded scripts version predates the key itself → older than v3.3.0 by
+// construction. Fire: an extra converging update is harmless, a frozen skill set is not.
+test("shouldFinishRefresh — manifest with no recorded scripts version (older than the key) → true", () => {
+  assert.equal(
+    shouldFinishRefresh({
+      manifestExists: true,
+      recordedRagVersion: "1.0.9",
+      packageRagVersion: "1.1.5",
+      recordedScriptsVersion: undefined,
+    }),
+    true,
+  );
+});
+
+// Same cohort, but NO update in flight (recorded rag == package rag): the SessionStart self-heal
+// also runs `npm install`, and a converged brain re-installing its deps has nothing to finish.
+// Without this conjunction, an old brain would be nagged to update at every single session start.
+test("shouldFinishRefresh — old cohort but no update mid-flight (self-heal / fresh install) → false", () => {
+  assert.equal(
+    shouldFinishRefresh({
+      manifestExists: true,
+      recordedRagVersion: "1.1.5",
+      packageRagVersion: "1.1.5",
+      recordedScriptsVersion: "1.0.0",
+    }),
+    false,
+  );
+});
+
+// Like the restart notice, the bottle PRINTS a directive and refreshes nothing itself: at
+// postinstall time there is no source to refresh from (the new skills live in the orchestrator's
+// temp clone), the staged base is already overwritten, and reconciling inside `npm install` would
+// recurse. So the banner's whole job is to make the AGENT run the second pass, in this same
+// interaction — the user asked once.
+test("finishRefreshBanner — orders the AGENT to re-run the update NOW, naming the command", () => {
+  const b = finishRefreshBanner();
+  assert.match(b, /node scripts\/update-engine\.mjs/); // the exact command, copy-pasteable
+  assert.match(b, /run (it|this command) (again|once more)/i); // an order to act, now
+  assert.match(b, /immediately|now\b/i);
+  assert.match(b, /skill/i); // the WHY: the engine skills are not refreshed yet
+  assert.match(b, /⚠️/); // unmissable, like its sibling
+  // It must not read as something to postpone or to hand over to the user.
+  assert.doesNotMatch(b, /next time|later|ask the user to run|optional/i);
 });

--- a/scripts/lib/brain-locale.mjs
+++ b/scripts/lib/brain-locale.mjs
@@ -1,0 +1,30 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// brain-locale.mjs — which locale a GIVEN brain was installed with.
+//
+// The fact is already on disk, on every brain: `scripts/lib/demo-locale.mjs` exports
+// `BRAIN_LOCALE`, and the fr overlay replaces that file with `"fr"`. It is LOCALE-OWNED
+// (`engine-copy-select.mjs` F2), so an update never overwrites it → it stays a truthful
+// marker for the brain's lifetime. We READ it (rather than importing the engine's own
+// module) because the answer must be about the BRAIN we are converging, which is not
+// necessarily the tree this code runs from.
+// ─────────────────────────────────────────────────────────────────────────────
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const DEFAULT_LOCALE = "en";
+
+// PURE: the locale declared by a `demo-locale.mjs` content.
+export function parseBrainLocale(content) {
+  const m = /BRAIN_LOCALE\s*=\s*"([^"]+)"/.exec(content ?? "");
+  return m ? m[1] : DEFAULT_LOCALE;
+}
+
+// The locale of the brain at `brainDir`. Unreadable marker → the default locale:
+// an update must never fail over it (that brain runs the root content anyway).
+export function readBrainLocale(brainDir) {
+  try {
+    return parseBrainLocale(readFileSync(join(brainDir, "scripts", "lib", "demo-locale.mjs"), "utf8"));
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+}

--- a/scripts/lib/brain-locale.test.mjs
+++ b/scripts/lib/brain-locale.test.mjs
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseBrainLocale, readBrainLocale } from "./brain-locale.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// brain-locale — which locale a GIVEN brain was installed with, read from its own
+// `scripts/lib/demo-locale.mjs` marker (a locale-owned file an update never
+// overwrites). Needed by the locale-aware skill refresh (Increment 2.5, trap T2):
+// the engine must deliver the FR source to a FR brain, not the root EN one.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("parseBrainLocale — reads the locale the marker declares", () => {
+  assert.equal(parseBrainLocale('export const BRAIN_LOCALE = "fr";\n'), "fr");
+});
+
+test("parseBrainLocale — no readable marker → the default locale, never a crash", () => {
+  // A brain with no marker (or one we could not read) must degrade to the root
+  // content, which is what such a brain was installed from anyway. An update is not
+  // allowed to fail over a missing marker.
+  for (const content of ["// nothing here\n", "", null, undefined]) {
+    assert.equal(parseBrainLocale(content), "en");
+  }
+});
+
+test("readBrainLocale — reads the marker of THAT brain, not of the tree we run from", () => {
+  const brainDir = mkdtempSync(join(tmpdir(), "brain-locale-"));
+  try {
+    mkdirSync(join(brainDir, "scripts", "lib"), { recursive: true });
+    writeFileSync(
+      join(brainDir, "scripts", "lib", "demo-locale.mjs"),
+      '// fr overlay\nexport const BRAIN_LOCALE = "fr";\n',
+    );
+    assert.equal(readBrainLocale(brainDir), "fr");
+  } finally {
+    rmSync(brainDir, { recursive: true, force: true });
+  }
+});
+
+test("readBrainLocale — a brain with no marker file at all → the default locale", () => {
+  const brainDir = mkdtempSync(join(tmpdir(), "brain-locale-"));
+  try {
+    assert.equal(readBrainLocale(brainDir), "en");
+  } finally {
+    rmSync(brainDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/engine-copy-select.mjs
+++ b/scripts/lib/engine-copy-select.mjs
@@ -27,6 +27,14 @@ export function localeOwnedPaths(sourceFiles) {
   return owned;
 }
 
+// The SOURCE file to deliver for `rel` to a brain installed in `locale`. The mirror
+// image of localeOwnedPaths: that one excludes locale-owned paths from the blind copy;
+// this one resolves the ONE source a locale-aware delivery should read.
+export function resolveLocaleSource({ rel, locale, sourceFiles }) {
+  const localized = `templates/${locale}/${rel}`;
+  return sourceFiles.includes(localized) ? localized : rel;
+}
+
 // The rel paths to ACTUALLY copy: matching the engine copy globs, MINUS the dev-only
 // files, MINUS the locale-owned files. `localeOwnedRel` may be injected (tests); it
 // defaults to the set derived from `sourceFiles`.

--- a/scripts/lib/engine-copy-select.test.mjs
+++ b/scripts/lib/engine-copy-select.test.mjs
@@ -1,7 +1,51 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { localeOwnedPaths, selectEngineFilesToCopy } from "./engine-copy-select.mjs";
+import { localeOwnedPaths, selectEngineFilesToCopy, resolveLocaleSource } from "./engine-copy-select.mjs";
+
+// ── resolveLocaleSource: WHICH source file to deliver to a brain of a given locale ──
+// The twin of localeOwnedPaths: that one EXCLUDES locale-owned paths from the blind
+// copy; this one RESOLVES a rel path to the source the brain's locale should get
+// (Increment 2.5, trap T2 — refreshing a FR brain from the root would re-anglicize it).
+test("resolveLocaleSource — the default-locale brain reads the ROOT file", () => {
+  assert.equal(
+    resolveLocaleSource({
+      rel: ".claude/skills/coach/SKILL.md",
+      locale: "en",
+      sourceFiles: [".claude/skills/coach/SKILL.md", "templates/fr/.claude/skills/coach/SKILL.md"],
+    }),
+    ".claude/skills/coach/SKILL.md",
+  );
+});
+
+test("resolveLocaleSource — a FR brain reads its OWN localized source, not the root one", () => {
+  assert.equal(
+    resolveLocaleSource({
+      rel: ".claude/skills/coach/SKILL.md",
+      locale: "fr",
+      sourceFiles: [".claude/skills/coach/SKILL.md", "templates/fr/.claude/skills/coach/SKILL.md"],
+    }),
+    "templates/fr/.claude/skills/coach/SKILL.md",
+  );
+});
+
+test("resolveLocaleSource — no source in the brain's locale → the ROOT file, never another locale's", () => {
+  // `switch` and `local-mirror` ship EN-only today. Falling back to the root is the
+  // safe answer: it is exactly what the FR brain received at install, so refreshing
+  // from it is a same-language update — never a regression, and never a Spanish skill.
+  assert.equal(
+    resolveLocaleSource({
+      rel: ".claude/skills/switch/SKILL.md",
+      locale: "fr",
+      sourceFiles: [
+        ".claude/skills/switch/SKILL.md",
+        "templates/es/.claude/skills/switch/SKILL.md", // another locale → must NOT be picked
+        "templates/fr/.claude/skills/coach/SKILL.md", // FR exists, but for another skill
+      ],
+    }),
+    ".claude/skills/switch/SKILL.md",
+  );
+});
 
 // ── localeOwnedPaths: which rel paths a locale OWNS (from templates/<locale>/<rel>) ──
 test("localeOwnedPaths — derives the owned rel from templates/<locale>/<rel>", () => {

--- a/scripts/lib/engine-skill-refresh.mjs
+++ b/scripts/lib/engine-skill-refresh.mjs
@@ -7,7 +7,7 @@
 // delivered → safe to overwrite. Anything else is the owner's property.
 // No fs, no side effects: the caller reads the bytes and applies the verdict.
 // ─────────────────────────────────────────────────────────────────────────────
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import { fingerprint, selectMergeFiles } from "./engine-source.mjs";
@@ -79,15 +79,28 @@ export function refreshUntouchedSkills({ brainDir, sourceDir, sourceFiles, manif
     const installed = existsSync(installedPath) ? readFileSync(installedPath, "utf8") : null;
     const { verdict, reason } = refreshVerdict({ installed, base: provenance[rel], candidate });
     const skill = skillNameOf(rel);
+    // Any verdict but "preserve: customized" means nothing newer is pending for that
+    // file, so a sidecar left by a previous update is now a lie ("a newer version
+    // awaits" when the owner already adopted it, or when we just refreshed it).
+    if (verdict !== "preserve" || reason !== "customized") rmSync(`${installedPath}.new`, { force: true });
     if (verdict === "refresh") {
       mkdirSync(dirname(installedPath), { recursive: true });
       writeFileSync(installedPath, candidate);
       refreshedFileMap[rel] = candidate;
       if (!skillsRefreshed.includes(skill)) skillsRefreshed.push(skill);
-    } else if (verdict === "preserve" && !skillsPreserved.some((p) => p.skill === skill)) {
+    } else if (verdict === "preserve") {
+      // "Never overwritten" must not mean "never offered": drop the engine's version
+      // BESIDE the owner's (conffile fallback) so adopting it stays their call. Only
+      // when they actually customized it — a `no-provenance` preserve says we cannot
+      // PROVE anything, and littering an older brain with 9 unexplained `.new` files
+      // would be noise, not a choice. `.new` is not a `SKILL.md`: nothing loads it.
+      const newVersionPath = reason === "customized" ? `${rel}.new` : undefined;
+      if (newVersionPath) writeFileSync(join(brainDir, newVersionPath), candidate);
       // Reported per SKILL, not per file: what the owner needs to hear is "your
       // prepare-1-1 stands as you wrote it", not a list of paths.
-      skillsPreserved.push({ skill, reason });
+      if (!skillsPreserved.some((p) => p.skill === skill)) {
+        skillsPreserved.push(newVersionPath ? { skill, reason, newVersionPath } : { skill, reason });
+      }
     }
   }
   return { skillsRefreshed, skillsPreserved, refreshedFileMap };

--- a/scripts/lib/engine-skill-refresh.mjs
+++ b/scripts/lib/engine-skill-refresh.mjs
@@ -13,11 +13,11 @@ import { dirname, join, resolve } from "node:path";
 import { fingerprint, selectMergeFiles } from "./engine-source.mjs";
 import { resolveLocaleSource } from "./engine-copy-select.mjs";
 import { readBrainLocale } from "./brain-locale.mjs";
-
-// The runtime home of the skills a brain uses. Increment 2.5 refreshes SKILLS only:
-// the other `merge` files (the constitution, settings.json, the engine-owned scripts)
-// keep their current regimes — the constitution's own layering stays a Gate 4 subject.
-const SKILLS_PREFIX = ".claude/skills/";
+// SKILLS_PREFIX = the runtime home of the skills a brain uses; STAGING_PREFIX = where a
+// staged skill's source ships. Increment 2.5 refreshes SKILLS only: the other `merge`
+// files (the constitution, settings.json, the engine-owned scripts) keep their current
+// regimes — the constitution's own layering stays a Gate 4 subject.
+import { SKILLS_PREFIX, STAGING_PREFIX } from "./staged-skills.mjs";
 
 // The source files eligible for a provenance-gated refresh: those the manifest
 // DECLARES engine-owned (`merge` regime) AND that live in the skills tree. A skill the
@@ -25,6 +25,21 @@ const SKILLS_PREFIX = ".claude/skills/";
 // of ADR 0012, unchanged here.
 export function selectRefreshableSkillFiles({ sourceFiles, manifest }) {
   return selectMergeFiles(manifest, sourceFiles).filter((rel) => rel.startsWith(SKILLS_PREFIX));
+}
+
+// The refresh works on (installed path ← source path) pairs, because the two families of
+// engine skills do NOT ship at the same place:
+//   • the 9 `merge` skills ship AT their runtime path (`.claude/skills/<name>/…`);
+//   • the staged ones ship at `engine-skills/<name>/…` and are install-if-absent'd into
+//     `.claude/skills/<name>/…` — the sacred scrub forbids delivering a skill under
+//     `.claude/skills/` by copy (ADR 0026), which is exactly what protects the owner's.
+// Mapping them here lets ONE verdict + ONE write path serve both.
+export function refreshableSkillPairs({ sourceFiles, manifest }) {
+  const merge = selectRefreshableSkillFiles({ sourceFiles, manifest }).map((rel) => ({ rel, sourceRel: rel }));
+  const staged = sourceFiles
+    .filter((f) => f.startsWith(STAGING_PREFIX) && f.slice(STAGING_PREFIX.length).includes("/"))
+    .map((sourceRel) => ({ rel: SKILLS_PREFIX + sourceRel.slice(STAGING_PREFIX.length), sourceRel }));
+  return [...merge, ...staged];
 }
 
 // Line endings are NOT authorship: a Windows checkout/editor can rewrite LF→CRLF
@@ -73,8 +88,8 @@ export function refreshUntouchedSkills({ brainDir, sourceDir, sourceFiles, manif
   if (resolve(sourceDir) === resolve(brainDir)) return { skillsRefreshed, skillsPreserved, refreshedFileMap };
 
   const locale = readBrainLocale(brainDir);
-  for (const rel of selectRefreshableSkillFiles({ sourceFiles, manifest })) {
-    const candidate = readFileSync(join(sourceDir, resolveLocaleSource({ rel, locale, sourceFiles })), "utf8");
+  for (const { rel, sourceRel } of refreshableSkillPairs({ sourceFiles, manifest })) {
+    const candidate = readFileSync(join(sourceDir, resolveLocaleSource({ rel: sourceRel, locale, sourceFiles })), "utf8");
     const installedPath = join(brainDir, rel);
     const installed = existsSync(installedPath) ? readFileSync(installedPath, "utf8") : null;
     const { verdict, reason } = refreshVerdict({ installed, base: provenance[rel], candidate });

--- a/scripts/lib/engine-skill-refresh.mjs
+++ b/scripts/lib/engine-skill-refresh.mjs
@@ -1,0 +1,39 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// engine-skill-refresh.mjs — the PURE decision core of "refresh an engine-shipped
+// skill if, and only if, we can PROVE nobody touched it" (plan Increment 2.5).
+// The proof already exists on every deployed brain: `engine-manifest.json` records a
+// sha256 `provenance` base per `merge` file (installer.mjs / engine-source.mjs), so a
+// file whose hash still matches that base is byte-identical to what the engine last
+// delivered → safe to overwrite. Anything else is the owner's property.
+// No fs, no side effects: the caller reads the bytes and applies the verdict.
+// ─────────────────────────────────────────────────────────────────────────────
+import { fingerprint } from "./engine-source.mjs";
+
+// Line endings are NOT authorship: a Windows checkout/editor can rewrite LF→CRLF
+// without anyone touching a word, and the recorded base was fingerprinted on the LF
+// content the engine delivered. Comparing the normalized content too keeps the whole
+// Windows fleet eligible for refresh instead of being frozen as "customized".
+const normalizeEol = (content) => content.split("\r\n").join("\n");
+
+function matchesBase(installed, base) {
+  return fingerprint(installed) === base || fingerprint(normalizeEol(installed)) === base;
+}
+
+// The verdict for ONE file, given what the brain has on disk (`installed`, null/undefined
+// when absent), the provenance base the engine recorded when it last delivered it
+// (`base`), and the content the update would deliver (`candidate`):
+//   • absent-install — nothing on disk → deliver it;
+//   • preserve (reason: customized | no-provenance) — the owner's copy stands;
+//   • unchanged — provably untouched and already up to date → write nothing;
+//   • refresh — provably untouched and outdated → overwrite.
+export function refreshVerdict({ installed, base, candidate }) {
+  if (installed === null || installed === undefined) return { verdict: "absent-install" };
+  // No base recorded → "untouched" is UNPROVABLE (not "customized"): keep the owner's
+  // copy either way, but the two deserve different prose in the update report.
+  if (!base) return { verdict: "preserve", reason: "no-provenance" };
+  if (!matchesBase(installed, base)) return { verdict: "preserve", reason: "customized" };
+  // Untouched AND already the candidate → write nothing: a converged brain must stay
+  // byte-identical, or every update would churn the auto-commit history for a no-op.
+  if (normalizeEol(installed) === normalizeEol(candidate)) return { verdict: "unchanged" };
+  return { verdict: "refresh" };
+}

--- a/scripts/lib/engine-skill-refresh.mjs
+++ b/scripts/lib/engine-skill-refresh.mjs
@@ -98,7 +98,12 @@ export function refreshUntouchedSkills({ brainDir, sourceDir, sourceFiles, manif
     // file, so a sidecar left by a previous update is now a lie ("a newer version
     // awaits" when the owner already adopted it, or when we just refreshed it).
     if (verdict !== "preserve" || reason !== "customized") rmSync(`${installedPath}.new`, { force: true });
-    if (verdict === "refresh") {
+    // `absent-install` writes down the SAME path as `refresh`: a skill is a SUBTREE, and
+    // install-if-absent decides at the skill-DIR level (`reconcile-brain.mjs` step 2.bis),
+    // so a `references/`/`examples/` file a release adds under a skill the brain ALREADY
+    // has is invisible to it. Dropping the verdict here would leave that file unreachable
+    // by any number of updates — the core/skill drift of this increment, one level down.
+    if (verdict === "refresh" || verdict === "absent-install") {
       mkdirSync(dirname(installedPath), { recursive: true });
       writeFileSync(installedPath, candidate);
       refreshedFileMap[rel] = candidate;

--- a/scripts/lib/engine-skill-refresh.mjs
+++ b/scripts/lib/engine-skill-refresh.mjs
@@ -94,10 +94,13 @@ export function refreshUntouchedSkills({ brainDir, sourceDir, sourceFiles, manif
     const installed = existsSync(installedPath) ? readFileSync(installedPath, "utf8") : null;
     const { verdict, reason } = refreshVerdict({ installed, base: provenance[rel], candidate });
     const skill = skillNameOf(rel);
-    // Any verdict but "preserve: customized" means nothing newer is pending for that
-    // file, so a sidecar left by a previous update is now a lie ("a newer version
-    // awaits" when the owner already adopted it, or when we just refreshed it).
-    if (verdict !== "preserve" || reason !== "customized") rmSync(`${installedPath}.new`, { force: true });
+    // A sidecar left by a previous update is a claim ("a newer version awaits") that only
+    // ONE verdict still backs: `preserve: customized`. Any other verdict makes it a lie —
+    // the owner already adopted it, or we just refreshed the file under it — so it goes.
+    // Cleared UNCONDITIONALLY, and the customized branch below re-drops it: guarding this
+    // on the verdict would be redundant with that write (rm-then-write and write-alone
+    // leave the same bytes), i.e. a condition no test could ever tell apart.
+    rmSync(`${installedPath}.new`, { force: true });
     // `absent-install` writes down the SAME path as `refresh`: a skill is a SUBTREE, and
     // install-if-absent decides at the skill-DIR level (`reconcile-brain.mjs` step 2.bis),
     // so a `references/`/`examples/` file a release adds under a skill the brain ALREADY

--- a/scripts/lib/engine-skill-refresh.mjs
+++ b/scripts/lib/engine-skill-refresh.mjs
@@ -7,7 +7,25 @@
 // delivered → safe to overwrite. Anything else is the owner's property.
 // No fs, no side effects: the caller reads the bytes and applies the verdict.
 // ─────────────────────────────────────────────────────────────────────────────
-import { fingerprint } from "./engine-source.mjs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { fingerprint, selectMergeFiles } from "./engine-source.mjs";
+import { resolveLocaleSource } from "./engine-copy-select.mjs";
+import { readBrainLocale } from "./brain-locale.mjs";
+
+// The runtime home of the skills a brain uses. Increment 2.5 refreshes SKILLS only:
+// the other `merge` files (the constitution, settings.json, the engine-owned scripts)
+// keep their current regimes — the constitution's own layering stays a Gate 4 subject.
+const SKILLS_PREFIX = ".claude/skills/";
+
+// The source files eligible for a provenance-gated refresh: those the manifest
+// DECLARES engine-owned (`merge` regime) AND that live in the skills tree. A skill the
+// manifest never names (the user's own) can never be selected — the founding principle
+// of ADR 0012, unchanged here.
+export function selectRefreshableSkillFiles({ sourceFiles, manifest }) {
+  return selectMergeFiles(manifest, sourceFiles).filter((rel) => rel.startsWith(SKILLS_PREFIX));
+}
 
 // Line endings are NOT authorship: a Windows checkout/editor can rewrite LF→CRLF
 // without anyone touching a word, and the recorded base was fingerprinted on the LF
@@ -36,4 +54,41 @@ export function refreshVerdict({ installed, base, candidate }) {
   // byte-identical, or every update would churn the auto-commit history for a no-op.
   if (normalizeEol(installed) === normalizeEol(candidate)) return { verdict: "unchanged" };
   return { verdict: "refresh" };
+}
+
+// The skill a rel path belongs to: `.claude/skills/switch/SKILL.md` → `switch`.
+const skillNameOf = (rel) => rel.slice(SKILLS_PREFIX.length).split("/")[0];
+
+// ─── I/O orchestrator (the reconciler's thin wiring) ─────────────────────────
+// Applies the verdict above to every engine-declared skill file, reading the source
+// through the brain's own locale (trap T2) and returning what it did, per SKILL.
+//
+// ⚠️ GUARD: `sourceDir === brainDir` means SessionStart self-heal — no new content, and
+// nobody asked for anything. A skill is only ever overwritten during an update the owner
+// explicitly requested (auto-finalize hands the reconciler the FETCHED source).
+export function refreshUntouchedSkills({ brainDir, sourceDir, sourceFiles, manifest, provenance = {} }) {
+  const skillsRefreshed = [];
+  const skillsPreserved = [];
+  const refreshedFileMap = {};
+  if (resolve(sourceDir) === resolve(brainDir)) return { skillsRefreshed, skillsPreserved, refreshedFileMap };
+
+  const locale = readBrainLocale(brainDir);
+  for (const rel of selectRefreshableSkillFiles({ sourceFiles, manifest })) {
+    const candidate = readFileSync(join(sourceDir, resolveLocaleSource({ rel, locale, sourceFiles })), "utf8");
+    const installedPath = join(brainDir, rel);
+    const installed = existsSync(installedPath) ? readFileSync(installedPath, "utf8") : null;
+    const { verdict, reason } = refreshVerdict({ installed, base: provenance[rel], candidate });
+    const skill = skillNameOf(rel);
+    if (verdict === "refresh") {
+      mkdirSync(dirname(installedPath), { recursive: true });
+      writeFileSync(installedPath, candidate);
+      refreshedFileMap[rel] = candidate;
+      if (!skillsRefreshed.includes(skill)) skillsRefreshed.push(skill);
+    } else if (verdict === "preserve" && !skillsPreserved.some((p) => p.skill === skill)) {
+      // Reported per SKILL, not per file: what the owner needs to hear is "your
+      // prepare-1-1 stands as you wrote it", not a list of paths.
+      skillsPreserved.push({ skill, reason });
+    }
+  }
+  return { skillsRefreshed, skillsPreserved, refreshedFileMap };
 }

--- a/scripts/lib/engine-skill-refresh.test.mjs
+++ b/scripts/lib/engine-skill-refresh.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { fingerprint } from "./engine-source.mjs";
-import { refreshVerdict, selectRefreshableSkillFiles } from "./engine-skill-refresh.mjs";
+import { refreshableSkillPairs, refreshVerdict, selectRefreshableSkillFiles } from "./engine-skill-refresh.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // engine-skill-refresh — the PURE verdict behind "refresh an engine skill only
@@ -85,6 +85,23 @@ test("already carrying the candidate content → nothing to do (no write, no chu
   );
 });
 
+test("a base RECORDED on CRLF bytes still matches its own file → refresh, not 'customized'", () => {
+  // The mirror image of the drift case below. On Windows, `git clone` with autocrlf hands
+  // the engine CRLF bytes, so what it DELIVERED — and therefore fingerprinted as the base —
+  // is CRLF. At the next update the file still matches that base RAW, but no longer once
+  // normalized. Comparing the normalized form alone would freeze the whole Windows fleet as
+  // "customized"; the raw comparison is what keeps them refreshable.
+  const deliveredCrlf = "# switch (v3.6.0)\r\nline two\r\n";
+  assert.deepEqual(
+    refreshVerdict({
+      installed: deliveredCrlf,
+      base: fingerprint(deliveredCrlf),
+      candidate: "# switch (v3.6.2)\nline two\n",
+    }),
+    { verdict: "refresh" },
+  );
+});
+
 test("Windows CRLF drift is NOT a customization → still refresh it", () => {
   // A Windows brain whose checkout/editor rewrote the line endings differs from the
   // base BYTE-wise while nobody edited a word. Freezing those brains forever would
@@ -121,5 +138,28 @@ test("selectRefreshableSkillFiles — the engine-declared SKILL files, and nothi
     ".claude/skills/coach/SKILL.md",
     ".claude/skills/coach/references/radical-candor.md",
     ".claude/skills/switch/SKILL.md",
+  ]);
+});
+
+test("refreshableSkillPairs — a loose file directly under engine-skills/ is NOT a staged skill", () => {
+  // A staged skill is `engine-skills/<name>/<file>`; the SKILL NAME is that first segment.
+  // A file sitting directly under `engine-skills/` has no such segment, so mapping it would
+  // aim at `.claude/skills/README.md` — a file loose in the skills root, belonging to no
+  // skill. Since the refresh now DELIVERS what is absent, an unguarded prefix would write
+  // that file into the owner's skills folder instead of merely ignoring it.
+  const manifest = { regimes: { merge: [".claude/skills/switch/**"] } };
+  const sourceFiles = [
+    "engine-skills/README.md", // loose: no skill segment
+    "engine-skills/lint/SKILL.md", // a genuine staged skill
+    "engine-skills/local-mirror/references/scopes.md", // nested deeper, still genuine
+    ".claude/skills/switch/SKILL.md",
+  ];
+  assert.deepEqual(refreshableSkillPairs({ sourceFiles, manifest }), [
+    { rel: ".claude/skills/switch/SKILL.md", sourceRel: ".claude/skills/switch/SKILL.md" },
+    { rel: ".claude/skills/lint/SKILL.md", sourceRel: "engine-skills/lint/SKILL.md" },
+    {
+      rel: ".claude/skills/local-mirror/references/scopes.md",
+      sourceRel: "engine-skills/local-mirror/references/scopes.md",
+    },
   ]);
 });

--- a/scripts/lib/engine-skill-refresh.test.mjs
+++ b/scripts/lib/engine-skill-refresh.test.mjs
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { fingerprint } from "./engine-source.mjs";
+import { refreshVerdict } from "./engine-skill-refresh.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// engine-skill-refresh — the PURE verdict behind "refresh an engine skill only
+// if we can PROVE nobody touched it" (plan Increment 2.5, Step 1). Given what the
+// brain has on disk, the provenance base the engine recorded when it last delivered
+// the file, and the candidate new content, it answers: install it / refresh it /
+// preserve the owner's version. No fs, no side effects.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("a file the brain does not have yet → install it", () => {
+  assert.deepEqual(
+    refreshVerdict({ installed: null, base: undefined, candidate: "# new skill\n" }),
+    { verdict: "absent-install" },
+  );
+});
+
+test("installed file still byte-identical to the recorded base → refresh it", () => {
+  const delivered = "# switch (v3.6.0)\n";
+  assert.deepEqual(
+    refreshVerdict({
+      installed: delivered,
+      base: fingerprint(delivered),
+      candidate: "# switch (v3.6.2)\n",
+    }),
+    { verdict: "refresh" },
+  );
+});
+
+test("CRLF copy of the candidate itself → still nothing to do", () => {
+  // Same content, Windows line endings: rewriting it would flip the file to LF at
+  // every single update (autocrlf puts the CRLFs back) — pure churn, zero gain.
+  const candidate = "# switch (v3.6.2)\nline two\n";
+  const installed = candidate.split("\n").join("\r\n");
+  assert.deepEqual(
+    refreshVerdict({ installed, base: fingerprint(candidate), candidate }),
+    { verdict: "unchanged" },
+  );
+});
+
+test("owner customized the file (hash no longer matches the base) → preserve it", () => {
+  const delivered = "# prepare-1-1 (v3.6.0)\n";
+  assert.deepEqual(
+    refreshVerdict({
+      installed: delivered + "\nMy own KPIs section.\n", // the documented customization case
+      base: fingerprint(delivered),
+      candidate: "# prepare-1-1 (v3.6.2)\n",
+    }),
+    { verdict: "preserve", reason: "customized" },
+  );
+});
+
+test("no provenance base recorded (pre-provenance brain) → preserve, but say WHY", () => {
+  // Nothing was ever fingerprinted for this file, so "untouched" is UNPROVABLE — we
+  // still keep the owner's copy, but the report must not call them a customizer.
+  assert.deepEqual(
+    refreshVerdict({ installed: "# switch\n", base: undefined, candidate: "# switch v2\n" }),
+    { verdict: "preserve", reason: "no-provenance" },
+  );
+});
+
+test("a base is recorded but the file is gone from disk → install it back", () => {
+  // Absence is whatever the fs seam reports for "no content" (null OR undefined) —
+  // a recorded base must never turn a missing file into a "preserve".
+  const delivered = "# switch (v3.6.0)\n";
+  for (const missing of [null, undefined]) {
+    assert.deepEqual(
+      refreshVerdict({ installed: missing, base: fingerprint(delivered), candidate: "# switch (v3.6.2)\n" }),
+      { verdict: "absent-install" },
+    );
+  }
+});
+
+test("already carrying the candidate content → nothing to do (no write, no churn)", () => {
+  // The steady state of an up-to-date brain: re-running the update must NOT rewrite
+  // the file, or every session would produce auto-commit noise for a no-op.
+  const current = "# switch (v3.6.2)\n";
+  assert.deepEqual(
+    refreshVerdict({ installed: current, base: fingerprint(current), candidate: current }),
+    { verdict: "unchanged" },
+  );
+});
+
+test("Windows CRLF drift is NOT a customization → still refresh it", () => {
+  // A Windows brain whose checkout/editor rewrote the line endings differs from the
+  // base BYTE-wise while nobody edited a word. Freezing those brains forever would
+  // hand the whole Windows fleet the very bug this increment fixes.
+  const delivered = "# switch (v3.6.0)\nline two\n";
+  assert.deepEqual(
+    refreshVerdict({
+      installed: delivered.split("\n").join("\r\n"),
+      base: fingerprint(delivered),
+      candidate: "# switch (v3.6.2)\nline two\n",
+    }),
+    { verdict: "refresh" },
+  );
+});

--- a/scripts/lib/engine-skill-refresh.test.mjs
+++ b/scripts/lib/engine-skill-refresh.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { fingerprint } from "./engine-source.mjs";
-import { refreshVerdict } from "./engine-skill-refresh.mjs";
+import { refreshVerdict, selectRefreshableSkillFiles } from "./engine-skill-refresh.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // engine-skill-refresh — the PURE verdict behind "refresh an engine skill only
@@ -98,4 +98,28 @@ test("Windows CRLF drift is NOT a customization → still refresh it", () => {
     }),
     { verdict: "refresh" },
   );
+});
+
+// ── Which files are even ELIGIBLE for the refresh ────────────────────────────
+test("selectRefreshableSkillFiles — the engine-declared SKILL files, and nothing else", () => {
+  const manifest = {
+    regimes: {
+      merge: [".claude/skills/coach/**", ".claude/skills/switch/**", "CLAUDE.md", "scripts/auto-commit.mjs"],
+    },
+  };
+  const sourceFiles = [
+    ".claude/skills/coach/SKILL.md",
+    ".claude/skills/coach/references/radical-candor.md",
+    ".claude/skills/switch/SKILL.md",
+    ".claude/skills/zzz-mine/SKILL.md", // home-made → the manifest never names it
+    "CLAUDE.md", // a merge file, but the constitution stays a Gate 4 concern
+    "scripts/auto-commit.mjs", // a merge file, but not a skill
+    "templates/fr/.claude/skills/coach/SKILL.md", // a SOURCE for a locale, not a target path
+    "rag/src/index.ts",
+  ];
+  assert.deepEqual(selectRefreshableSkillFiles({ sourceFiles, manifest }), [
+    ".claude/skills/coach/SKILL.md",
+    ".claude/skills/coach/references/radical-candor.md",
+    ".claude/skills/switch/SKILL.md",
+  ]);
 });

--- a/scripts/lib/engine-source.test.mjs
+++ b/scripts/lib/engine-source.test.mjs
@@ -36,6 +36,18 @@ test("selectMergeFiles — an exact merge entry selects only that file", () => {
   assert.deepEqual(selectMergeFiles(manifest, candidates), ["CLAUDE.md"]);
 });
 
+// The absent case, fed on purpose: a manifest may legitimately carry no `merge`
+// regime (a partial / hand-written one, or a future regime split). Selection must
+// then be EMPTY, never a crash — this runs at install time, on the brain's own
+// manifest, where a throw would abort the enrichment and leave a brain with no
+// provenance at all (frozen forever, ADR 0026 §8). Triangulated down the whole
+// optional chain: no merge key, no regimes key, no manifest at all.
+test("selectMergeFiles — a manifest with no merge regime selects nothing, and never throws", () => {
+  assert.deepEqual(selectMergeFiles({ regimes: { replace: ["rag/src/**"] } }, ["CLAUDE.md", "rag/src/index.ts"]), []);
+  assert.deepEqual(selectMergeFiles({ manifestVersion: 1 }, ["CLAUDE.md"]), []);
+  assert.deepEqual(selectMergeFiles(undefined, ["CLAUDE.md"]), []);
+});
+
 test("selectMergeFiles — a `**` glob selects the whole subtree, nothing outside it", () => {
   const manifest = { regimes: { merge: [".claude/skills/coach/**"] } };
   const candidates = [
@@ -84,6 +96,30 @@ test("buildSource — a launcher with no remote records repo:null (update-engine
     buildSource({ repo: "", tag: "v1.0.0", branch: "main", commit: "abc" }),
     { repo: null, ref: "v1.0.0" },
   );
+});
+
+// The two mirror images of the "no remote" case above. `git remote get-url` hands back
+// a trailing newline, and a launcher with no remote can yield blank-but-not-empty — both
+// must read as NO remote (repo: null), because that null is exactly what makes
+// update-engine ASK the user where to pull from instead of trying to clone `"  "`.
+// A padded but real URL, conversely, must be recorded CLEAN: a ref with a stray newline
+// is not clone-able.
+test("buildSource — a blank remote is no remote at all, and a padded one is recorded trimmed", () => {
+  assert.deepEqual(buildSource({ repo: "  \n ", tag: "v1.0.0", branch: "main", commit: "abc" }), {
+    repo: null,
+    ref: "v1.0.0",
+  });
+  assert.deepEqual(buildSource({ repo: " git@github.com:me/launcher.git\n", tag: "v1.0.0" }), {
+    repo: "git@github.com:me/launcher.git",
+    ref: "v1.0.0",
+  });
+});
+
+// The absent case: git facts that carry no `repo` key at all (an installer path that
+// never probed the remote). Must degrade to repo:null like the empty string, never throw
+// — a throw here aborts the whole manifest enrichment.
+test("buildSource — git facts with no repo key at all still record repo:null", () => {
+  assert.deepEqual(buildSource({ tag: null, branch: "main", commit: "abc" }), { repo: null, ref: "main" });
 });
 
 test("enrichManifest — sets source + provenance, preserves the rest, never mutates the input", () => {
@@ -202,4 +238,11 @@ test("recordSourceAndProvenance — writes source + fingerprints ONLY the merge 
   });
   // The rest of the manifest is preserved.
   assert.equal(m.engineVersion.rag, "1.1.0");
+
+  // …and it is written as a well-formed text file: 2-space indent + a FINAL NEWLINE.
+  // engine-manifest.json is git-committed and rewritten at every update, so a missing
+  // trailing newline makes every single update diff carry a spurious
+  // "\ No newline at end of file" — noise in the one file whose diff must stay readable.
+  const raw = readFileSync(join(brainDir, "engine-manifest.json"), "utf8");
+  assert.equal(raw, JSON.stringify(m, null, 2) + "\n");
 });

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -264,9 +264,14 @@ export async function reconcileBrain({
 // and local → schema is unchanged from its own viewpoint, so the child never reindexes
 // (it converges files; it does not migrate). RECONCILE ONLY: no fetch, no auto-finalize
 // → no recursion. `seams` is injectable for tests; defaults are the real I/O seams.
+// A flag in LAST position carries no value: reading past the end already yields
+// `undefined`, so no length guard is needed — one would be unable to change a single
+// byte of the result (mutation lesson: a guard that cannot matter says the same in less
+// code). The `i >= 0` check, on the other hand, is load-bearing: without it an ABSENT
+// flag would read `argv[0]` and hand back the first argument as its value.
 function flagValue(argv, name) {
   const i = argv.indexOf(name);
-  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+  return i >= 0 ? argv[i + 1] : undefined;
 }
 
 export async function runReconcileCli({ argv, seams = {} }) {

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 
 import { computeApplyPlan } from "./engine-apply-plan.mjs";
 import { matchesAny } from "./glob-match.mjs";
-import { installStagedSkills } from "./staged-skills.mjs";
+import { installStagedSkills, readStagedProvenance } from "./staged-skills.mjs";
 import { refreshUntouchedSkills } from "./engine-skill-refresh.mjs";
 import { seedHealthNote } from "./staged-health-note.mjs";
 import { reconcileMcpServers } from "./mcp-reconcile.mjs";
@@ -74,6 +74,10 @@ export async function reconcileBrain({
   //    dev-only files (scripts/lib/eval-*/mcp-search.*), F2 keeps the brain's
   //    locale-owned files (scripts/lib/demo-locale.mjs → no fr→en regression).
   const sourceFiles = listFilesRelPosix(sourceDir);
+  // ⚠️ BEFORE the copy: the brain's own `engine-skills/` copy is the provenance base of
+  // the STAGED skills (Increment 2.5), and `engine-skills/**` is a `replace` glob — one
+  // line later it holds the NEW content and every staged skill would read as untouched.
+  const stagedProvenance = readStagedProvenance(brainDir);
   const copyGlobs = [...plan.overwrite, ...plan.replaceScripts];
   const copied = [];
   for (const rel of selectEngineFilesToCopy({ sourceFiles, copyGlobs })) {
@@ -114,7 +118,10 @@ export async function reconcileBrain({
     sourceDir,
     sourceFiles,
     manifest: target,
-    provenance: local?.provenance ?? {},
+    // The two families of base, in one map keyed by the INSTALLED path: the manifest's
+    // recorded sha256 for the `merge` skills, the pre-copy staging tree for the staged
+    // ones. They can never collide — a staged skill is, by construction, not a merge file.
+    provenance: { ...(local?.provenance ?? {}), ...stagedProvenance },
   });
 
   // 2.ter Reconcile .mcp.json against the engine's MCP servers (ADR 0025): register a

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -135,7 +135,10 @@ export async function reconcileBrain({
     // The two families of base, in one map keyed by the INSTALLED path: the manifest's
     // recorded sha256 for the `merge` skills, the pre-copy staging tree for the staged
     // ones. They can never collide — a staged skill is, by construction, not a merge file.
-    provenance: { ...(local?.provenance ?? {}), ...stagedProvenance },
+    // No `?? {}`: object spread already ignores undefined, so the fallback could not
+    // change a byte (mutation lesson — a guard that cannot matter is noise). The `?.`,
+    // on the other hand, is load-bearing: a caller may legitimately have no `local`.
+    provenance: { ...local?.provenance, ...stagedProvenance },
   });
 
   // 2.ter Reconcile .mcp.json against the engine's MCP servers (ADR 0025): register a

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -30,6 +30,7 @@ import { seedHealthNote } from "./staged-health-note.mjs";
 import { reconcileMcpServers } from "./mcp-reconcile.mjs";
 import { reconcileHooks, repairEngineHookCommands, repairWin32NodePrefix } from "./hooks-reconcile.mjs";
 import { needsReindex } from "./reindex-trigger.mjs";
+import { reseedProvenance } from "./engine-source.mjs";
 import { listFilesRelPosix } from "./fs-walk.mjs";
 import { selectEngineFilesToCopy } from "./engine-copy-select.mjs";
 import {
@@ -260,8 +261,9 @@ export async function runReconcileCli({ argv, seams = {} }) {
   if (!brainDir || !sourceDir) {
     throw new Error("reconcile-brain: --brainDir and --sourceDir are required");
   }
-  const manifest = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
-  return reconcileBrain({
+  const manifestPath = join(brainDir, "engine-manifest.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const report = await reconcileBrain({
     brainDir,
     platform,
     sourceDir,
@@ -272,6 +274,22 @@ export async function runReconcileCli({ argv, seams = {} }) {
     runReindex: seams.runReindex ?? defaultRunReindex,
     countVaultNotes: seams.countVaultNotes ?? defaultCountVaultNotes,
   });
+
+  // T1 — re-seed the provenance base of the skills we just refreshed. The child is the
+  // LAST writer of the brain's manifest on the update path (the parent's step 7 already
+  // ran, and on the first update carrying this feature the parent runs the OLD code, so
+  // the refresh happens HERE). Without this, a refreshed file no longer matches its
+  // recorded base → the next update calls it "user-modified" and never refreshes it
+  // again: the feature would work exactly once per brain, silently.
+  if (Object.keys(report.refreshedFileMap).length > 0) {
+    const provenance = reseedProvenance({
+      priorProvenance: manifest.provenance ?? {},
+      manifest,
+      deliveredFileMap: report.refreshedFileMap,
+    });
+    writeFileSync(manifestPath, JSON.stringify({ ...manifest, provenance }, null, 2) + "\n");
+  }
+  return report;
 }
 
 // Guarded so importing this module never runs the CLI. FAIL LOUD on error (exit 1) —

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -44,6 +44,13 @@ import {
 // SKIPPED a self-copy: in SessionStart self-heal mode srcDir === brainDir, so a file
 // would be copied onto itself — on Linux `copyFileSync(f, f)` truncates the dest before
 // copying (it would zero the engine file; ADR 0015 cross-platform safety). Skip it.
+// `{{PROJECT_ROOT}}` is substituted POSIX-normalised (cf. installer toPosix): the brain
+// dir reaches templates as `C:/Users/...`, never `C:\Users\...`, because the values land
+// in hook commands Git Bash also has to run — a backslash there is eaten (issue #31).
+// Exported so the win32 contract is verifiable on a POSIX CI, where the transform is
+// otherwise a no-op and any regression in it would be invisible.
+export const toPosix = (p) => p.split("\\").join("/");
+
 function copyInto(srcDir, destDir, rel) {
   const src = join(srcDir, rel);
   const dest = join(destDir, rel);
@@ -142,7 +149,7 @@ export async function reconcileBrain({
   const brainMcpPath = join(brainDir, ".mcp.json");
   const mcpServersAdded = [];
   if (existsSync(templatePath) && existsSync(brainMcpPath)) {
-    const projectRoot = brainDir.split("\\").join("/"); // {{PROJECT_ROOT}} is posix (cf. installer toPosix)
+    const projectRoot = toPosix(brainDir);
     const templateMcp = JSON.parse(readFileSync(templatePath, "utf8").split("{{PROJECT_ROOT}}").join(projectRoot));
     const engineServerIds = Object.keys(templateMcp.mcpServers ?? {}); // desired-state = delivered template keys
     const brainMcp = JSON.parse(readFileSync(brainMcpPath, "utf8"));
@@ -173,7 +180,7 @@ export async function reconcileBrain({
   const settingsTemplatePath = join(sourceDir, ".claude", "settings.json.template");
   const brainSettingsPath = join(brainDir, ".claude", "settings.json");
   if (existsSync(settingsTemplatePath) && existsSync(brainSettingsPath)) {
-    const projectRoot = brainDir.split("\\").join("/"); // {{PROJECT_ROOT}} is posix (cf. step 2.ter)
+    const projectRoot = toPosix(brainDir); // same normalisation as step 2.ter
     const brainSettings = JSON.parse(readFileSync(brainSettingsPath, "utf8"));
     const templateSettings = JSON.parse(readFileSync(settingsTemplatePath, "utf8"));
     const { hooks: addedHooks, hooksAdded: added } = reconcileHooks({

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 import { computeApplyPlan } from "./engine-apply-plan.mjs";
 import { matchesAny } from "./glob-match.mjs";
 import { installStagedSkills } from "./staged-skills.mjs";
+import { refreshUntouchedSkills } from "./engine-skill-refresh.mjs";
 import { seedHealthNote } from "./staged-health-note.mjs";
 import { reconcileMcpServers } from "./mcp-reconcile.mjs";
 import { reconcileHooks, repairEngineHookCommands, repairWin32NodePrefix } from "./hooks-reconcile.mjs";
@@ -96,6 +97,24 @@ export async function reconcileBrain({
   //    file → pass-1 delivers it). install-if-absent each into `.claude/skills/<name>/`,
   //    alongside the merge-skill install above; fold the names into the same report.
   installedSkills.push(...installStagedSkills({ sourceDir, brainDir }));
+
+  // 2.bis-refresh REFRESH the engine skills the brain has NOT touched (Increment 2.5).
+  //    install-if-absent above stops at the skill-DIR level, so an already-present skill
+  //    was frozen forever: 12 skill commits since v3.2.2 reached nobody, while their
+  //    deterministic cores (a `replace` glob) were refreshed → live core/skill drift.
+  //    Here we overwrite ONLY what the sha256 provenance base proves byte-identical to
+  //    what the engine last delivered; a customized skill is preserved and reported.
+  //    ⚠️ Guarded on `sourceDir !== brainDir`: a skill is only ever overwritten during an
+  //    update the owner explicitly asked for (auto-finalize hands us the FETCHED source),
+  //    NEVER at SessionStart self-heal (which passes the brain as its own source — no new
+  //    content, and nobody asked). ADR 0026's "additive" invariant holds where it matters.
+  const { skillsRefreshed, skillsPreserved, refreshedFileMap } = refreshUntouchedSkills({
+    brainDir,
+    sourceDir,
+    sourceFiles,
+    manifest: target,
+    provenance: local?.provenance ?? {},
+  });
 
   // 2.ter Reconcile .mcp.json against the engine's MCP servers (ADR 0025): register a
   //    newly-shipped engine server the brain is MISSING, taking its definition from the
@@ -207,7 +226,20 @@ export async function reconcileBrain({
   //    any reindex so it reflects the current vault.
   const vaultNoteCount = await countVaultNotes({ brainDir });
 
-  return { copied, regenerated, reindexed, reindexReason, vaultNoteCount, installedSkills, mcpServersAdded, hooksAdded, hooksRepaired };
+  return {
+    copied,
+    regenerated,
+    reindexed,
+    reindexReason,
+    vaultNoteCount,
+    installedSkills,
+    skillsRefreshed,
+    skillsPreserved,
+    refreshedFileMap,
+    mcpServersAdded,
+    hooksAdded,
+    hooksRepaired,
+  };
 }
 
 // ── CLI entry — what the auto-finalize child process runs (ADR 0026, Layer A) ──

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -89,10 +89,17 @@ export async function reconcileBrain({
   //    (possibly user-customized) is left byte-identical; a brand-new engine skill is
   //    copied in. Non-declared / custom skills are never in `installSkills` → untouchable.
   const installedSkills = [];
+  // What install-if-absent WRITES is engine-delivered content, so it needs a provenance
+  // base like any other delivered merge file. Without it the freshly-installed skill
+  // reads `no-provenance` at every later update and is frozen forever — the very freeze
+  // this increment removes, re-entering by the install-if-absent door.
+  const installedFileMap = {};
   for (const skillGlob of plan.installSkills) {
     const skillDir = skillGlob.replace(/\/\*\*?$/, ""); // ".../local-mirror/**" → ".../local-mirror"
     if (existsSync(join(brainDir, skillDir))) continue; // present → preserve, never overwrite
-    for (const rel of sourceFiles.filter((f) => matchesAny([skillGlob], f))) copyInto(sourceDir, brainDir, rel);
+    for (const rel of sourceFiles.filter((f) => matchesAny([skillGlob], f))) {
+      if (copyInto(sourceDir, brainDir, rel)) installedFileMap[rel] = readFileSync(join(brainDir, rel), "utf8");
+    }
     installedSkills.push(skillDir.split("/").pop()); // the skill name, for the report
   }
 
@@ -241,6 +248,7 @@ export async function reconcileBrain({
     reindexReason,
     vaultNoteCount,
     installedSkills,
+    installedFileMap,
     skillsRefreshed,
     skillsPreserved,
     refreshedFileMap,
@@ -288,11 +296,12 @@ export async function runReconcileCli({ argv, seams = {} }) {
   // the refresh happens HERE). Without this, a refreshed file no longer matches its
   // recorded base → the next update calls it "user-modified" and never refreshes it
   // again: the feature would work exactly once per brain, silently.
-  if (Object.keys(report.refreshedFileMap).length > 0) {
+  const delivered = { ...report.installedFileMap, ...report.refreshedFileMap };
+  if (Object.keys(delivered).length > 0) {
     const provenance = reseedProvenance({
       priorProvenance: manifest.provenance ?? {},
       manifest,
-      deliveredFileMap: report.refreshedFileMap,
+      deliveredFileMap: delivered,
     });
     writeFileSync(manifestPath, JSON.stringify({ ...manifest, provenance }, null, 2) + "\n");
   }

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -20,8 +20,8 @@
 // ─────────────────────────────────────────────────────────────────────────────
 import { readFileSync, writeFileSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
+import { isEntrypoint } from "./entrypoint.mjs";
 import { computeApplyPlan } from "./engine-apply-plan.mjs";
 import { matchesAny } from "./glob-match.mjs";
 import { installStagedSkills, readStagedProvenance } from "./staged-skills.mjs";
@@ -308,13 +308,37 @@ export async function runReconcileCli({ argv, seams = {} }) {
   return report;
 }
 
-// Guarded so importing this module never runs the CLI. FAIL LOUD on error (exit 1) —
-// auto-finalize's own caller treats a child failure as best-effort (fail-soft there).
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  runReconcileCli({ argv: process.argv.slice(2) })
-    .then(() => process.exit(0))
-    .catch((e) => {
-      process.stderr.write(`\n❌ reconcile-brain failed.\n${e?.message ?? e}\n`);
-      process.exit(1);
-    });
+// The real I/O the child process runs on: the flags it was actually launched with and
+// the real stderr. Everything `runReconcileCliProcess` decides is testable BECAUSE it is
+// handed these instead of reaching for them (the `clear-example-notes` idiom, twin of
+// update-engine's `realUpdateDeps`) — the entry-point block below is now pure wiring.
+export const realReconcileDeps = {
+  argv: process.argv.slice(2),
+  runReconcileCli,
+  error: (s) => process.stderr.write(s),
+};
+
+// What the auto-finalize child process does, minus the process. Returns the exit code.
+// FAIL LOUD on error (exit 1) — auto-finalize's own caller treats a child failure as
+// best-effort (fail-soft there), so this banner is the ONLY trace a broken reconcile
+// leaves behind. `?? e` catches a thrown non-Error (a bare string); `?? "no reason
+// given"` catches a rejection with no reason at all — a ❌ over an empty line tells
+// nobody anything.
+export async function runReconcileCliProcess(deps = realReconcileDeps) {
+  try {
+    await deps.runReconcileCli({ argv: deps.argv });
+    return 0;
+  } catch (e) {
+    deps.error(`\n❌ reconcile-brain failed.\n${e?.message ?? e ?? "no reason given"}\n`);
+    return 1;
+  }
+}
+
+// ── CLI entry ────────────────────────────────────────────────────────────────
+// Guarded so importing this module never runs the CLI. Through the canonical
+// `isEntrypoint` (bug B2): a hand-rolled path/URL comparison silently never matches on
+// Windows paths or paths carrying a space, and a guard that never fires makes the whole
+// command an inert no-op that says nothing about it.
+if (isEntrypoint(import.meta.url, process.argv[1])) {
+  process.exit(await runReconcileCliProcess());
 }

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -872,3 +872,82 @@ test("reconcileBrain — a FR brain is refreshed from the FR source, never re-an
   );
   assert.deepEqual(report.skillsRefreshed, ["coach"]);
 });
+
+// ── T1: the trap that would make this feature die silently after ONE use ─────
+// A refreshed file no longer matches the base recorded for it. Unless the base is
+// re-seeded, the NEXT update classifies it "user-modified" and never refreshes it
+// again — the feature would work exactly once per brain, silently.
+test("runReconcileCli — re-seeds the provenance base of what it refreshed (T1)", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const delivered = "---\nname: switch\n---\nSwitch universes.\n";
+  const improved = delivered + "\nSingle-account native-connectors reminder.\n";
+  writeFile(brainDir, ".claude/skills/switch/SKILL.md", delivered);
+  writeFile(sourceDir, ".claude/skills/switch/SKILL.md", improved);
+  writeFile(
+    brainDir,
+    "engine-manifest.json",
+    JSON.stringify(
+      {
+        ...manifest({ extraMerge: [".claude/skills/switch/**"] }),
+        provenance: { ".claude/skills/switch/SKILL.md": base(delivered) },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const { ...s } = seams();
+  const runReconcileCli = await loadCli();
+  const report = await runReconcileCli({
+    argv: ["--brainDir", brainDir, "--sourceDir", sourceDir, "--platform", "posix"],
+    seams: s,
+  });
+
+  assert.deepEqual(report.skillsRefreshed, ["switch"]);
+  const persisted = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
+  assert.equal(
+    persisted.provenance[".claude/skills/switch/SKILL.md"],
+    base(improved),
+    "the base now describes what the engine JUST delivered",
+  );
+});
+
+test("runReconcileCli — refreshing twice in a row is a clean no-op, NOT a 'customized' verdict (T1)", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const delivered = "---\nname: coach\n---\nYour sparring partner.\n";
+  const improved = delivered + "\nA newer section.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", delivered);
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", improved);
+  writeFile(
+    brainDir,
+    "engine-manifest.json",
+    JSON.stringify(
+      {
+        ...manifest({ extraMerge: [".claude/skills/coach/**"] }),
+        provenance: { ".claude/skills/coach/SKILL.md": base(delivered) },
+      },
+      null,
+      2,
+    ),
+  );
+  const runReconcileCli = await loadCli();
+  const argv = ["--brainDir", brainDir, "--sourceDir", sourceDir, "--platform", "posix"];
+
+  const first = await runReconcileCli({ argv, seams: seams() });
+  const second = await runReconcileCli({ argv, seams: seams() });
+
+  assert.deepEqual(first.skillsRefreshed, ["coach"]);
+  assert.deepEqual(second.skillsRefreshed, [], "nothing left to do the second time");
+  assert.deepEqual(second.skillsPreserved, [], "the refreshed file is NOT mistaken for a customization");
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"), improved);
+});

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -245,6 +245,9 @@ test("reconcileBrain — index schema moved → reindex runs and is reported", a
   assert.deepEqual(calls.reindex, [brainDir], "schema moved → reindex must run once in the brain");
   assert.deepEqual(calls.reindexMode, ["full"], "a schema move re-encodes every note → FULL reindex");
   assert.equal(report.reindexed, true);
+  // The REASON is user-facing (update-engine's report says whether every note was
+  // re-encoded or not), so it is asserted by value, not merely as "truthy".
+  assert.equal(report.reindexReason, "schema");
 });
 
 // ── Test 4: THE EXTENSIBILITY INVARIANT (the project's promise — users may grow
@@ -398,6 +401,9 @@ test("reconcileBrain — seeds the engine-health note on an upgrader (absent) an
   assert.deepEqual(calls.reindex, [brainDir], "seeding the note must trigger a paired reindex");
   assert.deepEqual(calls.reindexMode, ["incremental"], "the seed pairing is INCREMENTAL (only the one note), never a full re-encode");
   assert.equal(report.reindexed, true);
+  // The two reasons must stay DISTINGUISHABLE: the schema case re-encodes the whole
+  // vault, this one does not, and the report tells the user which of the two happened.
+  assert.equal(report.reindexReason, "health-note-seed");
 });
 
 // ── Test 8: WRITE-IF-ABSENT + the index is its own membership oracle (ADR 0026,
@@ -1340,6 +1346,44 @@ test("runReconcileCli — a file it delivers under an existing skill stays refre
   assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md"), "utf8"), improved);
   const persisted = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
   assert.equal(persisted.provenance[".claude/skills/coach/references/radical-candor.md"], base(improved));
+});
+
+// The absent case for the launchers, never fed until now: a manifest that declares NO
+// `regenerate` bucket. Regenerating launchers is not free (it rewrites four files, which
+// the auto-commit hook then sees), so "nothing declared" must mean nothing done — and be
+// reported as such. Mirror image of test 1, which only ever saw a populated bucket.
+test("reconcileBrain — a manifest with an EMPTY regenerate bucket regenerates nothing", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const target = { ...manifest(), regimes: { ...manifest().regimes, regenerate: [] } };
+
+  const { calls, ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local: target, ...s });
+
+  assert.deepEqual(calls.regenerate, [], "nothing declared → the launcher seam is never called");
+  assert.equal(report.regenerated, false);
+  assert.equal(existsSync(join(brainDir, "rag/launch.sh")), false, "no launcher may appear out of nowhere");
+});
+
+// …and its mirror: a populated bucket regenerates, and SAYS it did.
+test("reconcileBrain — a populated regenerate bucket regenerates, and reports it", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const target = manifest();
+
+  const { calls, ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local: target, ...s });
+
+  assert.deepEqual(calls.regenerate, ["posix"]);
+  assert.equal(report.regenerated, true);
 });
 
 // ── The CLI's own contract: flag parsing, seam wiring, manifest write ────────

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -146,6 +146,11 @@ test("reconcileBrain — copies engine files, installs a missing engine skill, r
   // Missing engine skill installed from the source, and named in the report.
   assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"), skillBody);
   assert.deepEqual(report.installedSkills, ["coach"]);
+  // …and it is reported as INSTALLED, never as "brought up to date". Since Step 8.5's F2
+  // the refresh pass ALSO delivers an absent file (`absent-install`), so a broken
+  // install-if-absent would still put the bytes on disk — under the wrong headline, and
+  // stripped of its new-capability status (no restart counter, no "run once more").
+  assert.deepEqual(report.skillsRefreshed, [], "a skill that was ABSENT is installed, not refreshed");
   // Launchers regenerated once for this platform.
   assert.deepEqual(calls.regenerate, ["posix"]);
   assert.ok(existsSync(join(brainDir, "rag/launch.sh")));

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -1085,3 +1085,38 @@ test("runReconcileCli — refreshing twice in a row is a clean no-op, NOT a 'cus
   assert.deepEqual(second.skillsPreserved, [], "the refreshed file is NOT mistaken for a customization");
   assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"), improved);
 });
+
+// ── T1's sibling, found by the release-fixture QA (plan Step 8) ──────────────
+// install-if-absent (ADR 0025) delivers a skill the brain lacks — and recorded no base
+// for it. That skill would then read "no-provenance" at EVERY later update and never be
+// refreshed again: the exact freeze this increment removes, re-entering by the other
+// door. The cohort that just received `switch` must not be frozen on it forever.
+test("runReconcileCli — a skill it INSTALLS gets a provenance base, so the next update can refresh it", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const delivered = "---\nname: switch\n---\nSwitch universes.\n";
+  writeFile(sourceDir, ".claude/skills/switch/SKILL.md", delivered); // absent from the brain
+  writeFile(
+    brainDir,
+    "engine-manifest.json",
+    JSON.stringify({ ...manifest({ extraMerge: [".claude/skills/switch/**"] }), provenance: {} }, null, 2),
+  );
+
+  const runReconcileCli = await loadCli();
+  const report = await runReconcileCli({
+    argv: ["--brainDir", brainDir, "--sourceDir", sourceDir, "--platform", "posix"],
+    seams: seams(),
+  });
+
+  assert.deepEqual(report.installedSkills, ["switch"]);
+  const persisted = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
+  assert.equal(
+    persisted.provenance[".claude/skills/switch/SKILL.md"],
+    base(delivered),
+    "the base describes what was just installed — without it the skill is frozen forever",
+  );
+});

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -10,6 +10,8 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1329,4 +1331,123 @@ test("runReconcileCli — a file it delivers under an existing skill stays refre
   assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md"), "utf8"), improved);
   const persisted = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
   assert.equal(persisted.provenance[".claude/skills/coach/references/radical-candor.md"], base(improved));
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The COMPOSITION ROOT (Step 10). Everything above hands `runReconcileCli` its
+// argv and its seams, so nothing exercised the process-level wiring: the argv
+// slice, the error banner, the exit code, the entry-point guard. That is where
+// the survivors clustered — the same shape, and the same fix, as
+// `update-engine.mjs`'s `runUpdateCli(deps)` / `realUpdateDeps`.
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function loadProcessCli() {
+  return (await import("./reconcile-brain.mjs")).runReconcileCliProcess;
+}
+
+test("runReconcileCliProcess — a successful reconcile exits 0 and stays silent", async () => {
+  const seen = [];
+  const err = [];
+  const runReconcileCliProcess = await loadProcessCli();
+
+  const code = await runReconcileCliProcess({
+    argv: ["--brainDir", "/brains/mine", "--sourceDir", "/src"],
+    runReconcileCli: async (args) => seen.push(args) && { copied: [] },
+    error: (s) => err.push(s),
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(err, [], "a successful reconcile is a silent finisher — it must not write to stderr");
+  assert.deepEqual(seen, [{ argv: ["--brainDir", "/brains/mine", "--sourceDir", "/src"] }]);
+});
+
+// FAIL LOUD (the project's strategy): auto-finalize's own caller treats a child failure
+// as best-effort, so this banner + exit code is the ONLY trace a broken reconcile leaves.
+test("runReconcileCliProcess — a failure exits 1 and says exactly what broke", async () => {
+  const err = [];
+  const runReconcileCliProcess = await loadProcessCli();
+
+  const code = await runReconcileCliProcess({
+    argv: [],
+    runReconcileCli: async () => {
+      throw new Error("engine-manifest.json is unreadable");
+    },
+    error: (s) => err.push(s),
+  });
+
+  assert.equal(code, 1);
+  assert.deepEqual(err, ["\n❌ reconcile-brain failed.\nengine-manifest.json is unreadable\n"]);
+});
+
+// The bottom of the barrel, twin of update-engine's: a rejection with NO reason at all
+// (a thrown non-Error, an aborted child). A ❌ banner over an empty line tells nobody
+// anything — and this is the one output a failed reconcile leaves behind.
+test("runReconcileCliProcess — a rejection with no reason still explains itself", async () => {
+  const err = [];
+  const runReconcileCliProcess = await loadProcessCli();
+
+  const code = await runReconcileCliProcess({
+    argv: [],
+    runReconcileCli: async () => {
+      throw null;
+    },
+    error: (s) => err.push(s),
+  });
+
+  assert.equal(code, 1);
+  assert.deepEqual(err, ["\n❌ reconcile-brain failed.\nno reason given\n"]);
+});
+
+// A thrown bare string has no `.message` — the fallback must print the string itself,
+// not the word "undefined".
+test("runReconcileCliProcess — a thrown bare string is printed as-is", async () => {
+  const err = [];
+  const runReconcileCliProcess = await loadProcessCli();
+
+  const code = await runReconcileCliProcess({
+    argv: [],
+    runReconcileCli: async () => {
+      throw "npm exited 137";
+    },
+    error: (s) => err.push(s),
+  });
+
+  assert.equal(code, 1);
+  assert.deepEqual(err, ["\n❌ reconcile-brain failed.\nnpm exited 137\n"]);
+});
+
+// The wiring itself — the one thing `runReconcileCliProcess(deps)` can never prove,
+// since every test above hands it doubles. If `realReconcileDeps` passed the wrong argv
+// slice (node + the script path leaking in as flags) or a swallowing stream, the child
+// would run flawlessly against nothing and say so.
+test("realReconcileDeps — carries the process flags (not node/script) and the real stderr", async () => {
+  const { realReconcileDeps, runReconcileCli } = await import("./reconcile-brain.mjs");
+
+  assert.deepEqual(realReconcileDeps.argv, process.argv.slice(2));
+  assert.equal(realReconcileDeps.runReconcileCli, runReconcileCli);
+
+  const errs = [];
+  const realErr = process.stderr.write;
+  process.stderr.write = (s) => errs.push(s) && true;
+  try {
+    realReconcileDeps.error("boom\n");
+  } finally {
+    process.stderr.write = realErr;
+  }
+  assert.deepEqual(errs, ["boom\n"]);
+});
+
+// …and the last untested link: that the entry-point guard actually FIRES. Bug B2 was
+// exactly this class — a guard that silently never matched, so running the command did
+// nothing at all and said nothing about it. Everything above can be green while the
+// script is an inert no-op, so run it for real, as a process. Safe by construction: with
+// no flags it rejects before touching a single file.
+test("the CLI entry point actually runs the reconcile (and fails LOUDLY, never silently)", () => {
+  const script = fileURLToPath(new URL("./reconcile-brain.mjs", import.meta.url));
+
+  const r = spawnSync(process.execPath, [script], { encoding: "utf8" });
+
+  assert.equal(r.status, 1, "a script whose entry guard never fires would exit 0");
+  assert.equal(r.stderr, "\n❌ reconcile-brain failed.\nreconcile-brain: --brainDir and --sourceDir are required\n");
+  assert.equal(r.stdout, "", "a failed reconcile must not print anything to stdout");
 });

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -706,7 +706,20 @@ test("reconcileBrain (win32) — a repair with nothing added and no statusLine s
   });
 
   assert.deepEqual(report.hooksAdded, [], "the broken brain already wires every engine hook");
-  assert.ok(report.hooksRepaired.includes("scripts/session-self-heal.mjs"), "the repair itself is the only reason to write");
+  // The WHOLE list, not `.includes`: a report that also claimed to have repaired a
+  // statusLine this brain does not even have would be a lie the user acts on.
+  assert.deepEqual(
+    [...report.hooksRepaired].sort(),
+    [
+      "scripts/auto-commit.mjs",
+      "scripts/auto-push.mjs",
+      "scripts/session-health.mjs",
+      "scripts/session-obsidian-hint.mjs",
+      "scripts/session-self-heal.mjs",
+      "scripts/session-status.mjs",
+    ],
+    "the repair itself is the only reason to write — and it reports exactly what it healed",
+  );
   const settings = JSON.parse(readFileSync(join(brainDir, ".claude/settings.json"), "utf8"));
   const cmds = Object.values(settings.hooks).flatMap((groups) => groups.flatMap((g) => g.hooks.map((h) => h.command)));
   for (const cmd of cmds) assert.doesNotMatch(cmd, /cmd \/c/i, "the healed commands must actually be on disk");
@@ -793,9 +806,20 @@ test("reconcileBrain (win32) — heals the issue-#31 broken hook + statusLine co
     assert.doesNotMatch(cmd, /\\/, "no backslash must remain (Git Bash would eat it)");
     assert.match(cmd, new RegExp(`^${rootPosix}/scripts/run-node\\.cmd `), "the fixed forward-slash run-node.cmd prefix");
   }
-  assert.ok(report.hooksRepaired.includes("scripts/session-self-heal.mjs"), "a healed hook is reported");
-  assert.ok(report.hooksRepaired.includes("scripts/auto-push.mjs"), "the Stop hook is healed too");
-  assert.ok(report.hooksRepaired.includes("statusLine"), "the statusLine command is healed too");
+  // The whole list, in one assertion: the Stop hook and the top-level statusLine are
+  // healed alongside the SessionStart ones, and nothing else is claimed.
+  assert.deepEqual(
+    [...report.hooksRepaired].sort(),
+    [
+      "scripts/auto-commit.mjs",
+      "scripts/auto-push.mjs",
+      "scripts/session-health.mjs",
+      "scripts/session-obsidian-hint.mjs",
+      "scripts/session-self-heal.mjs",
+      "scripts/session-status.mjs",
+      "statusLine",
+    ],
+  );
   assert.equal(settings.mine, true, "a user-owned settings key survives the repair");
 
   // Idempotent: a second self-heal pass repairs nothing and leaves the file byte-identical.

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -816,7 +816,75 @@ test("reconcileBrain — a CUSTOMIZED skill is preserved byte-for-byte and repor
     "the owner's customized skill is untouched",
   );
   assert.deepEqual(report.skillsRefreshed, []);
-  assert.deepEqual(report.skillsPreserved, [{ skill: "prepare-1-1", reason: "customized" }]);
+  assert.deepEqual(report.skillsPreserved, [
+    { skill: "prepare-1-1", reason: "customized", newVersionPath: ".claude/skills/prepare-1-1/SKILL.md.new" },
+  ]);
+});
+
+test("reconcileBrain — the new version of a customized skill is dropped alongside as .new", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  // "We never overwrite your version" must not mean "you never get the improvement":
+  // the engine's version is left BESIDE the owner's, so adopting it (or cherry-picking
+  // from it) is a conversation away instead of invisible. Conffile fallback, plan §The
+  // decision. `.new` is not a `SKILL.md`, so Claude never loads it as a second skill.
+  const delivered = "---\nname: prepare-1-1\n---\nPrepare a 1-1.\n";
+  const mine = delivered + "\n## My own KPIs\nARR, churn.\n";
+  const candidate = delivered + "\nNew engine section.\n";
+  writeFile(brainDir, ".claude/skills/prepare-1-1/SKILL.md", mine);
+  writeFile(sourceDir, ".claude/skills/prepare-1-1/SKILL.md", candidate);
+  const target = manifest({ extraMerge: [".claude/skills/prepare-1-1/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/prepare-1-1/**"] }),
+    provenance: { ".claude/skills/prepare-1-1/SKILL.md": base(delivered) },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/prepare-1-1/SKILL.md.new"), "utf8"),
+    candidate,
+    "the engine version is available, verbatim, next to the owner's",
+  );
+  assert.deepEqual(report.skillsPreserved, [
+    { skill: "prepare-1-1", reason: "customized", newVersionPath: ".claude/skills/prepare-1-1/SKILL.md.new" },
+  ]);
+});
+
+test("reconcileBrain — a stale .new is cleared once the owner has adopted the new version", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  // The owner read the `.new` we dropped last time and pasted it over their own file.
+  // Leaving the sidecar behind would keep claiming "a newer version awaits" forever —
+  // a stale prompt to do work that is already done.
+  const candidate = "---\nname: prepare-1-1\n---\nPrepare a 1-1.\nNew engine section.\n";
+  writeFile(brainDir, ".claude/skills/prepare-1-1/SKILL.md", candidate);
+  writeFile(brainDir, ".claude/skills/prepare-1-1/SKILL.md.new", candidate);
+  writeFile(sourceDir, ".claude/skills/prepare-1-1/SKILL.md", candidate);
+  const target = manifest({ extraMerge: [".claude/skills/prepare-1-1/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/prepare-1-1/**"] }),
+    provenance: { ".claude/skills/prepare-1-1/SKILL.md": base(candidate) },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(
+    existsSync(join(brainDir, ".claude/skills/prepare-1-1/SKILL.md.new")),
+    false,
+    "nothing newer is pending → the sidecar must not survive",
+  );
+  assert.deepEqual(report.skillsPreserved, []);
 });
 
 test("reconcileBrain — SessionStart self-heal (sourceDir === brainDir) refreshes NOTHING and reports nothing", async (t) => {

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -92,8 +92,14 @@ function buildSource() {
 
 // Inject all four I/O seams; record their side effects. regenerateLaunchers writes
 // the launcher files (mirrors the real builder) so existence can be asserted.
+// `countVaultNotes` returns a DISTINCTIVE count (not 0) and records the brainDir it was
+// handed: a stub that returns 0 and ignores its argument cannot tell a wired seam from an
+// unwired one — the reconciler could call the real counter, or call it with no brain at
+// all, and every assertion would still hold.
+const STUB_VAULT_NOTES = 407;
+
 function seams() {
-  const calls = { install: [], reindex: [], reindexMode: [], regenerate: [] };
+  const calls = { install: [], reindex: [], reindexMode: [], regenerate: [], count: [] };
   return {
     calls,
     regenerateLaunchers: async ({ brainDir, platform }) => {
@@ -107,7 +113,10 @@ function seams() {
       calls.reindex.push(brainDir);
       calls.reindexMode.push(mode);
     },
-    countVaultNotes: async () => 0,
+    countVaultNotes: async ({ brainDir }) => {
+      calls.count.push(brainDir);
+      return STUB_VAULT_NOTES;
+    },
   };
 }
 
@@ -1331,6 +1340,103 @@ test("runReconcileCli — a file it delivers under an existing skill stays refre
   assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md"), "utf8"), improved);
   const persisted = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
   assert.equal(persisted.provenance[".claude/skills/coach/references/radical-candor.md"], base(improved));
+});
+
+// ── The CLI's own contract: flag parsing, seam wiring, manifest write ────────
+// `runReconcileCli` is what the auto-finalize CHILD is launched as, so its argv
+// handling is load-bearing: a flag silently read as `undefined` converges the wrong
+// folder (or nothing at all) while every in-process test stays green.
+
+test("runReconcileCli — refuses to run without BOTH directories, whichever one is missing", async () => {
+  const runReconcileCli = await loadCli();
+  const required = /reconcile-brain: --brainDir and --sourceDir are required/;
+
+  await assert.rejects(runReconcileCli({ argv: [] }), required);
+  await assert.rejects(runReconcileCli({ argv: ["--brainDir", "/brains/mine"] }), required);
+  await assert.rejects(runReconcileCli({ argv: ["--sourceDir", "/src"] }), required);
+  // A flag in LAST position carries no value — indistinguishable from an absent one.
+  await assert.rejects(runReconcileCli({ argv: ["--sourceDir", "/src", "--brainDir"] }), required);
+});
+
+// The platform decides which launcher halves get regenerated and which hook commands
+// get the win32 repair, so a `--platform` that never reaches the seams is a silent
+// cross-platform bug. Triangulated: the flag when given, this process's platform when not
+// — and an ABSENT flag must yield NO value, never the first argv entry it happens to sit near.
+test("runReconcileCli — the --platform flag reaches the seams, and defaults to this process's platform", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  writeFile(brainDir, "engine-manifest.json", JSON.stringify(manifest(), null, 2));
+  const runReconcileCli = await loadCli();
+
+  const given = seams();
+  await runReconcileCli({
+    argv: ["--brainDir", brainDir, "--sourceDir", sourceDir, "--platform", "win32"],
+    seams: given,
+  });
+  assert.deepEqual(given.calls.regenerate, ["win32"]);
+
+  const omitted = seams();
+  await runReconcileCli({ argv: ["--brainDir", brainDir, "--sourceDir", sourceDir], seams: omitted });
+  assert.deepEqual(omitted.calls.regenerate, [process.platform]);
+});
+
+// The seams the caller DOES pass must be the ones used — the `?? default` fallbacks are
+// there for the real child process, not to quietly override an injected double. Proven by
+// a stub whose count no real vault would return, handed the brain it was asked about.
+test("runReconcileCli — uses the seams it is given, brain and all, rather than the real I/O", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  writeFile(brainDir, "engine-manifest.json", JSON.stringify(manifest(), null, 2));
+
+  const { calls, ...s } = seams();
+  const runReconcileCli = await loadCli();
+  const report = await runReconcileCli({
+    argv: ["--brainDir", brainDir, "--sourceDir", sourceDir, "--platform", "posix"],
+    seams: s,
+  });
+
+  assert.equal(report.vaultNoteCount, STUB_VAULT_NOTES);
+  assert.deepEqual(calls.count, [brainDir], "the note count must be taken on the brain being reconciled");
+  assert.deepEqual(calls.install, [join(brainDir, "rag")]);
+});
+
+// The T1 re-seed writes the brain's manifest — the file every later update reads to decide
+// what it may touch. Two things must hold, and neither was pinned: it is written as a
+// well-formed text file (2-space indent + FINAL NEWLINE, it is git-committed and diffed at
+// every update), and a run that delivers NOTHING must not rewrite it at all. The fixture is
+// deliberately stored NON-canonically (compact JSON) so an unconditional rewrite is visible
+// as a byte change instead of hiding behind identical formatting.
+test("runReconcileCli — writes the manifest as a text file when it re-seeds, and not at all when it delivers nothing", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const manifestPath = join(brainDir, "engine-manifest.json");
+  writeFileSync(manifestPath, JSON.stringify(manifest())); // compact, no trailing newline
+  const untouched = readFileSync(manifestPath, "utf8");
+  const runReconcileCli = await loadCli();
+  const argv = ["--brainDir", brainDir, "--sourceDir", sourceDir, "--platform", "posix"];
+
+  await runReconcileCli({ argv, seams: seams() });
+  assert.equal(readFileSync(manifestPath, "utf8"), untouched, "nothing delivered → the manifest is not rewritten");
+
+  // Now give the source a skill to deliver: the re-seed fires and rewrites the manifest.
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", "---\nname: coach\n---\nYour sparring partner.\n");
+  writeFileSync(manifestPath, JSON.stringify(manifest({ extraMerge: [".claude/skills/coach/**"] })));
+  await runReconcileCli({ argv, seams: seams() });
+
+  const raw = readFileSync(manifestPath, "utf8");
+  assert.equal(raw, JSON.stringify(JSON.parse(raw), null, 2) + "\n");
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -1458,6 +1458,54 @@ test("runReconcileCli — a file it delivers under an existing skill stays refre
   assert.equal(persisted.provenance[".claude/skills/coach/references/radical-candor.md"], base(improved));
 });
 
+// Every glob in the real manifest today is `<skill>/**`, so the SINGLE-star shape — a
+// manifest declaring only a skill's top-level files — had never been fed. It must still
+// resolve to the skill's DIRECTORY: get that wrong and install-if-absent tests a path
+// that can never exist, so the skill is re-installed on every single update, and the
+// report names it `*` instead of the skill.
+test("reconcileBrain — a single-star skill glob still resolves to the skill's directory", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", "---\nname: coach\n---\nYour sparring partner.\n");
+  const target = manifest({ extraMerge: [".claude/skills/coach/*"] });
+
+  const first = await reconcile({ brainDir, platform: "posix", sourceDir, target, local: target, ...seams() });
+  const second = await reconcile({ brainDir, platform: "posix", sourceDir, target, local: target, ...seams() });
+
+  assert.deepEqual(first.installedSkills, ["coach"], "reported under the skill's name, not the wildcard");
+  assert.equal(existsSync(join(brainDir, ".claude/skills/coach/SKILL.md")), true);
+  assert.deepEqual(second.installedSkills, [], "the skill dir now exists → never re-installed");
+});
+
+// A caller that knows the TARGET but has no `local` manifest to offer (the shape any
+// converge-only caller has). Provenance must then read as empty rather than crash: a
+// throw here aborts the whole reconcile, and with it the launchers, the install and the
+// reindex — for a brain that was merely missing a baseline.
+test("reconcileBrain — a reconcile with no `local` manifest at all still converges", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const skill = "---\nname: coach\n---\nYour sparring partner.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", skill);
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", skill + "Challenge directly.\n");
+  const target = manifest({ extraMerge: [".claude/skills/coach/**"] });
+
+  const { calls, ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, ...s });
+
+  assert.deepEqual(report.skillsRefreshed, [], "no base on record → nothing may be overwritten");
+  assert.deepEqual(report.skillsPreserved, [{ skill: "coach", reason: "no-provenance" }]);
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"), skill, "the brain's copy is left alone");
+  assert.deepEqual(calls.install, [join(brainDir, "rag")], "the rest of the converge still runs");
+});
+
 // ── The {{PROJECT_ROOT}} normalisation, made verifiable OFF Windows ──────────
 // On a POSIX CI the transform is a no-op on every real path, so a regression in it
 // would be invisible there and would only surface on the deployed Windows fleet — as

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -896,6 +896,128 @@ test("reconcileBrain — a NEW file under an ALREADY-INSTALLED skill is delivere
   assert.deepEqual(report.skillsPreserved, []);
 });
 
+// A pre-provenance brain: the file is engine-shipped but nothing was ever fingerprinted
+// for it, so "untouched" is UNPROVABLE. We keep the owner's copy either way, but the two
+// preserves are NOT the same report: `no-provenance` must not call them a customizer, and
+// must NOT litter the brain with a `.new` for a claim we cannot make. A sidecar left by an
+// earlier update is cleared all the same — only `preserve: customized` still has something
+// newer genuinely pending.
+test("reconcileBrain — an UNPROVABLE skill is preserved WITHOUT a .new, and a stale one is cleared", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const theirs = "---\nname: coach\n---\nYour sparring partner, as they have it.\n";
+  const candidate = theirs + "\nA newer engine section.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", theirs);
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md.new", "left over from an earlier update\n");
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", candidate);
+  const target = manifest({ extraMerge: [".claude/skills/coach/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/coach/**"] }),
+    provenance: {}, // nothing was ever recorded for this file
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"), theirs);
+  assert.deepEqual(report.skillsRefreshed, []);
+  assert.deepEqual(
+    report.skillsPreserved,
+    [{ skill: "coach", reason: "no-provenance" }],
+    "reported as unprovable, NOT as a customization, and with no .new to point at",
+  );
+  assert.equal(
+    existsSync(join(brainDir, ".claude/skills/coach/SKILL.md.new")),
+    false,
+    "we make no claim here, so the old sidecar's claim must not survive either",
+  );
+});
+
+// The report speaks in SKILLS, the refresh works in FILES. Now that a skill can hold more
+// than one engine file, the two counts diverge: what the owner must read is "your coach
+// skill was brought up to date", once, not the same name repeated per file touched.
+test("reconcileBrain — TWO refreshed files in ONE skill are reported as ONE skill", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const skillWas = "---\nname: coach\n---\nYour sparring partner.\n";
+  const refWas = "# Radical Candor\nCare personally.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", skillWas);
+  writeFile(brainDir, ".claude/skills/coach/references/radical-candor.md", refWas);
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", skillWas + "Now with examples.\n");
+  writeFile(sourceDir, ".claude/skills/coach/references/radical-candor.md", refWas + "Challenge directly.\n");
+  const target = manifest({ extraMerge: [".claude/skills/coach/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/coach/**"] }),
+    provenance: {
+      ".claude/skills/coach/SKILL.md": base(skillWas),
+      ".claude/skills/coach/references/radical-candor.md": base(refWas),
+    },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.deepEqual(report.skillsRefreshed, ["coach"], "named once, not once per file");
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"),
+    skillWas + "Now with examples.\n",
+  );
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md"), "utf8"),
+    refWas + "Challenge directly.\n",
+    "both files moved, even though the skill is named once",
+  );
+});
+
+test("reconcileBrain — TWO customized files in ONE skill are reported once, but BOTH get a .new", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const skillWas = "---\nname: coach\n---\nYour sparring partner.\n";
+  const refWas = "# Radical Candor\nCare personally.\n";
+  const skillNext = skillWas + "Engine's newer take.\n";
+  const refNext = refWas + "Engine's newer reference.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", skillWas + "MY OWN tone.\n");
+  writeFile(brainDir, ".claude/skills/coach/references/radical-candor.md", refWas + "MY OWN notes.\n");
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", skillNext);
+  writeFile(sourceDir, ".claude/skills/coach/references/radical-candor.md", refNext);
+  const target = manifest({ extraMerge: [".claude/skills/coach/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/coach/**"] }),
+    provenance: {
+      ".claude/skills/coach/SKILL.md": base(skillWas),
+      ".claude/skills/coach/references/radical-candor.md": base(refWas),
+    },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(report.skillsPreserved.length, 1, "one line per SKILL, not per file");
+  assert.deepEqual(
+    report.skillsPreserved.map(({ skill, reason }) => ({ skill, reason })),
+    [{ skill: "coach", reason: "customized" }],
+  );
+  // Reporting once must not mean delivering once: every customized file still gets its own
+  // sidecar, or the owner silently loses the engine's newer version of the unnamed one.
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md.new"), "utf8"), skillNext);
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md.new"), "utf8"),
+    refNext,
+  );
+});
+
 // ── STAGED skills (engine-skills/) get the same treatment as the merge 9 ─────
 // A staged skill (local-mirror, lint, open-note…) is delivered install-if-absent from
 // the non-sacred `engine-skills/<name>/` path, and provenance is recorded for `merge`

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -54,13 +54,13 @@ const SACRED = {
   "vault/my-note.md": "# Mollecuisse\nThe canary that must never be lost.\n",
 };
 
-function manifest({ ragVersion = "1.1.0", indexSchemaVersion = 1, extraMerge = [], engineMcpServers = ["vault-rag"] } = {}) {
+function manifest({ ragVersion = "1.1.0", indexSchemaVersion = 1, extraMerge = [], extraReplace = [], engineMcpServers = ["vault-rag"] } = {}) {
   return {
     manifestVersion: 1,
     engineVersion: { rag: ragVersion, constitutionTemplate: "1.0.0", scripts: "1.0.0" },
     indexSchemaVersion,
     regimes: {
-      replace: ["rag/src/**", "rag/package.json"],
+      replace: ["rag/src/**", "rag/package.json", ...extraReplace],
       regenerate: ["rag/launch.sh", "rag/launch.cmd", "scripts/run-node.sh", "scripts/run-node.cmd"],
       merge: [".claude/skills/zzz-mine/**", "scripts/update-engine.mjs", ...extraMerge],
     },
@@ -854,6 +854,72 @@ test("reconcileBrain — the new version of a customized skill is dropped alongs
   assert.deepEqual(report.skillsPreserved, [
     { skill: "prepare-1-1", reason: "customized", newVersionPath: ".claude/skills/prepare-1-1/SKILL.md.new" },
   ]);
+});
+
+// ── STAGED skills (engine-skills/) get the same treatment as the merge 9 ─────
+// A staged skill (local-mirror, lint, open-note…) is delivered install-if-absent from
+// the non-sacred `engine-skills/<name>/` path, and provenance is recorded for `merge`
+// files only — so it had NO base and would read `no-provenance` forever, frozen at the
+// version it was installed at. Its base costs nothing though: the brain's OWN
+// `engine-skills/<name>/` copy, read BEFORE this update overwrites it, IS byte-for-byte
+// what the engine last delivered (install-if-absent copied that very subtree).
+test("reconcileBrain — an untouched STAGED skill is refreshed, using the brain's own staging copy as the base", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const delivered = "---\nname: lint\n---\nLint the vault.\n";
+  const next = delivered + "\nNow reports orphan notes too.\n";
+  writeFile(brainDir, ".claude/skills/lint/SKILL.md", delivered); // installed at a past update
+  writeFile(brainDir, "engine-skills/lint/SKILL.md", delivered); // …from THIS staging copy
+  writeFile(sourceDir, "engine-skills/lint/SKILL.md", next);
+  const opts = { extraReplace: ["engine-skills/**"] };
+  const target = manifest(opts);
+  const local = manifest({ ragVersion: "1.0.0", ...opts });
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/lint/SKILL.md"), "utf8"), next);
+  assert.deepEqual(report.skillsRefreshed, ["lint"]);
+});
+
+test("reconcileBrain — a CUSTOMIZED staged skill is preserved too (the staging base discriminates)", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  // Same fixture as above, except the owner edited their installed copy. The staging
+  // tree still holds what the engine delivered, so the divergence is provable — and a
+  // staged skill earns exactly the same protection as a merge one.
+  const delivered = "---\nname: lint\n---\nLint the vault.\n";
+  const mine = delivered + "\n## My own rules\nNo orphan meeting notes.\n";
+  const next = delivered + "\nNow reports orphan notes too.\n";
+  writeFile(brainDir, ".claude/skills/lint/SKILL.md", mine);
+  writeFile(brainDir, "engine-skills/lint/SKILL.md", delivered);
+  writeFile(sourceDir, "engine-skills/lint/SKILL.md", next);
+  const opts = { extraReplace: ["engine-skills/**"] };
+
+  const { ...s } = seams();
+  const report = await reconcile({
+    brainDir,
+    platform: "posix",
+    sourceDir,
+    target: manifest(opts),
+    local: manifest({ ragVersion: "1.0.0", ...opts }),
+    ...s,
+  });
+
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/lint/SKILL.md"), "utf8"), mine);
+  assert.deepEqual(report.skillsRefreshed, []);
+  assert.deepEqual(report.skillsPreserved, [
+    { skill: "lint", reason: "customized", newVersionPath: ".claude/skills/lint/SKILL.md.new" },
+  ]);
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/lint/SKILL.md.new"), "utf8"), next);
 });
 
 test("reconcileBrain — a stale .new is cleared once the owner has adopted the new version", async (t) => {

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -744,3 +744,131 @@ async function reconcile(args) {
   const reconcileBrain = await loadReconciler();
   return reconcileBrain(args);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Increment 2.5 — refresh an UNTOUCHED engine skill. Until now an already-present
+// skill dir was skipped wholesale (install-if-absent), so 12 skill commits since
+// v3.2.2 reached nobody. The refresh is gated on the sha256 provenance base every
+// brain already records: overwrite ONLY what is provably byte-identical to what the
+// engine last delivered.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// The digest shape the manifest's `provenance` records (engine-source.fingerprint).
+function base(content) {
+  return "sha256:" + createHash("sha256").update(content).digest("hex");
+}
+
+test("reconcileBrain — an UNTOUCHED engine skill is refreshed to the source's version", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  // The brain carries the skill EXACTLY as the engine last delivered it (v3.6.0),
+  // the source carries the improved one (v3.6.2) — the real 4e43e70 case.
+  const delivered = "---\nname: switch\n---\nSwitch universes.\n";
+  const improved = delivered + "\nSingle-account native-connectors reminder.\n";
+  writeFile(brainDir, ".claude/skills/switch/SKILL.md", delivered);
+  writeFile(sourceDir, ".claude/skills/switch/SKILL.md", improved);
+  const target = manifest({ extraMerge: [".claude/skills/switch/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/switch/**"] }),
+    provenance: { ".claude/skills/switch/SKILL.md": base(delivered) },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/switch/SKILL.md"), "utf8"),
+    improved,
+    "the untouched skill now carries the engine's newer version",
+  );
+  assert.deepEqual(report.skillsRefreshed, ["switch"]);
+  assert.deepEqual(report.skillsPreserved, []);
+});
+
+test("reconcileBrain — a CUSTOMIZED skill is preserved byte-for-byte and reported as such", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  // The documented case: the owner refined prepare-1-1 to their own KPIs.
+  const delivered = "---\nname: prepare-1-1\n---\nPrepare a 1-1.\n";
+  const mine = delivered + "\n## My own KPIs\nARR, churn.\n";
+  writeFile(brainDir, ".claude/skills/prepare-1-1/SKILL.md", mine);
+  writeFile(sourceDir, ".claude/skills/prepare-1-1/SKILL.md", delivered + "\nNew engine section.\n");
+  const target = manifest({ extraMerge: [".claude/skills/prepare-1-1/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/prepare-1-1/**"] }),
+    provenance: { ".claude/skills/prepare-1-1/SKILL.md": base(delivered) },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/prepare-1-1/SKILL.md"), "utf8"),
+    mine,
+    "the owner's customized skill is untouched",
+  );
+  assert.deepEqual(report.skillsRefreshed, []);
+  assert.deepEqual(report.skillsPreserved, [{ skill: "prepare-1-1", reason: "customized" }]);
+});
+
+test("reconcileBrain — SessionStart self-heal (sourceDir === brainDir) refreshes NOTHING and reports nothing", async (t) => {
+  const brainDir = buildBrain();
+  t.after(() => rmSync(brainDir, { recursive: true, force: true }));
+  // Same fixture as the customized case, but the brain is its own source: the local
+  // converge has no new content, and nobody asked for an update. A skill is only ever
+  // overwritten during an explicit update — and the owner is not nagged at every start.
+  const delivered = "---\nname: prepare-1-1\n---\nPrepare a 1-1.\n";
+  const mine = delivered + "\n## My own KPIs\nARR, churn.\n";
+  writeFile(brainDir, ".claude/skills/prepare-1-1/SKILL.md", mine);
+  const target = manifest({ extraMerge: [".claude/skills/prepare-1-1/**"] });
+  const local = {
+    ...manifest({ extraMerge: [".claude/skills/prepare-1-1/**"] }),
+    provenance: { ".claude/skills/prepare-1-1/SKILL.md": base(delivered) },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir: brainDir, target, local, ...s });
+
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/prepare-1-1/SKILL.md"), "utf8"), mine);
+  assert.deepEqual(report.skillsRefreshed, []);
+  assert.deepEqual(report.skillsPreserved, [], "no nagging at session start");
+});
+
+test("reconcileBrain — a FR brain is refreshed from the FR source, never re-anglicized (T2)", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  // The brain declares its install locale in its own (locale-owned) marker.
+  writeFile(brainDir, "scripts/lib/demo-locale.mjs", 'export const BRAIN_LOCALE = "fr";\n');
+  const deliveredFr = "---\nname: coach\n---\nTon sparring-partner.\n";
+  const improvedFr = deliveredFr + "\nNouvelle section.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", deliveredFr);
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", "---\nname: coach\n---\nYour sparring partner.\nNew section.\n");
+  writeFile(sourceDir, "templates/fr/.claude/skills/coach/SKILL.md", improvedFr);
+  const target = manifest({ extraMerge: [".claude/skills/coach/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/coach/**"] }),
+    provenance: { ".claude/skills/coach/SKILL.md": base(deliveredFr) },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"),
+    improvedFr,
+    "the FR brain got the FR version of the newer skill",
+  );
+  assert.deepEqual(report.skillsRefreshed, ["coach"]);
+});

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -856,6 +856,46 @@ test("reconcileBrain — the new version of a customized skill is dropped alongs
   ]);
 });
 
+// A skill is a SUBTREE, not a single `SKILL.md`: a release may add a `references/`
+// or `examples/` file to a skill the brain already has. install-if-absent can never
+// deliver it (it skips at the skill-DIR level, and the dir exists), so if the refresh
+// drops the `absent-install` verdict too, that file reaches NO deployed brain — the
+// very core/skill drift this increment closes, one level deeper.
+test("reconcileBrain — a NEW file under an ALREADY-INSTALLED skill is delivered, not dropped", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const delivered = "---\nname: coach\n---\nBe a fierce coach.\n";
+  const added = "# Radical Candor\nCare personally, challenge directly.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", delivered);
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", delivered); // untouched AND up to date
+  writeFile(sourceDir, ".claude/skills/coach/references/radical-candor.md", added); // the newcomer
+  const target = manifest({ extraMerge: [".claude/skills/coach/**"] });
+  const local = {
+    ...manifest({ ragVersion: "1.0.0", extraMerge: [".claude/skills/coach/**"] }),
+    provenance: { ".claude/skills/coach/SKILL.md": base(delivered) },
+  };
+
+  const { ...s } = seams();
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
+
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md"), "utf8"),
+    added,
+    "the file the release added under the existing skill actually landed",
+  );
+  assert.equal(
+    readFileSync(join(brainDir, ".claude/skills/coach/SKILL.md"), "utf8"),
+    delivered,
+    "and the already-converged sibling was not rewritten for nothing",
+  );
+  assert.deepEqual(report.skillsRefreshed, ["coach"]);
+  assert.deepEqual(report.skillsPreserved, []);
+});
+
 // ── STAGED skills (engine-skills/) get the same treatment as the merge 9 ─────
 // A staged skill (local-mirror, lint, open-note…) is delivered install-if-absent from
 // the non-sacred `engine-skills/<name>/` path, and provenance is recorded for `merge`
@@ -1119,4 +1159,47 @@ test("runReconcileCli — a skill it INSTALLS gets a provenance base, so the nex
     base(delivered),
     "the base describes what was just installed — without it the skill is frozen forever",
   );
+});
+
+// Same freeze, third door: a file delivered because it was MISSING under an existing
+// skill needs a base too, or the release after it would read "no-provenance" and never
+// improve it again. Proven end-to-end: deliver it, then ship a better one.
+test("runReconcileCli — a file it delivers under an existing skill stays refreshable next time", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const skill = "---\nname: coach\n---\nYour sparring partner.\n";
+  const added = "# Radical Candor\nCare personally.\n";
+  const improved = added + "Challenge directly.\n";
+  writeFile(brainDir, ".claude/skills/coach/SKILL.md", skill);
+  writeFile(sourceDir, ".claude/skills/coach/SKILL.md", skill);
+  writeFile(sourceDir, ".claude/skills/coach/references/radical-candor.md", added);
+  writeFile(
+    brainDir,
+    "engine-manifest.json",
+    JSON.stringify(
+      {
+        ...manifest({ extraMerge: [".claude/skills/coach/**"] }),
+        provenance: { ".claude/skills/coach/SKILL.md": base(skill) },
+      },
+      null,
+      2,
+    ),
+  );
+  const runReconcileCli = await loadCli();
+  const argv = ["--brainDir", brainDir, "--sourceDir", sourceDir, "--platform", "posix"];
+
+  const first = await runReconcileCli({ argv, seams: seams() });
+  writeFile(sourceDir, ".claude/skills/coach/references/radical-candor.md", improved); // the NEXT release
+  const second = await runReconcileCli({ argv, seams: seams() });
+
+  assert.deepEqual(first.skillsRefreshed, ["coach"]);
+  assert.deepEqual(second.skillsRefreshed, ["coach"], "still refreshable — not frozen on no-provenance");
+  assert.deepEqual(second.skillsPreserved, []);
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md"), "utf8"), improved);
+  const persisted = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
+  assert.equal(persisted.provenance[".claude/skills/coach/references/radical-candor.md"], base(improved));
 });

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -47,6 +47,10 @@ function writeFile(root, rel, content) {
   writeFileSync(abs, content);
 }
 
+// The expectation side of the {{PROJECT_ROOT}} normalisation: a no-op on POSIX, the real
+// contract on win32 (where the temp brain dir carries backslashes).
+const toPosixPath = (p) => p.split("\\").join("/");
+
 // The sacred files the reconciler must never touch (write-allowlist safety core).
 const SACRED = {
   "CLAUDE.md": "# My personalized constitution\nI tailored this. Do not touch.\n",
@@ -616,6 +620,11 @@ test("reconcileBrain — wires the missing engine SessionStart hooks into settin
   assert.ok(cmds.includes(`/usr/local/bin/node "${root}/scripts/session-obsidian-hint.mjs"`), "session-obsidian-hint wired");
   assert.equal(settings.mine, true, "a user-owned settings key must be preserved");
   assert.equal(settings.hooks.SessionStart[0].hooks[0].command, `/usr/local/bin/node "${brainDir}/scripts/session-status.mjs"`, "the existing session-status entry stays first, untouched");
+  // settings.json is SACRED and git-committed: when the reconciler does write it, it
+  // writes a well-formed text file (final newline included), not a stripped blob.
+  const rawSettings = readFileSync(join(brainDir, ".claude/settings.json"), "utf8");
+  assert.equal(rawSettings, JSON.stringify(settings, null, 2) + "\n");
+  assert.equal("statusLine" in settings, false, "a brain with no statusLine must not acquire an empty one");
 });
 
 // ── Test 13: idempotence + A2 invariant — a SECOND reconcile over a converged brain wires
@@ -642,6 +651,100 @@ test("reconcileBrain — a converged brain's settings.json is left byte-identica
   const second = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s2 });
   assert.deepEqual(second.hooksAdded, [], "a converged brain wires nothing");
   assert.equal(sha256(join(brainDir, ".claude/settings.json")), settingsHash, "settings.json must be byte-identical on the 2nd run (no churn)");
+});
+
+// Test 13's fixture is written EXACTLY as the reconciler would serialise it, so a
+// reconciler that rewrote settings.json unconditionally would still leave it
+// byte-identical — the no-churn guard was self-confirming. Here the very same converged
+// brain stores its settings NON-canonically (the shape a human editor leaves: 4-space
+// indent, no final newline). Now "written only when something is actually added" is a
+// claim the bytes can refute. This matters: settings.json is SACRED, and a silent
+// reformat of the user's own file at every session start is exactly the churn ADR 0026
+// forbids.
+test("reconcileBrain — a converged brain's HAND-FORMATTED settings.json is not even reformatted", async (t) => {
+  const brainDir = buildBrain();
+  const sourceDir = buildSource();
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  writeFile(sourceDir, ".claude/settings.json.template", JSON.stringify(templateSessionStart(), null, 2) + "\n");
+  const target = manifest();
+  const local = manifest({ ragVersion: "1.0.0" });
+
+  // First converge normally, then re-store the SAME settings hand-formatted.
+  writeFile(brainDir, ".claude/settings.json", JSON.stringify(v310Settings(brainDir), null, 2) + "\n");
+  await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...seams() });
+  const settingsPath = join(brainDir, ".claude/settings.json");
+  const handFormatted = JSON.stringify(JSON.parse(readFileSync(settingsPath, "utf8")), null, 4); // 4 spaces, no final newline
+  writeFileSync(settingsPath, handFormatted);
+
+  const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...seams() });
+
+  assert.deepEqual(report.hooksAdded, []);
+  assert.deepEqual(report.hooksRepaired, []);
+  assert.equal(readFileSync(settingsPath, "utf8"), handFormatted, "nothing to add → settings.json must not be touched AT ALL");
+});
+
+// A deployed win32 brain whose hook commands are broken but which has NO statusLine and
+// is missing no hook: the ONLY reason to write is the repair itself. Nothing else covered
+// that term of the write guard in isolation — every other repair fixture also had a
+// statusLine to heal, so a reconciler that ignored repairs alone would have stayed green
+// and left the whole Windows fleet broken forever (the additive merge never rewrites an
+// existing command, so the repair is these brains' only route back).
+test("reconcileBrain (win32) — a repair with nothing added and no statusLine still writes", async (t) => {
+  const brainDir = buildBrain();
+  t.after(() => rmSync(brainDir, { recursive: true, force: true }));
+  const rootPosix = toPosixPath(brainDir);
+  const { statusLine, ...noStatusLine } = brokenWin32Settings(rootPosix);
+  writeFile(brainDir, ".claude/settings.json", JSON.stringify(noStatusLine, null, 2) + "\n");
+  writeFile(brainDir, ".claude/settings.json.template", JSON.stringify(templateSessionStart(), null, 2) + "\n");
+  const target = manifest();
+
+  const report = await reconcile({
+    brainDir, platform: "win32", sourceDir: brainDir, target, local: target, ...seams(),
+  });
+
+  assert.deepEqual(report.hooksAdded, [], "the broken brain already wires every engine hook");
+  assert.ok(report.hooksRepaired.includes("scripts/session-self-heal.mjs"), "the repair itself is the only reason to write");
+  const settings = JSON.parse(readFileSync(join(brainDir, ".claude/settings.json"), "utf8"));
+  const cmds = Object.values(settings.hooks).flatMap((groups) => groups.flatMap((g) => g.hooks.map((h) => h.command)));
+  for (const cmd of cmds) assert.doesNotMatch(cmd, /cmd \/c/i, "the healed commands must actually be on disk");
+  assert.equal("statusLine" in settings, false, "a brain with no statusLine must not acquire an empty one");
+});
+
+// The mirror: ONLY the statusLine is broken. It is not a hook, it lives at the top level
+// of settings.json, and it is repaired through its own separate path — so it needs its own
+// reason-to-write and its own line in the report, named exactly.
+test("reconcileBrain (win32) — a broken statusLine alone is reason enough to write, and is named as such", async (t) => {
+  const brainDir = buildBrain();
+  t.after(() => rmSync(brainDir, { recursive: true, force: true }));
+  const rootPosix = toPosixPath(brainDir);
+  const healed = (script) => `${rootPosix}/scripts/run-node.cmd "${rootPosix}/scripts/${script}"`;
+  const settingsIn = {
+    mine: true,
+    statusLine: { type: "command", command: brokenWin32Settings(rootPosix).statusLine.command }, // the ONLY broken thing
+    hooks: {
+      PostToolUse: [{ matcher: "Write|Edit", hooks: [{ type: "command", command: healed("auto-commit.mjs"), timeout: 30000 }] }],
+      SessionStart: ["session-self-heal", "session-health", "session-obsidian-hint", "session-status"].map((s) => ({
+        matcher: "", hooks: [{ type: "command", command: healed(`${s}.mjs`), timeout: 20000 }],
+      })),
+      Stop: [{ matcher: "", hooks: [{ type: "command", command: healed("auto-push.mjs"), timeout: 20000 }] }],
+    },
+  };
+  writeFile(brainDir, ".claude/settings.json", JSON.stringify(settingsIn, null, 2) + "\n");
+  writeFile(brainDir, ".claude/settings.json.template", JSON.stringify(templateSessionStart(), null, 2) + "\n");
+  const target = manifest();
+
+  const report = await reconcile({
+    brainDir, platform: "win32", sourceDir: brainDir, target, local: target, ...seams(),
+  });
+
+  assert.deepEqual(report.hooksAdded, []);
+  assert.deepEqual(report.hooksRepaired, ["statusLine"], "the statusLine is the sole repair, and is reported under that exact name");
+  const settings = JSON.parse(readFileSync(join(brainDir, ".claude/settings.json"), "utf8"));
+  assert.doesNotMatch(settings.statusLine.command, /cmd \/c/i);
+  assert.equal(settings.statusLine.type, "command", "the rest of the statusLine entry survives the repair");
 });
 
 // A DEPLOYED Windows brain generated before the issue-#31 fix: every engine hook
@@ -756,9 +859,16 @@ test("reconcileBrain — registers MCP servers from the DELIVERED template keys,
   const report = await reconcile({ brainDir, platform: "posix", sourceDir, target, local, ...s });
 
   assert.deepEqual(report.mcpServersAdded, ["local-mirror"], "the template's local-mirror server registers even though the manifest is stale");
-  const mcp = JSON.parse(readFileSync(join(brainDir, ".mcp.json"), "utf8"));
+  const raw = readFileSync(join(brainDir, ".mcp.json"), "utf8");
+  const mcp = JSON.parse(raw);
   assert.ok(mcp.mcpServers["local-mirror"], "local-mirror is now in .mcp.json");
   assert.ok(mcp.mcpServers["vault-rag"], "vault-rag is preserved");
+  // {{PROJECT_ROOT}} must arrive SUBSTITUTED (and POSIX-normalised): an unsubstituted
+  // placeholder means an MCP server that cannot start, and the brain loses its RAG.
+  assert.equal(mcp.mcpServers["local-mirror"].cwd, toPosixPath(brainDir));
+  // …and the file stays a well-formed text file: it is git-committed, and a missing
+  // final newline puts a "\ No newline at end of file" in every diff that touches it.
+  assert.equal(raw, JSON.stringify(mcp, null, 2) + "\n");
 });
 
 // Tiny indirection so the helpers above read cleanly; resolves the lazily-loaded export.
@@ -1346,6 +1456,17 @@ test("runReconcileCli — a file it delivers under an existing skill stays refre
   assert.equal(readFileSync(join(brainDir, ".claude/skills/coach/references/radical-candor.md"), "utf8"), improved);
   const persisted = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
   assert.equal(persisted.provenance[".claude/skills/coach/references/radical-candor.md"], base(improved));
+});
+
+// ── The {{PROJECT_ROOT}} normalisation, made verifiable OFF Windows ──────────
+// On a POSIX CI the transform is a no-op on every real path, so a regression in it
+// would be invisible there and would only surface on the deployed Windows fleet — as
+// a hook command Git Bash silently eats (issue #31). Fed a win32-shaped path instead.
+test("toPosix — a Windows brain dir reaches the templates with forward slashes only", async () => {
+  const { toPosix } = await import("./reconcile-brain.mjs");
+
+  assert.equal(toPosix("C:\\Users\\me\\my-brain"), "C:/Users/me/my-brain");
+  assert.equal(toPosix("/Users/me/my-brain"), "/Users/me/my-brain", "a POSIX path passes through untouched");
 });
 
 // The absent case for the launchers, never fed until now: a manifest that declares NO

--- a/scripts/lib/release-fixture-refresh.test.mjs
+++ b/scripts/lib/release-fixture-refresh.test.mjs
@@ -1,0 +1,184 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// release-fixture-refresh.test.mjs — the QA of the skill refresh (Increment 2.5)
+// against brains reproduced from REAL release tags, not hand-written fixtures.
+//
+// WHY A SEPARATE SUITE. `reconcile-brain.test.mjs` drives the mechanism with tiny
+// synthetic skills — right for the unit-level contract, blind to the one question
+// this increment exists to answer: does a brain deployed at v3.6.0 actually END UP
+// with the v3.6.2 `switch` skill? Here the source is THE REPOSITORY ITSELF and the
+// brain is built from bytes taken verbatim from the tags (`maintainers/qa/release-
+// fixtures/<tag>/`, captured with `git show <tag>:<path>`), so the assertions are
+// about released content, not about a mock.
+//
+// Never a real deployed brain's content: the tags are public, the personal edits are
+// synthetic (`maintainers/plans/…/engine-managed-file-merge-strategy.md`, Step 8).
+//
+// The fixtures live under `maintainers/` (dev-only prefix, never copied into a brain);
+// this test file ships like every other `scripts/lib/*.test.mjs` and is simply never run
+// there. The I/O seams (npm install, reindex, launchers) are injected — no network.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { reconcileBrain } from "./reconcile-brain.mjs";
+// The PRODUCTION digest, deliberately: a hand-rolled sha256 in the test would silently
+// disagree with the manifest's format and turn every untouched skill into "customized".
+import { fingerprint, reseedProvenance } from "./engine-source.mjs";
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FIXTURES = join(REPO, "maintainers", "qa", "release-fixtures");
+
+const readRepo = (rel) => readFileSync(join(REPO, rel), "utf8");
+const readBrain = (brainDir, rel) => readFileSync(join(brainDir, rel), "utf8");
+
+function writeFile(root, rel, content) {
+  mkdirSync(dirname(join(root, rel)), { recursive: true });
+  writeFileSync(join(root, rel), content);
+}
+
+// A brain as the installer of `<tag>` left it: that release's skills, that release's
+// manifest, and the provenance base the installer records for every `merge` file it
+// delivers — the sha256 of the very bytes it wrote. `edits` overwrites a skill AFTER
+// the base is computed, which is exactly what a user customization looks like on disk.
+function brainAtRelease(tag, { edits = {} } = {}) {
+  const brainDir = mkdtempSync(join(tmpdir(), `sbg-qa-${tag}-`));
+  cpSync(join(FIXTURES, tag), brainDir, { recursive: true });
+  const manifest = JSON.parse(readBrain(brainDir, "engine-manifest.json"));
+  const provenance = {};
+  for (const rel of skillFilesOf(tag)) provenance[rel] = fingerprint(readBrain(brainDir, rel));
+  manifest.provenance = provenance;
+  // The sacred trio, so the QA also observes that a refresh leaves them alone.
+  writeFile(brainDir, "CLAUDE.md", "# My constitution\nI tailored this.\n");
+  writeFile(brainDir, ".env", "GOOGLE_GEMINI_API_KEY=secret\n");
+  writeFile(brainDir, ".claude/settings.json", '{\n  "mine": true\n}\n');
+  for (const [rel, content] of Object.entries(edits)) writeFile(brainDir, rel, content);
+  return { brainDir, manifest };
+}
+
+// The skill files the fixture carries, as brain-relative POSIX paths.
+function skillFilesOf(tag) {
+  const skills = {
+    "v3.6.0": [".claude/skills/switch/SKILL.md", ".claude/skills/prepare-1-1/SKILL.md"],
+    "v3.2.2": [".claude/skills/import/SKILL.md"],
+  };
+  return skills[tag];
+}
+
+// Everything the reconciler does to the world, stubbed: this QA is about file content.
+function seams() {
+  const calls = { install: [], reindex: [] };
+  return {
+    calls,
+    regenerateLaunchers: async () => {},
+    runInstall: async ({ ragDir }) => calls.install.push(ragDir),
+    runReindex: async ({ brainDir }) => calls.reindex.push(brainDir),
+    countVaultNotes: async () => 0,
+  };
+}
+
+// One real update: the repository at HEAD is the fetched source (`sourceDir !== brainDir`,
+// i.e. the auto-finalize child of an explicitly-requested update).
+async function updateFrom(brainDir, local) {
+  const { calls, ...s } = seams();
+  const target = JSON.parse(readRepo("engine-manifest.json"));
+  return reconcileBrain({ brainDir, platform: "posix", sourceDir: REPO, target, local, ...s });
+}
+
+// ── The case this increment was pulled forward for (plan §"The trigger") ──────
+// `4e43e70` shipped 22 lines into `.claude/skills/switch/SKILL.md` in v3.6.2. A brain
+// installed at v3.6.0 or v3.6.1 could never receive them: its skill directory exists, so
+// install-if-absent skipped it, while the deterministic core it drives (a `replace` glob)
+// was refreshed at every update — the core/skill drift, live on shipped releases.
+test("QA v3.6.0 → HEAD — the untouched `switch` skill ends up at the released v3.6.2 content", async (t) => {
+  const { brainDir, manifest } = brainAtRelease("v3.6.0");
+  t.after(() => rmSync(brainDir, { recursive: true, force: true }));
+  const installedAtRelease = readBrain(brainDir, ".claude/skills/switch/SKILL.md");
+
+  const report = await updateFrom(brainDir, manifest);
+
+  assert.equal(
+    readBrain(brainDir, ".claude/skills/switch/SKILL.md"),
+    readRepo(".claude/skills/switch/SKILL.md"),
+    "the v3.6.0 brain must end up byte-identical to the released skill",
+  );
+  assert.notEqual(readBrain(brainDir, ".claude/skills/switch/SKILL.md"), installedAtRelease);
+  // Not just "some bytes changed": the single-account connectors reminder `4e43e70` added.
+  assert.match(readBrain(brainDir, ".claude/skills/switch/SKILL.md"), /single-account/);
+  assert.ok(report.skillsRefreshed.includes("switch"), "and the owner is told which skill moved");
+  // Silent delivery is the bug we are fixing, so an untouched skill is never "preserved".
+  assert.deepEqual(report.skillsPreserved.filter((p) => p.skill === "switch"), []);
+});
+
+// The promise made to anyone who tailored a skill (the documented `prepare-1-1` "refine to
+// your own KPIs" case): their file stands, and the engine's newer version waits beside it.
+test("QA v3.6.0 → HEAD — a customized skill is kept byte-identical, with the new version beside it", async (t) => {
+  const customized = readFileSync(join(FIXTURES, "v3.6.0/.claude/skills/prepare-1-1/SKILL.md"), "utf8") +
+    "\n## My own KPIs\n- churn\n- time-to-first-review\n";
+  const { brainDir, manifest } = brainAtRelease("v3.6.0", {
+    edits: { ".claude/skills/prepare-1-1/SKILL.md": customized },
+  });
+  t.after(() => rmSync(brainDir, { recursive: true, force: true }));
+
+  const report = await updateFrom(brainDir, manifest);
+
+  assert.equal(readBrain(brainDir, ".claude/skills/prepare-1-1/SKILL.md"), customized, "never clobbered");
+  assert.equal(
+    readBrain(brainDir, ".claude/skills/prepare-1-1/SKILL.md.new"),
+    readRepo(".claude/skills/prepare-1-1/SKILL.md"),
+    "the engine's version is offered alongside, not imposed",
+  );
+  assert.deepEqual(
+    report.skillsPreserved.filter((p) => p.skill === "prepare-1-1"),
+    [{ skill: "prepare-1-1", reason: "customized", newVersionPath: ".claude/skills/prepare-1-1/SKILL.md.new" }],
+  );
+  assert.ok(!report.skillsRefreshed.includes("prepare-1-1"));
+  // The sacred trio is untouched by the same run.
+  assert.equal(readBrain(brainDir, "CLAUDE.md"), "# My constitution\nI tailored this.\n");
+  assert.equal(readBrain(brainDir, ".env"), "GOOGLE_GEMINI_API_KEY=secret\n");
+});
+
+// The oldest cohort in the fleet. Its manifest predates `switch` entirely, so that skill
+// arrives by install-if-absent (ADR 0025), while a skill it DOES carry and never touched
+// is refreshed — the 12 skill commits that had reached nobody since v3.2.2.
+test("QA v3.2.2 → HEAD — an untouched skill is refreshed, and a skill unknown at that release is installed", async (t) => {
+  const { brainDir, manifest } = brainAtRelease("v3.2.2");
+  t.after(() => rmSync(brainDir, { recursive: true, force: true }));
+  assert.ok(!existsSync(join(brainDir, ".claude/skills/switch")), "v3.2.2 predates universes");
+
+  const report = await updateFrom(brainDir, manifest);
+
+  assert.equal(readBrain(brainDir, ".claude/skills/import/SKILL.md"), readRepo(".claude/skills/import/SKILL.md"));
+  assert.ok(report.skillsRefreshed.includes("import"));
+  assert.equal(readBrain(brainDir, ".claude/skills/switch/SKILL.md"), readRepo(".claude/skills/switch/SKILL.md"));
+  assert.ok(report.installedSkills.includes("switch"), "a skill unknown at that release still arrives");
+});
+
+// A converged brain must stay byte-identical: every write here would be auto-committed,
+// so a "refresh" that rewrites identical bytes turns each update into history churn.
+test("QA already-converged brain — a second update refreshes nothing and rewrites nothing", async (t) => {
+  const { brainDir, manifest } = brainAtRelease("v3.6.0");
+  t.after(() => rmSync(brainDir, { recursive: true, force: true }));
+
+  const first = await updateFrom(brainDir, manifest);
+  // Re-seed through the PRODUCTION helper, over what the update path actually delivers:
+  // the skills it refreshed AND the ones it installed. Leave the installed ones out and
+  // they read `no-provenance` forever — frozen the day they arrived.
+  manifest.provenance = reseedProvenance({
+    priorProvenance: manifest.provenance,
+    manifest,
+    deliveredFileMap: { ...first.installedFileMap, ...first.refreshedFileMap },
+  });
+  const before = skillFilesOf("v3.6.0").map((rel) => fingerprint(readBrain(brainDir, rel)));
+
+  const second = await updateFrom(brainDir, manifest);
+
+  assert.deepEqual(second.skillsRefreshed, [], "nothing left to refresh");
+  assert.deepEqual(second.skillsPreserved, [], "and nothing mistaken for a customization");
+  assert.deepEqual(skillFilesOf("v3.6.0").map((rel) => fingerprint(readBrain(brainDir, rel))), before);
+  assert.ok(!existsSync(join(brainDir, ".claude/skills/switch/SKILL.md.new")), "no sidecar on a converged brain");
+});

--- a/scripts/lib/staged-skills.mjs
+++ b/scripts/lib/staged-skills.mjs
@@ -11,10 +11,36 @@
 // byte-identical; a brand-new staged skill is copied in whole. Pure I/O, win32-safe
 // (POSIX rels split back to the OS separator, ADR 0015). Returns the installed names.
 // ─────────────────────────────────────────────────────────────────────────────
-import { readdirSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
+import { readdirSync, mkdirSync, copyFileSync, existsSync, readFileSync } from "node:fs";
 import { join, dirname, sep } from "node:path";
 
 import { listFilesRelPosix } from "./fs-walk.mjs";
+import { fingerprint } from "./engine-source.mjs";
+
+// The staging path a staged skill's SOURCE ships at, and where it gets installed.
+export const STAGING_PREFIX = "engine-skills/";
+export const SKILLS_PREFIX = ".claude/skills/";
+
+// The provenance base of the staged skills — for free, and retroactively for the whole
+// deployed fleet (Increment 2.5). Provenance is recorded for `merge` files only, so a
+// staged skill has none and would read `no-provenance` forever, frozen at the version it
+// was installed at. But the brain's OWN `engine-skills/<name>/` copy IS byte-for-byte
+// what the engine last delivered — install-if-absent copied that very subtree into
+// `.claude/skills/<name>/`. So it answers the only question the refresh asks: "is what
+// is installed still what we delivered?".
+//
+// ⚠️ MUST be read BEFORE the copy step overwrites `engine-skills/**` (a `replace` glob),
+// or the base becomes the NEW content and every staged skill reads as untouched.
+// Keyed by the INSTALLED path, so the refresh consumes it like any other base.
+export function readStagedProvenance(brainDir) {
+  const stagingDir = join(brainDir, STAGING_PREFIX);
+  if (!existsSync(stagingDir)) return {}; // pre-staging brain → no base, nothing claimed
+  const base = {};
+  for (const rel of listFilesRelPosix(stagingDir)) {
+    base[SKILLS_PREFIX + rel] = fingerprint(readFileSync(join(stagingDir, rel.split("/").join(sep)), "utf8"));
+  }
+  return base;
+}
 
 export function installStagedSkills({ sourceDir, brainDir }) {
   const stagingDir = join(sourceDir, "engine-skills");

--- a/scripts/lib/update-engine.test.mjs
+++ b/scripts/lib/update-engine.test.mjs
@@ -371,7 +371,7 @@ function fp(content) {
   return "sha256:" + createHash("sha256").update(content).digest("hex");
 }
 
-function manifest({ ragVersion, indexSchemaVersion, ref, provenance = {} }) {
+function manifest({ ragVersion, indexSchemaVersion, ref, provenance = {}, extraMerge = [] }) {
   return JSON.stringify(
     {
       manifestVersion: 1,
@@ -389,6 +389,7 @@ function manifest({ ragVersion, indexSchemaVersion, ref, provenance = {} }) {
           "scripts/status-line.mjs",
           "scripts/verify-rag.mjs",
           "scripts/update-engine.mjs",
+          ...extraMerge,
         ],
       },
       engineMcpServers: ["vault-rag"],
@@ -972,4 +973,52 @@ test("gate — returns the vault note count from the injected seam", async (t) =
   });
 
   assert.equal(report.vaultNoteCount, 42);
+});
+
+// ── Increment 2.5 / trap T1 — the parent's step 7 must not lose the reseed ────
+// When the in-process reconcile refreshes a skill, step 7 rewrites the manifest from
+// the `local` copy it read BEFORE reconciling. Unless the refreshed files are folded
+// into the re-seed, the skill's base stays at the OLD content and the very next update
+// classifies it "user-modified" — the feature would die after one use.
+test("updateEngine — a refreshed skill's provenance base is re-seeded by step 7", async (t) => {
+  const brainDir = mkdtempSync(join(tmpdir(), "sbg-brain-refresh-"));
+  const sourceDir = mkdtempSync(join(tmpdir(), "sbg-source-refresh-"));
+  t.after(() => {
+    rmSync(brainDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+  const delivered = "---\nname: switch\n---\nSwitch universes.\n";
+  const improved = delivered + "\nSingle-account native-connectors reminder.\n";
+  const extraMerge = [".claude/skills/switch/**"];
+  for (const [rel, content] of Object.entries(flat(engineFiles("vA")))) writeFile(brainDir, rel, content);
+  writeFile(brainDir, ".claude/skills/switch/SKILL.md", delivered);
+  writeFile(
+    brainDir,
+    "engine-manifest.json",
+    manifest({
+      ragVersion: "1.0.0",
+      indexSchemaVersion: 1,
+      ref: "v1.0.0",
+      extraMerge,
+      provenance: { ".claude/skills/switch/SKILL.md": fp(delivered) },
+    }),
+  );
+  for (const [rel, content] of Object.entries(flat(engineFiles("vB")))) writeFile(sourceDir, rel, content);
+  writeFile(sourceDir, ".claude/skills/switch/SKILL.md", improved);
+  writeFile(
+    sourceDir,
+    "engine-manifest.json",
+    manifest({ ragVersion: "1.1.0", indexSchemaVersion: 1, ref: "v1.1.0", extraMerge }),
+  );
+
+  const { report } = await runUpdate({ brainDir, sourceDir, platform: "posix" });
+
+  assert.deepEqual(report.skillsRefreshed, ["switch"]);
+  assert.equal(readFileSync(join(brainDir, ".claude/skills/switch/SKILL.md"), "utf8"), improved);
+  const m = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
+  assert.equal(
+    m.provenance[".claude/skills/switch/SKILL.md"],
+    fp(improved),
+    "step 7 must re-seed the base of what the reconcile just refreshed",
+  );
 });

--- a/scripts/lib/update-engine.test.mjs
+++ b/scripts/lib/update-engine.test.mjs
@@ -44,7 +44,8 @@ async function loadCore() {
 // ── formatReport: the human summary the brain-side skill prints (Step 6) ──────
 // Pure (report object → string) so the wording is unit-tested; the CLI entry holds
 // only the untestable I/O wiring (ADR 0009).
-import { formatReport, defaultCountVaultNotes } from "../update-engine.mjs";
+import { formatReport, countNewCapabilities, needsRestart, runUpdateCli, armRestartFlag, defaultCountVaultNotes } from "../update-engine.mjs";
+import { RESTART_FLAG_REL } from "./restart-nudge.mjs";
 
 // F2: the default count must match what the indexer actually treats as a note —
 // the document-scanner excludes `_template.md`, `.gitkeep` and the `.obsidian/`
@@ -278,6 +279,137 @@ test("formatReport — a true no-op (nothing swapped or regenerated) does NOT cr
   assert.doesNotMatch(out, /once more/i);
 });
 
+// Step 10 (mutation hardening): the regex tests above each pin ONE line, so every
+// OTHER line is free to mutate — an emptied literal, a flipped guard, a line that
+// appears when it should not. These two assert the WHOLE report, byte for byte: the
+// quiet no-op (the floor: only the lines that ALWAYS show) and the everything-on
+// update (the ceiling: every optional line at once, in order). Between them every
+// prose branch is pinned, both when it fires and when it must stay silent.
+test("formatReport — a quiet no-op prints EXACTLY the four always-on lines, nothing else", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: [],
+    regenerated: false,
+    reindexed: false,
+  });
+  assert.equal(
+    out,
+    [
+      "✅ Engine updated to v3.6.2 (rag 1.1.4).",
+      "   • 0 engine file(s) swapped",
+      "   • index format unchanged — no reindex needed",
+      "   Your notes, .env, constitution, settings and custom skills were left untouched.",
+    ].join("\n"),
+  );
+});
+
+test("formatReport — an everything-on update prints every optional line, in order, byte for byte", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: ["rag/src/index.ts", "scripts/auto-commit.mjs"],
+    regenerated: true,
+    reindexed: true,
+    vaultNoteCount: 2,
+    installedSkills: ["local-mirror"],
+    mcpServersAdded: ["local-mirror"],
+    // Deliberately NOT alphabetical: a sorting mutant must diverge from the input order.
+    skillsRefreshed: ["switch", "coach"],
+    // A customized preserve (reported, with its sidecar) next to a no-provenance one
+    // (silent by design) — the discriminating pair for the `reason` filter.
+    skillsPreserved: [
+      { skill: "prepare-1-1", reason: "customized", newVersionPath: ".claude/skills/prepare-1-1/SKILL.md.new" },
+      { skill: "import", reason: "no-provenance" },
+    ],
+    hooksAdded: ["scripts/session-health.mjs"],
+    // "statusLine" is the decoy: it carries neither the `scripts/` prefix nor the
+    // `.mjs` suffix, so it must pass through the stripping untouched.
+    hooksRepaired: ["scripts/auto-push.mjs", "statusLine"],
+  });
+  assert.equal(
+    out,
+    [
+      "✅ Engine updated to v3.6.2 (rag 1.1.4).",
+      "   • 2 engine file(s) swapped + launchers regenerated",
+      "   • reindexed — the index format changed (your notes were re-encoded, nothing lost)",
+      "   • your vault holds 2 notes — searchable as the reindex finishes",
+      "   • new engine skill(s) installed: local-mirror",
+      "   • new MCP server(s) registered: local-mirror",
+      "   • engine skill(s) brought up to date: switch, coach",
+      '   • your customized "prepare-1-1" skill was kept exactly as you wrote it — the newer engine version sits next to it as .claude/skills/prepare-1-1/SKILL.md.new',
+      "   • new runtime hook(s) wired: session-health",
+      "   • repaired Windows hook command(s) (issue #31 — 'laude' error): auto-push, statusLine",
+      "   ⚠️ ACTION NEEDED — 3 new capabilities are installed on disk but NOT active in THIS conversation.",
+      "   A FULL RESTART of Claude (close it and reopen) is enough: come back to THIS same",
+      "   conversation afterwards and your brain can use them. You do NOT need to start a",
+      "   brand-new chat for this. Until you restart, your brain CAN'T use them.",
+      "   • If still missing after a restart, run /update-engine once more.",
+      "   Your notes, .env, constitution, settings and custom skills were left untouched.",
+    ].join("\n"),
+  );
+});
+
+// The third shape, between the floor and the ceiling: an upgrader whose schema did NOT
+// move (health-note seed only), holding a single note, with a preserve the report must
+// stay SILENT about — and the steady-state restart banner, whose wording is a different
+// literal from the new-capability one above.
+test("formatReport — a steady-state upgrade prints the incremental-reindex + generic-restart wording, byte for byte", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: ["rag/src/index.ts"],
+    regenerated: false,
+    reindexed: true,
+    reindexReason: "health-note-seed",
+    vaultNoteCount: 1,
+    skillsPreserved: [{ skill: "coach", reason: "no-provenance" }],
+  });
+  assert.equal(
+    out,
+    [
+      "✅ Engine updated to v3.6.2 (rag 1.1.4).",
+      "   • 1 engine file(s) swapped",
+      "   • ensured the engine health-check note is present and indexed (incremental — your other notes were not re-encoded)",
+      "   • your vault holds 1 note — searchable as the reindex finishes",
+      "   ⚠️ ACTION NEEDED — your engine was updated on disk, but THIS conversation is",
+      "   still running the OLD version. A FULL RESTART of Claude (close it and reopen) is",
+      "   enough: come back to THIS same conversation afterwards and the update takes effect.",
+      "   Until you restart, your brain keeps using the old engine.",
+      "   Your notes, .env, constitution, settings and custom skills were left untouched.",
+    ].join("\n"),
+  );
+});
+
+// The boundary of the capability counter (lesson: triangulate the singular/plural pair).
+// ONE new capability must read "1 new capability IS installed … can use IT" — the
+// ceiling test above pins the plural half of the very same three ternaries.
+test("formatReport — exactly one new capability reads in the singular, byte for byte", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: [],
+    regenerated: false,
+    reindexed: false,
+    installedSkills: ["local-mirror"],
+  });
+  assert.equal(
+    out,
+    [
+      "✅ Engine updated to v3.6.2 (rag 1.1.4).",
+      "   • 0 engine file(s) swapped",
+      "   • index format unchanged — no reindex needed",
+      "   • new engine skill(s) installed: local-mirror",
+      "   ⚠️ ACTION NEEDED — 1 new capability is installed on disk but NOT active in THIS conversation.",
+      "   A FULL RESTART of Claude (close it and reopen) is enough: come back to THIS same",
+      "   conversation afterwards and your brain can use it. You do NOT need to start a",
+      "   brand-new chat for this. Until you restart, your brain CAN'T use it.",
+      "   • If still missing after a restart, run /update-engine once more.",
+      "   Your notes, .env, constitution, settings and custom skills were left untouched.",
+    ].join("\n"),
+  );
+});
+
 // ── Increment 2.5, Step 5: report the SKILL refresh ──────────────────────────
 // The whole point of the increment is that a shipped skill improvement finally
 // reaches an existing brain. Delivering it silently leaves the user unaware their
@@ -392,6 +524,168 @@ test("formatReport — when reindexed, hints that searchability catches up as in
   });
   assert.match(out, /9 note/);
   assert.match(out, /indexing|searchable|catches up/i);
+});
+
+// ── Step 10: the CLI's decisions, extracted OUT of the entry-point block ──────
+// They used to live inside `if (isEntrypoint(...))`, unreachable by any test — which
+// is why ~40 of the file's 96 surviving mutants clustered there. Pure predicates now.
+test("countNewCapabilities — sums the skills, MCP servers and hooks this update delivered", () => {
+  assert.equal(
+    countNewCapabilities({
+      installedSkills: ["local-mirror"],
+      mcpServersAdded: ["local-mirror", "vault-rag"],
+      hooksAdded: ["scripts/session-health.mjs", "scripts/session-self-heal.mjs", "scripts/auto-push.mjs"],
+    }),
+    6,
+  );
+});
+
+// The absent twin: an older reconcile (or a partial report) carries none of the three
+// lists. Counting must yield 0 — never NaN, which would make the banner read
+// "NaN new capabilities" and, worse, silently falsify every comparison against it.
+test("countNewCapabilities — a report carrying none of the three lists counts 0", () => {
+  assert.equal(countNewCapabilities({ copied: ["rag/src/index.ts"] }), 0);
+});
+
+// Increment 2.5: a refreshed skill is the trigger this branch ADDED — its new text
+// loads only at the next session start, so the persistent nudge must be armed even
+// though not a single engine file was swapped.
+test("needsRestart — a refresh-only update still arms the nudge", () => {
+  assert.equal(
+    needsRestart({ copied: [], regenerated: false, skillsRefreshed: ["switch"] }),
+    true,
+  );
+});
+
+// The don't-cry-wolf boundary, same as the report banner's: an update that changed
+// nothing on disk must leave the nudge disarmed, or the statusLine nags forever.
+test("needsRestart — a genuine no-op leaves the nudge disarmed", () => {
+  assert.equal(
+    needsRestart({ copied: [], regenerated: false, skillsRefreshed: [], installedSkills: [], mcpServersAdded: [], hooksAdded: [] }),
+    false,
+  );
+});
+
+// The other three triggers, each ALONE (an OR chain where only one disjunct is ever
+// exercised is indistinguishable from that disjunct): a swapped engine file, a mere
+// launcher regeneration, and a brand-new capability each stale the running session.
+test("needsRestart — a swapped file, a launcher regeneration or a new capability each arm it on their own", () => {
+  const base = { copied: [], regenerated: false, skillsRefreshed: [], installedSkills: [], mcpServersAdded: [], hooksAdded: [] };
+  assert.equal(needsRestart({ ...base, copied: ["rag/src/index.ts"] }), true, "a swapped engine file");
+  assert.equal(needsRestart({ ...base, regenerated: true }), true, "regenerated launchers");
+  assert.equal(needsRestart({ ...base, hooksAdded: ["scripts/session-health.mjs"] }), true, "a newly wired hook");
+});
+
+// The CLI itself, now a function taking its I/O as deps (the `clear-example-notes`
+// idiom): the happy path prints the human report on stdout, arms nothing else, and
+// hands the shell a 0.
+test("runUpdateCli — prints the report on stdout and exits 0", async () => {
+  const out = [];
+  const code = await runUpdateCli({
+    brainDir: "/brains/mine",
+    updateEngine: async ({ brainDir }) => {
+      assert.equal(brainDir, "/brains/mine", "the CLI updates the brain it was told about");
+      return { ref: "v3.6.2", engineVersion: { rag: "1.1.4" }, copied: [], regenerated: false, reindexed: false };
+    },
+    armRestartFlag: () => assert.fail("a no-op update must not arm the restart nudge"),
+    log: (s) => out.push(s),
+    error: (s) => assert.fail(`nothing should reach stderr, got: ${s}`),
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(out, [
+    formatReport({ ref: "v3.6.2", engineVersion: { rag: "1.1.4" }, copied: [], regenerated: false, reindexed: false }) + "\n",
+  ]);
+});
+
+// FAIL LOUD: a failed update must reach stderr with the message AND the "the brain was
+// NOT changed past this point" reassurance, print NOTHING on stdout (a report there
+// would read as success), and hand the shell a non-zero.
+test("runUpdateCli — a failed update goes to stderr, prints no report, and exits 1", async () => {
+  const err = [];
+  const code = await runUpdateCli({
+    brainDir: "/brains/mine",
+    updateEngine: async () => {
+      throw new Error("git clone failed: host unreachable");
+    },
+    armRestartFlag: () => assert.fail("a failed update must not arm the restart nudge"),
+    log: (s) => assert.fail(`nothing should reach stdout, got: ${s}`),
+    error: (s) => err.push(s),
+  });
+
+  assert.equal(code, 1);
+  assert.deepEqual(err, [
+    "\n❌ update-engine failed — the brain was NOT changed past this point.\ngit clone failed: host unreachable\n",
+  ]);
+});
+
+// A thrown non-Error (a rejected string, a bare object) must still print SOMETHING
+// usable — the `?? e` fallback, whose absent twin is otherwise never exercised.
+test("runUpdateCli — a thrown non-Error still reaches stderr, not an empty 'undefined'", async () => {
+  const err = [];
+  const code = await runUpdateCli({
+    brainDir: "/brains/mine",
+    updateEngine: async () => {
+      throw "ENOSPC: no space left on device";
+    },
+    armRestartFlag: () => {},
+    log: () => {},
+    error: (s) => err.push(s),
+  });
+
+  assert.equal(code, 1);
+  assert.deepEqual(err, [
+    "\n❌ update-engine failed — the brain was NOT changed past this point.\nENOSPC: no space left on device\n",
+  ]);
+});
+
+// The wiring the no-op test above can only prove NEGATIVELY: an update that did place
+// something on disk arms the nudge, ONCE, in the brain it just updated (a flag armed in
+// the wrong folder nudges nobody).
+test("runUpdateCli — an update that changed something arms the nudge in that brain, once", async () => {
+  const armed = [];
+  const code = await runUpdateCli({
+    brainDir: "/brains/mine",
+    updateEngine: async () => ({
+      ref: "v3.6.2",
+      engineVersion: { rag: "1.1.4" },
+      copied: [],
+      regenerated: false,
+      reindexed: false,
+      skillsRefreshed: ["switch"],
+    }),
+    armRestartFlag: (dir) => armed.push(dir),
+    log: () => {},
+    error: (s) => assert.fail(`nothing should reach stderr, got: ${s}`),
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(armed, ["/brains/mine"]);
+});
+
+// The flag write itself: it lands where `session-self-heal` / the statusLine look for
+// it, with a body a human can read if they ever open it — and it creates the `.cache/`
+// folder, which a freshly-installed brain does not have yet.
+test("armRestartFlag — drops the nudge file under the brain, creating .cache/ if needed", () => {
+  const brainDir = mkdtempSync(join(tmpdir(), "sbg-flag-"));
+
+  armRestartFlag(brainDir);
+
+  assert.equal(
+    readFileSync(join(brainDir, RESTART_FLAG_REL), "utf8"),
+    "restart needed to finish the engine update\n",
+  );
+});
+
+// Fail-soft: the nudge is a convenience on top of an update that ALREADY succeeded and
+// is ALREADY recorded. A read-only `.cache/`, a full disk — none of it may turn a good
+// update into a failure the user reads as "my brain was not updated".
+test("armRestartFlag — an unwritable brain never throws (the update already succeeded)", () => {
+  const brainDir = mkdtempSync(join(tmpdir(), "sbg-flag-ro-"));
+  // A FILE where the `.cache` directory should go → mkdir + write both fail.
+  writeFileSync(join(brainDir, ".cache"), "not a directory\n");
+
+  assert.doesNotThrow(() => armRestartFlag(brainDir));
 });
 
 function sha256(path) {

--- a/scripts/lib/update-engine.test.mjs
+++ b/scripts/lib/update-engine.test.mjs
@@ -278,6 +278,82 @@ test("formatReport — a true no-op (nothing swapped or regenerated) does NOT cr
   assert.doesNotMatch(out, /once more/i);
 });
 
+// ── Increment 2.5, Step 5: report the SKILL refresh ──────────────────────────
+// The whole point of the increment is that a shipped skill improvement finally
+// reaches an existing brain. Delivering it silently leaves the user unaware their
+// `switch` skill just gained the native-connectors reminder — say which skills
+// were brought up to date.
+test("formatReport — names the engine skill(s) it refreshed to the new version", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: ["rag/src/index.ts"],
+    regenerated: false,
+    reindexed: false,
+    skillsRefreshed: ["switch", "coach"],
+  });
+  assert.match(out, /switch, coach/);
+  assert.match(out, /skill/i);
+  // Not a NEW capability: the skill was already there, only its content moved on.
+  assert.doesNotMatch(out, /new engine skill/i);
+});
+
+// The other half of the promise: a skill the owner made their own is NEVER
+// overwritten, and they are TOLD — with the path of the new version dropped next to
+// it, so "I'd like the new bits too" is one question away instead of invisible.
+test("formatReport — says which customized skill was preserved, and where its new version sits", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: ["rag/src/index.ts"],
+    regenerated: false,
+    reindexed: false,
+    skillsPreserved: [
+      { skill: "prepare-1-1", reason: "customized", newVersionPath: ".claude/skills/prepare-1-1/SKILL.md.new" },
+    ],
+  });
+  assert.match(out, /prepare-1-1/);
+  assert.match(out, /\.claude\/skills\/prepare-1-1\/SKILL\.md\.new/);
+  assert.match(out, /kept|preserved|as you wrote/i);
+});
+
+// Step 1's refinement, carried into the prose: a pre-provenance brain (nothing was
+// ever fingerprinted for that file) must NOT be told it customized anything — it
+// didn't. There is nothing to decide and nothing to adopt, so the report stays silent
+// rather than manufacturing a scary, unactionable line on every single update.
+test("formatReport — a preserve with no provenance is NOT reported as a customization", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: ["rag/src/index.ts"],
+    regenerated: false,
+    reindexed: false,
+    skillsPreserved: [{ skill: "coach", reason: "no-provenance" }],
+  });
+  assert.doesNotMatch(out, /customized/i);
+  assert.doesNotMatch(out, /coach/);
+});
+
+// A refreshed skill is on disk but THIS conversation loaded the OLD text when it
+// started (Layer B config-freeze) — exactly the staleness the restart banner exists
+// for. Staying silent because no engine *file* was swapped would let the user try the
+// improved skill in a session that cannot see it, and conclude the update lied.
+test("formatReport — a refresh-only update still says the running session is stale", () => {
+  const out = formatReport({
+    ref: "v3.6.2",
+    engineVersion: { rag: "1.1.4" },
+    copied: [],
+    regenerated: false,
+    reindexed: false,
+    skillsRefreshed: ["switch"],
+  });
+  assert.match(out, /action needed/i);
+  assert.match(out, /restart/i);
+  // Still not a NEW capability: no counter, no "run once more" fallback.
+  assert.doesNotMatch(out, /once more/i);
+  assert.doesNotMatch(out, /new capabilit/i);
+});
+
 // F2: the recap must surface the number the USER cares about — how many notes their
 // brain holds — not just the maintainer-facing "N engine files swapped" count.
 test("formatReport — surfaces the vault note count", () => {

--- a/scripts/lib/update-engine.test.mjs
+++ b/scripts/lib/update-engine.test.mjs
@@ -9,7 +9,9 @@ import {
   rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -44,7 +46,7 @@ async function loadCore() {
 // ── formatReport: the human summary the brain-side skill prints (Step 6) ──────
 // Pure (report object → string) so the wording is unit-tested; the CLI entry holds
 // only the untestable I/O wiring (ADR 0009).
-import { formatReport, countNewCapabilities, needsRestart, runUpdateCli, armRestartFlag, defaultCountVaultNotes } from "../update-engine.mjs";
+import { formatReport, countNewCapabilities, needsRestart, bareHookName, runUpdateCli, realUpdateDeps, armRestartFlag, defaultCountVaultNotes } from "../update-engine.mjs";
 import { RESTART_FLAG_REL } from "./restart-nudge.mjs";
 
 // F2: the default count must match what the indexer actually treats as a note —
@@ -312,9 +314,10 @@ test("formatReport — an everything-on update prints every optional line, in or
     regenerated: true,
     reindexed: true,
     vaultNoteCount: 2,
-    installedSkills: ["local-mirror"],
-    mcpServersAdded: ["local-mirror"],
-    // Deliberately NOT alphabetical: a sorting mutant must diverge from the input order.
+    // Every list holds TWO entries, deliberately NOT alphabetical: on a single item a
+    // dropped separator and a re-sorted list are both invisible.
+    installedSkills: ["local-mirror", "coach"],
+    mcpServersAdded: ["local-mirror", "vault-rag"],
     skillsRefreshed: ["switch", "coach"],
     // A customized preserve (reported, with its sidecar) next to a no-provenance one
     // (silent by design) — the discriminating pair for the `reason` filter.
@@ -322,7 +325,7 @@ test("formatReport — an everything-on update prints every optional line, in or
       { skill: "prepare-1-1", reason: "customized", newVersionPath: ".claude/skills/prepare-1-1/SKILL.md.new" },
       { skill: "import", reason: "no-provenance" },
     ],
-    hooksAdded: ["scripts/session-health.mjs"],
+    hooksAdded: ["scripts/session-health.mjs", "scripts/session-self-heal.mjs"],
     // "statusLine" is the decoy: it carries neither the `scripts/` prefix nor the
     // `.mjs` suffix, so it must pass through the stripping untouched.
     hooksRepaired: ["scripts/auto-push.mjs", "statusLine"],
@@ -334,17 +337,35 @@ test("formatReport — an everything-on update prints every optional line, in or
       "   • 2 engine file(s) swapped + launchers regenerated",
       "   • reindexed — the index format changed (your notes were re-encoded, nothing lost)",
       "   • your vault holds 2 notes — searchable as the reindex finishes",
-      "   • new engine skill(s) installed: local-mirror",
-      "   • new MCP server(s) registered: local-mirror",
+      "   • new engine skill(s) installed: local-mirror, coach",
+      "   • new MCP server(s) registered: local-mirror, vault-rag",
       "   • engine skill(s) brought up to date: switch, coach",
       '   • your customized "prepare-1-1" skill was kept exactly as you wrote it — the newer engine version sits next to it as .claude/skills/prepare-1-1/SKILL.md.new',
-      "   • new runtime hook(s) wired: session-health",
+      "   • new runtime hook(s) wired: session-health, session-self-heal",
       "   • repaired Windows hook command(s) (issue #31 — 'laude' error): auto-push, statusLine",
-      "   ⚠️ ACTION NEEDED — 3 new capabilities are installed on disk but NOT active in THIS conversation.",
+      "   ⚠️ ACTION NEEDED — 6 new capabilities are installed on disk but NOT active in THIS conversation.",
       "   A FULL RESTART of Claude (close it and reopen) is enough: come back to THIS same",
       "   conversation afterwards and your brain can use them. You do NOT need to start a",
       "   brand-new chat for this. Until you restart, your brain CAN'T use them.",
       "   • If still missing after a restart, run /update-engine once more.",
+      "   Your notes, .env, constitution, settings and custom skills were left untouched.",
+    ].join("\n"),
+  );
+});
+
+// A manifest with no `engineVersion` block is a broken manifest — but by the time the
+// report is printed the update is DONE and recorded, so crashing here would print
+// "the brain was NOT changed past this point" over a change that DID happen. Degrade
+// honestly instead: say the version is unknown, and keep every other line.
+test("formatReport — a target manifest with no engineVersion says so instead of crashing", () => {
+  const out = formatReport({ ref: "v3.6.2", copied: [], regenerated: false, reindexed: false });
+
+  assert.equal(
+    out,
+    [
+      "✅ Engine updated to v3.6.2 (rag unknown).",
+      "   • 0 engine file(s) swapped",
+      "   • index format unchanged — no reindex needed",
       "   Your notes, .env, constitution, settings and custom skills were left untouched.",
     ].join("\n"),
   );
@@ -526,6 +547,17 @@ test("formatReport — when reindexed, hints that searchability catches up as in
   assert.match(out, /indexing|searchable|catches up/i);
 });
 
+// F-B2 (ADR 0026): hooks are wired into settings.json by PATH, and read by the user by
+// bare name. The stripping is anchored on purpose — only a LEADING `scripts/` and a
+// TRAILING `.mjs` go — so a value that is not a script path ("statusLine") survives
+// intact and nothing is chopped out of the middle of a name.
+test("bareHookName — strips only a leading scripts/ and a trailing .mjs", () => {
+  assert.equal(bareHookName("scripts/session-health.mjs"), "session-health");
+  assert.equal(bareHookName("statusLine"), "statusLine", "not a script path — untouched");
+  assert.equal(bareHookName("vendor/scripts/probe.mjs"), "vendor/scripts/probe", "scripts/ mid-path is part of the name");
+  assert.equal(bareHookName("scripts/probe.mjs.bak"), "probe.mjs.bak", ".mjs mid-name is part of the name");
+});
+
 // ── Step 10: the CLI's decisions, extracted OUT of the entry-point block ──────
 // They used to live inside `if (isEntrypoint(...))`, unreachable by any test — which
 // is why ~40 of the file's 96 surviving mutants clustered there. Pure predicates now.
@@ -564,6 +596,13 @@ test("needsRestart — a genuine no-op leaves the nudge disarmed", () => {
     needsRestart({ copied: [], regenerated: false, skillsRefreshed: [], installedSkills: [], mcpServersAdded: [], hooksAdded: [] }),
     false,
   );
+});
+
+// The absent twin: a report carrying none of the keys at all (an older reconcile, a
+// partial report) must answer "no restart needed" — never explode. The optional chains
+// are the whole reason this holds, and nothing else exercises them.
+test("needsRestart — a report carrying none of the keys answers no, without throwing", () => {
+  assert.equal(needsRestart({}), false);
 });
 
 // The other three triggers, each ALONE (an OR chain where only one disjunct is ever
@@ -663,11 +702,90 @@ test("runUpdateCli — an update that changed something arms the nudge in that b
   assert.deepEqual(armed, ["/brains/mine"]);
 });
 
+// The bottom of the barrel: a rejection with NO reason at all (a `throw null`, an
+// aborted child). The banner must still say something a human can act on — printing a
+// bare "null" under a ❌ is the same dead end as printing nothing.
+test("runUpdateCli — a rejection with no reason still explains itself", async () => {
+  const err = [];
+  const code = await runUpdateCli({
+    brainDir: "/brains/mine",
+    updateEngine: async () => {
+      throw null;
+    },
+    armRestartFlag: () => {},
+    log: () => {},
+    error: (s) => err.push(s),
+  });
+
+  assert.equal(code, 1);
+  assert.deepEqual(err, [
+    "\n❌ update-engine failed — the brain was NOT changed past this point.\nno reason given\n",
+  ]);
+});
+
+// …and the last untested link: that the entry-point guard actually FIRES. Bug B2 was
+// exactly this — a hand-rolled `file://` comparison that silently never matched, so
+// running the command did nothing at all and said nothing about it. Everything above
+// can be green while the script is a no-op, so run it for real, as a process.
+// Safe by construction: the COMMITTED launcher manifest pins no `source`
+// (engine-manifest-integrity enforces it), so the run fails on that before it can
+// fetch, write or touch anything.
+test("the CLI entry point actually runs the update (and fails LOUDLY, never silently)", () => {
+  const script = resolve(dirname(fileURLToPath(import.meta.url)), "../update-engine.mjs");
+
+  const r = spawnSync(process.execPath, [script], { encoding: "utf8" });
+
+  assert.equal(r.status, 1, "a script that silently does nothing would exit 0");
+  assert.match(r.stderr, /❌ update-engine failed/);
+  assert.match(r.stderr, /no source repo recorded/);
+  assert.equal(r.stdout, "", "a failed update must not print a success report");
+});
+
+// The wiring itself — the one thing `runUpdateCli(deps)` can never prove, since every
+// test hands it doubles. If `realUpdateDeps` pointed at the wrong folder or at a
+// swallowing stream, the CLI would run flawlessly against nothing and say so.
+test("realUpdateDeps — points at the brain the script lives in, and at the real streams", () => {
+  const brainRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+  assert.equal(realUpdateDeps.brainDir, brainRoot, "brainDir = the parent of scripts/, i.e. the brain itself");
+  assert.equal(realUpdateDeps.armRestartFlag, armRestartFlag);
+  assert.equal(realUpdateDeps.updateEngine.name, "updateEngine");
+
+  const outs = [];
+  const errs = [];
+  const [realOut, realErr] = [process.stdout.write, process.stderr.write];
+  process.stdout.write = (s) => outs.push(s) && true;
+  process.stderr.write = (s) => errs.push(s) && true;
+  try {
+    realUpdateDeps.log("the report\n");
+    realUpdateDeps.error("the failure\n");
+  } finally {
+    [process.stdout.write, process.stderr.write] = [realOut, realErr];
+  }
+  assert.deepEqual(outs, ["the report\n"], "the report goes to stdout");
+  assert.deepEqual(errs, ["the failure\n"], "the failure goes to stderr, never mixed into the report");
+});
+
 // The flag write itself: it lands where `session-self-heal` / the statusLine look for
 // it, with a body a human can read if they ever open it — and it creates the `.cache/`
 // folder, which a freshly-installed brain does not have yet.
 test("armRestartFlag — drops the nudge file under the brain, creating .cache/ if needed", () => {
   const brainDir = mkdtempSync(join(tmpdir(), "sbg-flag-"));
+
+  armRestartFlag(brainDir);
+
+  assert.equal(
+    readFileSync(join(brainDir, RESTART_FLAG_REL), "utf8"),
+    "restart needed to finish the engine update\n",
+  );
+});
+
+// The common case, and the one a non-recursive mkdir would break: `.cache/` is already
+// there (every brain past its first session has it) and the flag was cleared by a
+// converged session. Re-arming must still drop the file, not blow up on EEXIST and get
+// swallowed by the fail-soft catch — which would silently stop nudging forever.
+test("armRestartFlag — re-arms in a brain whose .cache/ already exists", () => {
+  const brainDir = mkdtempSync(join(tmpdir(), "sbg-flag-again-"));
+  mkdirSync(join(brainDir, dirname(RESTART_FLAG_REL)), { recursive: true });
 
   armRestartFlag(brainDir);
 
@@ -845,7 +963,10 @@ async function runUpdate({ brainDir, sourceDir, platform, resolveLatestTag, coun
     // target's version; overridable to exercise the offline/no-tag fallback. The
     // committed launcher manifest has NO `source`, so this — not target.source —
     // is the single thing that advances the brain's recorded ref.
-    resolveLatestTag: resolveLatestTag ?? (async () => "v1.1.0"),
+    resolveLatestTag: async (arg) => {
+      calls.resolveTag = arg;
+      return resolveLatestTag ? resolveLatestTag(arg) : "v1.1.0";
+    },
     fetchSource: async ({ repo, ref }) => {
       calls.fetch = { repo, ref };
       return sourceDir;
@@ -883,6 +1004,14 @@ for (const platform of ["posix", "win32"]) {
     // 0. The engine was fetched at the RESOLVED latest tag (not the brain's pinned
     //    ref) — this is what makes the displayed Version actually advance (ADR 0017).
     assert.equal(calls.fetch.ref, "v1.1.0", "must fetch the resolved latest tag, not the old pinned ref");
+    //    …and the tag was looked up on the repo the BRAIN recorded. Ask without it and
+    //    the lookup answers null, the update silently re-pulls the pinned ref forever,
+    //    and the brain never advances a single version.
+    assert.deepEqual(
+      calls.resolveTag,
+      { repo: "https://example.test/launcher.git" },
+      "the latest tag must be resolved on the brain's recorded source repo",
+    );
 
     // 1. Every COPIED engine file now carries the vB bytes — the `replace` bucket and
     //    the engine-owned scripts (incl. update-engine.mjs self-update). The launchers
@@ -913,7 +1042,12 @@ for (const platform of ["posix", "win32"]) {
     assertSacredUntouched(brainDir, before);
 
     // 5. The brain's manifest now records the new version + the ref it pulled.
-    const m = JSON.parse(readFileSync(join(brainDir, "engine-manifest.json"), "utf8"));
+    const manifestText = readFileSync(join(brainDir, "engine-manifest.json"), "utf8");
+    // The brain is a git repo whose hook commits this file: a manifest written without
+    // its trailing newline shows up as a "\ No newline at end of file" diff on every
+    // single update, forever.
+    assert.equal(manifestText.endsWith("}\n"), true, "the manifest must be written with a trailing newline");
+    const m = JSON.parse(manifestText);
     assert.equal(m.engineVersion.rag, "1.1.0", "manifest engineVersion.rag must be bumped to the target");
     assert.equal(m.indexSchemaVersion, 2, "manifest indexSchemaVersion must follow the target");
     assert.equal(m.source.ref, "v1.1.0", "manifest source.ref must ADVANCE to the resolved latest tag");

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -66,16 +66,24 @@ export function needsRestart(report) {
   );
 }
 
+// F-B2 (ADR 0026) / issue #31: hooks are wired into settings.json by PATH
+// (`scripts/session-health.mjs`) but read by the user by bare name. Both anchors are
+// deliberate — only a LEADING `scripts/` and a TRAILING `.mjs` go — so a value that is
+// not a script path at all ("statusLine") passes through untouched.
+export function bareHookName(command) {
+  return command.replace(/^scripts\//, "").replace(/\.mjs$/, "");
+}
+
 // Human summary the brain-side `update-engine` skill shows the user (Step 6, ADR
 // 0016). Pure so the wording is unit-tested; the CLI entry only wires the I/O.
 export function formatReport(report) {
   const { ref, engineVersion, copied, regenerated, reindexed, reindexReason, vaultNoteCount, installedSkills = [], skillsRefreshed = [], skillsPreserved = [], mcpServersAdded = [], hooksAdded = [], hooksRepaired = [] } = report;
   // F-B2 (ADR 0026): the engine-owned SessionStart hooks wired into an upgrader's
   // settings.json, by their bare name (scripts/session-health.mjs → session-health).
-  const wiredHooks = hooksAdded.map((s) => s.replace(/^scripts\//, "").replace(/\.mjs$/, ""));
+  const wiredHooks = hooksAdded.map(bareHookName);
   // Issue #31: broken `cmd /c "…\run-node.cmd"` hook/statusLine commands healed in place
   // on a pre-fix Windows brain (by bare name; "statusLine" passes through unchanged).
-  const healedHooks = hooksRepaired.map((s) => s.replace(/^scripts\//, "").replace(/\.mjs$/, ""));
+  const healedHooks = hooksRepaired.map(bareHookName);
   // Honest reindex line: a schema move re-encodes EVERY note; the health-note pairing (ADR
   // 0026 decision B, upgraders) only makes sure the one engine-owned note is present and
   // indexed (incremental — your other notes are untouched) — never claim "the index format
@@ -86,7 +94,10 @@ export function formatReport(report) {
       ? `   • ensured the engine health-check note is present and indexed (incremental — your other notes were not re-encoded)`
       : `   • reindexed — the index format changed (your notes were re-encoded, nothing lost)`;
   const lines = [
-    `✅ Engine updated to ${ref} (rag ${engineVersion?.rag}).`,
+    // `?? "unknown"`: a manifest with no engineVersion block is broken, but the update
+    // it describes is already done and recorded — printing "undefined" (or throwing)
+    // would be the report lying about a change that DID happen.
+    `✅ Engine updated to ${ref} (rag ${engineVersion?.rag ?? "unknown"}).`,
     `   • ${copied.length} engine file(s) swapped` + (regenerated ? " + launchers regenerated" : ""),
     reindexLine,
   ];
@@ -336,7 +347,10 @@ export async function runUpdateCli(deps = realUpdateDeps) {
     deps.log(formatReport(report) + "\n");
     return 0;
   } catch (e) {
-    deps.error(`\n❌ update-engine failed — the brain was NOT changed past this point.\n${e?.message ?? e}\n`);
+    // `?? e` catches a thrown non-Error (a bare string); `?? "no reason given"` catches
+    // a rejection with no reason at all — a ❌ banner over an empty line tells nobody
+    // anything, and this is the one output a failed update leaves behind.
+    deps.error(`\n❌ update-engine failed — the brain was NOT changed past this point.\n${e?.message ?? e ?? "no reason given"}\n`);
     return 1;
   }
 }

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -44,7 +44,7 @@ export { defaultCountVaultNotes };
 // Human summary the brain-side `update-engine` skill shows the user (Step 6, ADR
 // 0016). Pure so the wording is unit-tested; the CLI entry only wires the I/O.
 export function formatReport(report) {
-  const { ref, engineVersion, copied, regenerated, reindexed, reindexReason, vaultNoteCount, installedSkills = [], mcpServersAdded = [], hooksAdded = [], hooksRepaired = [] } = report;
+  const { ref, engineVersion, copied, regenerated, reindexed, reindexReason, vaultNoteCount, installedSkills = [], skillsRefreshed = [], skillsPreserved = [], mcpServersAdded = [], hooksAdded = [], hooksRepaired = [] } = report;
   // F-B2 (ADR 0026): the engine-owned SessionStart hooks wired into an upgrader's
   // settings.json, by their bare name (scripts/session-health.mjs → session-health).
   const wiredHooks = hooksAdded.map((s) => s.replace(/^scripts\//, "").replace(/\.mjs$/, ""));
@@ -82,6 +82,24 @@ export function formatReport(report) {
   if (mcpServersAdded.length > 0) {
     lines.push(`   • new MCP server(s) registered: ${mcpServersAdded.join(", ")}`);
   }
+  // Increment 2.5: an engine skill the owner never touched was brought up to date.
+  // Distinct from "new engine skill(s) installed" above — the skill was already
+  // there, so the news is that it MOVED ON, not that it appeared.
+  if (skillsRefreshed.length > 0) {
+    lines.push(`   • engine skill(s) brought up to date: ${skillsRefreshed.join(", ")}`);
+  }
+  // ...and the mirror promise: a skill the owner edited is left ALONE. Report it per
+  // skill, with the path of the new version dropped beside it, so the choice to adopt
+  // the new bits stays theirs. `no-provenance` stays silent on purpose: it is a machine
+  // detail (an older brain that was never fingerprinted), not a decision the user made
+  // nor one they can act on.
+  for (const { skill, reason, newVersionPath } of skillsPreserved) {
+    if (reason !== "customized") continue;
+    lines.push(
+      `   • your customized "${skill}" skill was kept exactly as you wrote it` +
+        (newVersionPath ? ` — the newer engine version sits next to it as ${newVersionPath}` : ""),
+    );
+  }
   if (wiredHooks.length > 0) {
     lines.push(`   • new runtime hook(s) wired: ${wiredHooks.join(", ")}`);
   }
@@ -107,7 +125,7 @@ export function formatReport(report) {
       `   brand-new chat for this. Until you restart, your brain CAN'T use ${them}.`,
       `   • If still missing after a restart, run /update-engine once more.`,
     );
-  } else if (copied.length > 0 || regenerated) {
+  } else if (copied.length > 0 || regenerated || skillsRefreshed.length > 0) {
     // F-B7d (ship-blocker A1): even a steady-state swap with NO brand-new capability still
     // needs a restart — the MCP server, hooks and constitution THIS conversation loaded are
     // the OLD ones until Claude is reopened. Stay silent and a "✅ done" reads as "already
@@ -115,7 +133,7 @@ export function formatReport(report) {
     // new-capability counter / "run once more" fallback (those are reserved for actual new
     // capabilities). The genuine no-op (nothing swapped) skips this entirely → no crying wolf.
     lines.push(
-      `   ⚠️ ACTION NEEDED — the engine code was updated on disk, but THIS conversation is`,
+      `   ⚠️ ACTION NEEDED — your engine was updated on disk, but THIS conversation is`,
       `   still running the OLD version. A FULL RESTART of Claude (close it and reopen) is`,
       `   enough: come back to THIS same conversation afterwards and the update takes effect.`,
       `   Until you restart, your brain keeps using the old engine.`,
@@ -261,7 +279,9 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
       // a belt for the in-session converged case (the report banner alone scrolls away).
       // The next fresh, converged session clears it (session-self-heal). Fail-soft.
       const newCaps = (report.installedSkills?.length ?? 0) + (report.mcpServersAdded?.length ?? 0) + (report.hooksAdded?.length ?? 0);
-      if (report.copied?.length > 0 || report.regenerated || newCaps > 0) {
+      // A refreshed skill counts too (Increment 2.5): its new text loads only at the
+      // next session start, so the nudge must keep standing until the user restarts.
+      if (report.copied?.length > 0 || report.regenerated || newCaps > 0 || report.skillsRefreshed?.length > 0) {
         try {
           const flagPath = join(brainDir, RESTART_FLAG_REL);
           mkdirSync(dirname(flagPath), { recursive: true });

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -158,8 +158,20 @@ export async function updateEngine({
   //    vault notes — all behind the deterministic, idempotent
   //    `reconcileBrain`. Extracted so the SAME reconciler runs at auto-finalize (a fresh
   //    child process at the end of this function) and at SessionStart self-heal.
-  const { copied, regenerated, reindexed, reindexReason, vaultNoteCount, installedSkills, mcpServersAdded, hooksAdded, hooksRepaired } =
-    await reconcileBrain({
+  const {
+    copied,
+    regenerated,
+    reindexed,
+    reindexReason,
+    vaultNoteCount,
+    installedSkills,
+    skillsRefreshed,
+    skillsPreserved,
+    refreshedFileMap,
+    mcpServersAdded,
+    hooksAdded,
+    hooksRepaired,
+  } = await reconcileBrain({
       brainDir,
       platform,
       sourceDir,
@@ -176,9 +188,15 @@ export async function updateEngine({
   //    re-delivered (the engine-owned scripts, read back from disk), while the user's
   //    untouched merge files (CLAUDE.md/settings/skills) keep their prior base — so a
   //    future Phase 2 3-way still detects the user's edits.
-  const deliveredFileMap = Object.fromEntries(
-    copied.map((rel) => [rel, readFileSync(join(brainDir, rel), "utf8")]),
-  );
+  //    T1 (Increment 2.5): the skills the reconcile just REFRESHED are re-delivered
+  //    content too, so they must be re-seeded here. Miss them and this manifest write
+  //    (built from the `local` copy read before the reconcile) leaves their base at the
+  //    OLD content → the next update calls them "user-modified" and never refreshes
+  //    them again: the feature would work exactly once per brain, silently.
+  const deliveredFileMap = {
+    ...Object.fromEntries(copied.map((rel) => [rel, readFileSync(join(brainDir, rel), "utf8")])),
+    ...refreshedFileMap,
+  };
   const updated = {
     ...local,
     engineVersion: target.engineVersion,
@@ -212,7 +230,21 @@ export async function updateEngine({
     // swallowed on purpose — the update succeeded; self-heal will finish the job.
   }
 
-  return { ref: updated.source.ref, engineVersion: updated.engineVersion, copied, regenerated, reindexed, reindexReason, vaultNoteCount, installedSkills, mcpServersAdded, hooksAdded, hooksRepaired };
+  return {
+    ref: updated.source.ref,
+    engineVersion: updated.engineVersion,
+    copied,
+    regenerated,
+    reindexed,
+    reindexReason,
+    vaultNoteCount,
+    installedSkills,
+    skillsRefreshed,
+    skillsPreserved,
+    mcpServersAdded,
+    hooksAdded,
+    hooksRepaired,
+  };
 }
 
 // ── CLI entry (the command the brain-side `update-engine` skill runs) ─────────

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -22,6 +22,7 @@ import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { RESTART_FLAG_REL } from "./lib/restart-nudge.mjs";
+import { isEntrypoint } from "./lib/entrypoint.mjs";
 
 import {
   fetchSource as defaultFetchSource,
@@ -40,6 +41,30 @@ import { defaultFinalizeReconcile } from "./lib/auto-finalize.mjs";
 
 // Re-export so the engine's own tests keep importing the count seam from here.
 export { defaultCountVaultNotes };
+
+// How many capabilities this update DELIVERED that the running conversation cannot
+// see yet (Layer B config-freeze): a skill, an MCP server and a hook all load only at
+// the next session start. Pure, and shared by the report banner and the CLI's
+// restart-flag decision so the two can never drift apart.
+export function countNewCapabilities(report) {
+  return (
+    (report.installedSkills?.length ?? 0) +
+    (report.mcpServersAdded?.length ?? 0) +
+    (report.hooksAdded?.length ?? 0)
+  );
+}
+
+// Did this update place anything on disk that only takes effect at the next session
+// start? Then the persistent restart flag must be armed (A2 / F-B7d), so the statusLine
+// keeps nudging after the report banner has scrolled away.
+export function needsRestart(report) {
+  return (
+    report.copied?.length > 0 ||
+    Boolean(report.regenerated) ||
+    countNewCapabilities(report) > 0 ||
+    report.skillsRefreshed?.length > 0
+  );
+}
 
 // Human summary the brain-side `update-engine` skill shows the user (Step 6, ADR
 // 0016). Pure so the wording is unit-tested; the CLI entry only wires the I/O.
@@ -93,11 +118,15 @@ export function formatReport(report) {
   // the new bits stays theirs. `no-provenance` stays silent on purpose: it is a machine
   // detail (an older brain that was never fingerprinted), not a decision the user made
   // nor one they can act on.
+  // The path is read UNCONDITIONALLY: `refreshUntouchedSkills` emits `customized` only
+  // ever WITH a `newVersionPath` (engine-skill-refresh.mjs — the sidecar is written on
+  // that same branch), so a "no path" fallback here would be a state the producer cannot
+  // emit — a dead branch to maintain and mutation-test forever, not a safety net.
   for (const { skill, reason, newVersionPath } of skillsPreserved) {
     if (reason !== "customized") continue;
     lines.push(
       `   • your customized "${skill}" skill was kept exactly as you wrote it` +
-        (newVersionPath ? ` — the newer engine version sits next to it as ${newVersionPath}` : ""),
+        ` — the newer engine version sits next to it as ${newVersionPath}`,
     );
   }
   if (wiredHooks.length > 0) {
@@ -113,7 +142,7 @@ export function formatReport(report) {
   // this same conversation (field-proven, F4). Do NOT muddy it with "start a new
   // conversation": that is the distinct initial-rooting rule (a never-rooted session),
   // not what is needed just to pick up new capabilities.
-  const newCapabilities = installedSkills.length + mcpServersAdded.length + wiredHooks.length;
+  const newCapabilities = countNewCapabilities(report);
   if (newCapabilities > 0) {
     const noun = newCapabilities === 1 ? "capability" : "capabilities";
     const them = newCapabilities === 1 ? "it" : "them";
@@ -270,36 +299,50 @@ export async function updateEngine({
   };
 }
 
-// ── CLI entry (the command the brain-side `update-engine` skill runs) ─────────
-// Guarded so importing this module in tests does NOT run it. Operates on the brain
-// the script lives in (<brain>/scripts/update-engine.mjs → brainDir = its parent),
-// with the real git/npm/ONNX seams. FAIL LOUD (the project's strategy): on any
-// error, print it to stderr and exit non-zero — never pretend it worked.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const brainDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  updateEngine({ brainDir })
-    .then((report) => {
-      // A2 (F-B7d): if this update placed anything a restart is needed for, arm the
-      // persistent restart flag so the statusLine keeps nudging until the user restarts —
-      // a belt for the in-session converged case (the report banner alone scrolls away).
-      // The next fresh, converged session clears it (session-self-heal). Fail-soft.
-      const newCaps = (report.installedSkills?.length ?? 0) + (report.mcpServersAdded?.length ?? 0) + (report.hooksAdded?.length ?? 0);
-      // A refreshed skill counts too (Increment 2.5): its new text loads only at the
-      // next session start, so the nudge must keep standing until the user restarts.
-      if (report.copied?.length > 0 || report.regenerated || newCaps > 0 || report.skillsRefreshed?.length > 0) {
-        try {
-          const flagPath = join(brainDir, RESTART_FLAG_REL);
-          mkdirSync(dirname(flagPath), { recursive: true });
-          writeFileSync(flagPath, "restart needed to finish the engine update\n");
-        } catch {
-          /* fail-soft: the nudge is a convenience, never a blocker */
-        }
-      }
-      process.stdout.write(formatReport(report) + "\n");
-      process.exit(0);
-    })
-    .catch((e) => {
-      process.stderr.write(`\n❌ update-engine failed — the brain was NOT changed past this point.\n${e?.message ?? e}\n`);
-      process.exit(1);
-    });
+// A2 (F-B7d): arm the persistent restart flag so the statusLine keeps nudging until
+// the user restarts — a belt for the in-session converged case (the report banner
+// alone scrolls away). The next fresh, converged session clears it
+// (session-self-heal). Fail-soft: the nudge is a convenience, never a blocker.
+export function armRestartFlag(brainDir) {
+  try {
+    const flagPath = join(brainDir, RESTART_FLAG_REL);
+    mkdirSync(dirname(flagPath), { recursive: true });
+    writeFileSync(flagPath, "restart needed to finish the engine update\n");
+  } catch {
+    /* fail-soft */
+  }
+}
+
+// The real I/O the CLI runs on: the brain the script lives in
+// (<brain>/scripts/update-engine.mjs → brainDir = its parent), the real update, the
+// real flag write and the real streams. Everything `runUpdateCli` decides is testable
+// BECAUSE it is handed these instead of reaching for them (the `clear-example-notes`
+// idiom) — the entry-point block below is now pure wiring.
+export const realUpdateDeps = {
+  brainDir: resolve(dirname(fileURLToPath(import.meta.url)), ".."),
+  updateEngine,
+  armRestartFlag,
+  log: (s) => process.stdout.write(s),
+  error: (s) => process.stderr.write(s),
+};
+
+// The command the brain-side `update-engine` skill runs, minus the process. Returns
+// the exit code. FAIL LOUD (the project's strategy): on any error, print it to stderr
+// and hand back a non-zero — never pretend it worked.
+export async function runUpdateCli(deps = realUpdateDeps) {
+  try {
+    const report = await deps.updateEngine({ brainDir: deps.brainDir });
+    if (needsRestart(report)) deps.armRestartFlag(deps.brainDir);
+    deps.log(formatReport(report) + "\n");
+    return 0;
+  } catch (e) {
+    deps.error(`\n❌ update-engine failed — the brain was NOT changed past this point.\n${e?.message ?? e}\n`);
+    return 1;
+  }
+}
+
+// ── CLI entry ────────────────────────────────────────────────────────────────
+// Guarded so importing this module in tests does NOT run it.
+if (isEntrypoint(import.meta.url, process.argv[1])) {
+  process.exit(await runUpdateCli());
 }

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -183,6 +183,7 @@ export async function updateEngine({
     reindexReason,
     vaultNoteCount,
     installedSkills,
+    installedFileMap,
     skillsRefreshed,
     skillsPreserved,
     refreshedFileMap,
@@ -211,8 +212,12 @@ export async function updateEngine({
   //    (built from the `local` copy read before the reconcile) leaves their base at the
   //    OLD content → the next update calls them "user-modified" and never refreshes
   //    them again: the feature would work exactly once per brain, silently.
+  //    Same for the skills the reconcile just INSTALLED (install-if-absent): they are
+  //    engine-delivered content with no base yet, and a skill without a base is never
+  //    refreshable again.
   const deliveredFileMap = {
     ...Object.fromEntries(copied.map((rel) => [rel, readFileSync(join(brainDir, rel), "utf8")])),
+    ...installedFileMap,
     ...refreshedFileMap,
   };
   const updated = {

--- a/templates/fr/.claude/skills/update-engine/SKILL.md
+++ b/templates/fr/.claude/skills/update-engine/SKILL.md
@@ -80,6 +80,17 @@ applique exactement les fichiers du moteur, régénère les launchers, lance `np
 - **`exit 1`** → **relaie l'erreur telle quelle** et dis à l'utilisateur que le cerveau n'a pas
   été modifié au-delà du point d'échec. **Ne prétends jamais que ça a marché si ça a échoué.**
 
+> 🔁 **OBLIGATOIRE — si la sortie porte la bannière `ENGINE UPDATE UNFINISHED — AGENT, RUN THE
+> UPDATE ONCE MORE`, relance `node scripts/update-engine.mjs` une seconde fois, tout de suite, SANS
+> reposer la question** (la personne a déjà demandé cette mise à jour). Ce cerveau vient d'un moteur
+> antérieur à la **v3.3.0**, dont l'orchestrateur ne relance pas le réconciliateur fraîchement
+> écrit : la première passe pose le nouveau moteur sur le disque, **seule la seconde remet à jour
+> ses skills du moteur restés intacts**. Rends compte du résumé de la **SECONDE** passe et de sa
+> consigne de redémarrage, pas de ceux de la première, sans faire attendre la personne derrière une
+> question intermédiaire. **Aucune boucle possible** : la seconde passe enregistre les nouvelles
+> versions, donc la bannière disparaît. _(Vecteur transitoire pour la cohorte pré-v3.3.0 ; il
+> disparaîtra avec elle.)_
+
 > **Si le résumé indique que de nouveaux skills/MCP ont été installés** (l'avertissement
 > « ACTION NEEDED ») : dis à l'utilisateur qu'un **redémarrage complet de Claude** (fermer puis
 > rouvrir) suffit, puis de **revenir dans CETTE même conversation** — la nouvelle capacité se

--- a/templates/fr/.claude/skills/update-engine/SKILL.md
+++ b/templates/fr/.claude/skills/update-engine/SKILL.md
@@ -71,6 +71,12 @@ applique exactement les fichiers du moteur, régénère les launchers, lance `np
 - **`exit 0`** → relaie le résumé affiché (nouvelle version, combien de fichiers du moteur ont
   été remplacés, si une réindexation a eu lieu). Rassure : rien de ce qui est à l'utilisateur
   n'a été touché.
+  - Si le résumé liste des **skills du moteur remis à jour**, nomme-les : une amélioration
+    livrée il y a des mois vient enfin d'arriver dans ce cerveau ; la livrer en silence, c'est
+    laisser la personne ignorer qu'elle l'a désormais.
+  - S'il indique qu'un **skill personnalisé a été conservé**, relaie-le aussi, **avec le chemin
+    du fichier `.new`** : sa version reste intacte, et la version plus récente du moteur est
+    posée à côté. Propose de comparer les deux, ou d'intégrer les nouveautés dans la sienne.
 - **`exit 1`** → **relaie l'erreur telle quelle** et dis à l'utilisateur que le cerveau n'a pas
   été modifié au-delà du point d'échec. **Ne prétends jamais que ça a marché si ça a échoué.**
 

--- a/templates/fr/.claude/skills/update-engine/SKILL.md
+++ b/templates/fr/.claude/skills/update-engine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-engine
-description: "Met à jour le MOTEUR de ton second cerveau (le code de recherche RAG, les launchers et les scripts du moteur) vers une version plus récente, sur opt-in et sans jamais toucher à tes notes, ton .env, ta constitution, tes réglages ni tes skills perso. Réindexe uniquement si le format d'index a changé. À utiliser quand l'utilisateur demande de mettre à jour le moteur de son cerveau, ou de vérifier si une mise à jour est disponible."
-version: 1.0.0
+description: "Met à jour le MOTEUR de ton second cerveau (le code de recherche RAG, les launchers et les scripts du moteur) vers une version plus récente, sur opt-in et sans jamais toucher à tes notes, ton .env, ta constitution, tes réglages, tes skills à toi ni aucun skill du moteur que tu as personnalisé. Réindexe uniquement si le format d'index a changé. À utiliser quand l'utilisateur demande de mettre à jour le moteur de son cerveau, ou de vérifier si une mise à jour est disponible."
+version: 1.1.0
 ---
 
 # /update-engine — Mets à jour le moteur de ton cerveau (opt-in, non destructif)
@@ -10,8 +10,8 @@ version: 1.0.0
 > le code de recherche RAG (`rag/`), les launchers et les scripts du moteur. Ce skill le
 > remplace par une version plus récente épinglée dans le launcher qui t'a généré, **sans
 > jamais toucher à ce qui est à toi** : tes notes, ton `.env`, ta constitution
-> (`CLAUDE.md`), ton `.claude/settings.json` et tes skills perso restent **identiques au
-> octet près**.
+> (`CLAUDE.md`), ton `.claude/settings.json`, tes skills à toi et **tout skill du moteur que
+> tu as personnalisé** restent **identiques à l'octet près**.
 >
 > ⚠️ **Ce skill n'est qu'un pilote conversationnel mince.** Tout le vrai travail, testable,
 > vit dans le cœur déterministe `scripts/update-engine.mjs` (ADR 0016). Ce skill se contente
@@ -40,7 +40,9 @@ toujours être une action consciente et acceptée.
 | launchers `rag/launch.*`, `scripts/run-node.*` | `.env` (tes clés) |
 | scripts du moteur (`auto-commit`, `auto-push`, `status-line`, `verify-rag`) | `CLAUDE.md` (ta constitution) |
 | `update-engine` lui-même (il s'auto-met à jour) | `.claude/settings.json` |
-|  | tes skills perso `.claude/skills/**` |
+| skills du moteur **manquants** (p. ex. `local-mirror`) : _ajoutés s'ils sont absents_ (ADR 0025) | **tes** skills à toi (`.claude/skills/**`) : le moteur ne les déclare pas, il ne peut donc jamais les écrire |
+| skills du moteur **que tu n'as jamais modifiés** : _remis à jour_ (ADR 0026 §8) | tout skill du moteur **que tu as personnalisé** : conservé à l'octet près, la version plus récente du moteur étant posée **à côté** en `.new` |
+| serveurs MCP du moteur **manquants** dans `.mcp.json` : _ajoutés s'ils sont absents_ (ADR 0025) | tout serveur que tu as ajouté toi-même à `.mcp.json` |
 
 ## Procédure
 
@@ -48,8 +50,13 @@ toujours être une action consciente et acceptée.
 Explique, simplement :
 - ça récupère un moteur plus récent et remplace le nouveau code, les launchers et les scripts
   du moteur ;
-- **tes notes, ton `.env`, ta constitution, tes réglages et tes skills perso restent
+- **tes notes, ton `.env`, ta constitution, tes réglages et tes skills à toi restent
   intacts** ;
+- ça **remet à jour les skills du moteur que tu n'as jamais modifiés**, pour que les
+  améliorations livrées depuis l'installation de ce cerveau finissent par lui parvenir ;
+  **tout ce que tu as personnalisé reste exactement tel que tu l'as écrit**, la version plus
+  récente du moteur étant simplement posée à côté en `.new`, libre à toi de l'adopter ou de
+  l'ignorer ;
 - ça **réindexe uniquement si le format d'index a changé** (quelques minutes, rien de perdu —
   tes notes sont simplement ré-encodées) ;
 - **prérequis** : `git`, `npm` et une connexion réseau (comme à l'installation). Ici


### PR DESCRIPTION
## The gap this closes

Until now, an engine skill that already existed on a brain was **never** updated. Every skill
improvement shipped since `v3.2.2` (12 commits touching `.claude/skills/**`) reached **fresh installs
only**. Concretely: `4e43e70` (shipped in v3.6.2) added the single-account connectors reminder to
`switch/SKILL.md` — a brain installed at v3.6.0/v3.6.1 would never receive it, even after
`/update-engine`, while the matching deterministic core (`scripts/lib/universes.mjs`, a `replace`
glob) *was* refreshed. A live core/skill drift, growing with the installed base.

## The decision

**Refresh an engine skill if, and only if, we can prove nobody touched it.** The proof already exists
on every deployed brain: the installer records a sha256 provenance base per `merge` file in
`engine-manifest.json`.

- hash matches the recorded base → byte-identical to what the engine last delivered → **overwrite**;
- hash differs → the owner tailored it → **touch nothing**, drop the new version alongside as
  `SKILL.md.new`, and **say so** in the report.

It never weakens ADR 0012's write-allowlist: we only overwrite a file we can prove is untouched,
which is strictly safer than what `update-engine` already does on `rag/src/**`.

## Where it lives

`reconcileBrain`, behind a `sourceDir !== brainDir` guard, so the rule holds: **a skill is only ever
overwritten during an update the owner explicitly asked for, never silently at SessionStart.**
Locale-aware (a French brain gets the French source, never re-anglicized), provenance re-seeded after
each refresh (else the feature dies after one use), and reported per skill in the `update-engine`
summary.

Three defects found on the way, each fixed here:

- a skill delivered by **install-if-absent got no provenance base**, so it was frozen the day it
  arrived — the very freeze this closes, re-entering by another door;
- the `absent-install` verdict was **silently dropped** by the I/O wrapper, so a file a release adds
  *under* an already-installed skill would have reached no brain, ever;
- the **staged skills** (6 of them) had no provenance base at all; their own `engine-skills/<name>/`
  copy, read before the copy step overwrites it, is a free retroactive base for the whole fleet.

**Pre-v3.3.0 cohort** (no auto-finalize in their installed orchestrator) converges on their **first**
`/update-engine`, not their second, via the proven message-in-a-bottle vector. Everyone at v3.3.0+
converges in a single pass.

## Verification

- `843` harness tests, green (`node --test scripts/**.test.mjs rag/*.test.mjs`).
- **QA on real release tags** (v3.2.2 / v3.6.0 / v3.6.2 bytes captured under
  `maintainers/qa/release-fixtures/`), automated: a v3.6.0 fixture must end up with the v3.6.2
  `switch` skill. That suite is what caught the install-if-absent provenance defect.
- `/code-review` of the whole increment before Step 10: 2 findings, both real, both fixed.
- **Mutation testing** on the impacted surface, every survivor killed or recorded as equivalent:

| File | Before | After |
|---|---|---|
| `scripts/lib/engine-skill-refresh.mjs` | 86.72 % | **100 %** |
| `scripts/update-engine.mjs` | 51.52 % | **98.49 %** |
| `scripts/lib/reconcile-brain.mjs` | 71.43 % | **96.45 %** |
| `scripts/lib/engine-source.mjs` | 81.40 % | **93.02 %** |

The last three were **never** audited before: those low scores are not a regression from this branch.
The root-cause retrospective ("how did we come to write tests that score this badly") landed in
`maintainers/mutation/RETROSPECTIVE.md`, with the generalizable rules fed back into the
`tdd-discipline` skill.

## Docs & decisions

- ADR **0026** amended in place (the reconciler gains a conditional, provenance-gated overwrite,
  scoped to explicit updates); ADR **0025** cross-noted.
- `update-engine` skill (EN + `templates/fr`) and `SETUP.md` §10 realigned — the load-bearing claim
  "any engine skill you already have is never touched" was true yesterday and is a lie today.
- Plan: `maintainers/plans/prospective/engine-managed-file-merge-strategy.md` → §"Increment 2.5"
  (ROADMAP Gate 2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
