### PR TITLE
v4.6.0 — The One Where It Asks Which One You Mean

### DIFF
--- a/.claude/skills/prepare-1-1/SKILL.md
+++ b/.claude/skills/prepare-1-1/SKILL.md
@@ -60,6 +60,7 @@ Read them there. What makes a 1-1 prep the **worst** place to break them:
 - **Reconcile first.** Does anything you retrieved contradict what you are about to write? This skill
   produced the field defect that proves it: it announced a role change as *"unconfirmed"* while the
   vault's own `people/` note recorded it **confirmed two months earlier**.
+
 Markers are mandatory here too: ✅ observed and quoted · 🟡 inferred · 🔴 unverified negative or
 behavioural — and 🔴 is **never** safe to say out loud in the meeting.
 

--- a/.claude/skills/prepare-1-1/SKILL.md
+++ b/.claude/skills/prepare-1-1/SKILL.md
@@ -139,7 +139,7 @@ of completion, **update** the `updated:` date. Append-only on facts already reco
 - Do not make things up; flag a partial or low-quality source.
 - No empty section — omit it (except "KPI review" and "Recurring focus areas" in case B, to keep
   as a reminder even when empty, since these are the sections you must make your own).
-- Never a bare URL: `[text](url)`. Backlinks `[[people/firstname-lastname]]` (never a first name alone).
+- Never a bare URL: `[text](url)`. Backlinks `[[people/firstname-lastname]]` — no full name, no link: the name stays plain text.
 
 ## Refining this skill (that's the point of a meta skill)
 The structure above is a **starting point**. Make it yours: replace the example KPIs with

--- a/.claude/skills/prepare-1-1/SKILL.md
+++ b/.claude/skills/prepare-1-1/SKILL.md
@@ -60,12 +60,18 @@ Read them there. What makes a 1-1 prep the **worst** place to break them:
 - **Reconcile first.** Does anything you retrieved contradict what you are about to write? This skill
   produced the field defect that proves it: it announced a role change as *"unconfirmed"* while the
   vault's own `people/` note recorded it **confirmed two months earlier**.
-- **The vault outranks the delta on anything about a person.** Read `vault/people/<name>.md` before
-  asserting who someone is, what their title is, or what they owe you. A bare first name stays a bare
-  first name.
-
 Markers are mandatory here too: ✅ observed and quoted · 🟡 inferred · 🔴 unverified negative or
 behavioural — and 🔴 is **never** safe to say out loud in the meeting.
+
+## Identity discipline
+
+**Same arrangement, same reason — [`sync-sources` § Identity discipline](../sync-sources/SKILL.md#identity-discipline)
+holds the rules; this skill obeys them.** Resolve against the vault before writing a person, never
+invent the missing half of a name, and ask the vault before calling anything new. Read them there.
+
+A 1-1 prep is where getting this wrong costs the most: every person in the file is **one of the two
+people in the room**. Getting their surname, their title or their reporting line wrong is not a
+broken backlink here — it is said to their face, or to their manager's.
 
 ## Step 2 — Writing the briefing
 

--- a/.claude/skills/sync-sources/SKILL.md
+++ b/.claude/skills/sync-sources/SKILL.md
@@ -112,6 +112,19 @@ one. See "Identity discipline" just below: the name stays plain text. This secti
    read-time half is what makes the block worth writing: when a bare first name matches several
    cards and nothing in the source tells them apart, that name is **unresolved** — rule 2 applies
    (plain text, no link). Never resolve to the nearest one, and never to the one you saw last.
+6. **Say how sure you are.** Conformant is not true. The builder hands every card the same clean
+   frontmatter and the same green `/lint`, so a name read off an org chart and a name inferred from a
+   nickname come out looking identical — and the vault then reads both as its own answer to who
+   exists. So a `people/` card carries a **confidence block**: what this identity rests on, in the
+   scale the claim discipline already uses below (✅ observed · 🟡 derived or probable · 🔴 unverified),
+   never a second one. The builder enforces it: `scripts/file-back-note.mjs` refuses a new person card
+   until the spec carries `confidence` — a level and the **basis** it rests on (the source, its date,
+   the card it matched). Answer it honestly rather than reaching for the level that unblocks the
+   write: `unverified`, written down, costs nothing and is exactly what the next pass needs to know.
+   And the read-time half, which is what makes the block worth writing: a card marked 🟡 or 🔴 is a
+   **lead, not the vault's answer** — re-verify it before resolving anything against it, and never
+   let it become established merely because it has been written down for a while. That is the claim
+   discipline's *"yesterday's caveat is a debt"*, applied to the vault's own cards.
 
 ## Claim discipline
 

--- a/.claude/skills/sync-sources/SKILL.md
+++ b/.claude/skills/sync-sources/SKILL.md
@@ -95,6 +95,13 @@ one. See "Identity discipline" just below: the name stays plain text. This secti
    become CTO Visma France (unconfirmed)"* while `people/hossam-laanait.md` already said *"CTO Visma
    France (confirmed 04/06)"* — a dated record downgraded into a rumour. The vault's answer wins;
    if you contradict it, say so and say on what.
+4. **A link is not a person.** Never create a `people/` card merely to satisfy an incoming
+   `[[people/…]]` link. A dangling link is a defect of the *link*: repair it where it was written —
+   fix the spelling, point it at the card that does exist, or drop it. Creating the target instead
+   promotes a mis-resolution into the vault's own answer to *who exists*, and the next resolution
+   then resolves against it. `people/stephanie-music.md` was born exactly that way, from one
+   mis-resolved link; that name occurs once in the whole vault — in its own title. A card is written
+   when someone confirms the person, never to make a link report go green.
 
 ## Claim discipline
 

--- a/.claude/skills/sync-sources/SKILL.md
+++ b/.claude/skills/sync-sources/SKILL.md
@@ -102,6 +102,16 @@ one. See "Identity discipline" just below: the name stays plain text. This secti
    then resolves against it. `people/stephanie-music.md` was born exactly that way, from one
    mis-resolved link; that name occurs once in the whole vault — in its own title. A card is written
    when someone confirms the person, never to make a link report go green.
+5. **Say which one.** A first name is rarely unique: the vault this discipline was written for held
+   three Romain, three Marie, two Karim, two Caroline and two Michael. So a `people/` card carries a
+   **homonymy block** — one line under the title saying what tells this person apart from everyone
+   the vault knows by that first name (their role, their organisation, and the other cards by name).
+   Without it the card resolves nothing; it moves the ambiguity one hop, into the vault. The builder
+   enforces it: `scripts/file-back-note.mjs` refuses a new person whose first name the vault already
+   holds unless the spec carries `distinguish`, and its refusal names the homonyms it found. The
+   read-time half is what makes the block worth writing: when a bare first name matches several
+   cards and nothing in the source tells them apart, that name is **unresolved** — rule 2 applies
+   (plain text, no link). Never resolve to the nearest one, and never to the one you saw last.
 
 ## Claim discipline
 

--- a/.claude/skills/sync-sources/SKILL.md
+++ b/.claude/skills/sync-sources/SKILL.md
@@ -66,9 +66,29 @@ main context = final synthesis (~3-5k tokens of input)
 ## People registry (backlinks)
 
 For consistent `[[people/firstname-lastname]]` backlinks (no broken links), the sub-agents
-rely on the cards in `vault/people/`. Rule: **kebab-case, no accents**
-(`[[people/jane-doe]]`). **Never a first name alone** (`[[people/jane]]` is forbidden). Create the
-backlinks even if the target page doesn't exist (*dangling links* OK); do not create the target pages.
+rely on the cards in `vault/people/`. Shape of a link, when you have a full name: **kebab-case, no
+accents** (`[[people/jane-doe]]`). The backlink may point at a page that doesn't exist yet
+(*dangling links* OK); do not create the target pages.
+
+**When you only have a first name, you have no link to write** — not a shortened one, not a completed
+one. See "Identity discipline" just below: the name stays plain text. This section describes the
+*shape* of a link once the person is resolved; it never asks you to produce a full name you don't have.
+
+## Identity discipline
+
+> **Read the vault before you write about the people in it.** A briefing once turned the source's
+> *"Jérémy (front Candor)"* into *"Jérémy Hinard"* — a surname that exists nowhere but in that note.
+> The next resolution then resolves against the fabrication.
+
+1. **Resolve before you write.** Before naming a person in a note, read what the vault already says
+   about them: the `people/` cards (the active universe's **and** the root's cross-cutting ones) and
+   the organisation notes. The vault outranks both your memory of this session and the source's
+   shorthand.
+2. **Never invent the missing half of an identity.** A first name with no surname **stays a first
+   name**: write it as plain text, never as `[[people/…]]`, and never complete it with a surname the
+   source did not give you. *"Jérémy (front Candor)"* is written *"Jérémy (front Candor)"*. Losing a
+   backlink costs a click; a fabricated identity is permanent, gets indexed, and becomes what the
+   next resolution resolves against.
 
 ## Claim discipline
 
@@ -211,7 +231,7 @@ RULES:
 - A bare first name stays a bare first name. Never resolve it into a full identity — that is a
   claim about who someone IS, and it has already attributed a resignation to the wrong person.
 - Create the backlinks even if the target page doesn't exist.
-- Backlinks via vault/people/ (kebab-case no accents, never a first name alone).
+- Backlinks via vault/people/ (kebab-case, no accents). No full name, no link: the name stays plain text.
 - NEVER a shell (python3 -c, node -e, awk, sed, jq, grep, cat…) to read/load/split the
   content: if you must re-read a file (vault or offloaded result .../tool-results/...), use
   the Read tool; splitting and summarizing are done by reasoning, not on the command line.
@@ -263,7 +283,7 @@ NEGATIVE CLAIMS:
 
 RULES:
 - Ignore pure conversational noise (hello/thanks/emoji) and bots/notifications.
-- Backlinks via vault/people/ (never a first name alone).
+- Backlinks via vault/people/ (kebab-case, no accents). No full name, no link: the name stays plain text.
 - NEVER a shell (python3 -c, node -e, awk, sed, jq, grep, cat…) to read/load/split the
   content: if you must re-read a file (vault or offloaded result .../tool-results/...), use
   the Read tool; splitting and summarizing are done by reasoning, not on the command line.

--- a/.claude/skills/sync-sources/SKILL.md
+++ b/.claude/skills/sync-sources/SKILL.md
@@ -89,6 +89,12 @@ one. See "Identity discipline" just below: the name stays plain text. This secti
    source did not give you. *"Jérémy (front Candor)"* is written *"Jérémy (front Candor)"*. Losing a
    backlink costs a click; a fabricated identity is permanent, gets indexed, and becomes what the
    next resolution resolves against.
+3. **Ask the vault before you call anything new.** A fact is only *new* relative to what the vault
+   already holds, so run a `search_vault` on it before presenting it as news — and read what comes
+   back. A briefing once republished a two-month-old fact as a scoop, and wrote *"Hossam, who would
+   become CTO Visma France (unconfirmed)"* while `people/hossam-laanait.md` already said *"CTO Visma
+   France (confirmed 04/06)"* — a dated record downgraded into a rumour. The vault's answer wins;
+   if you contradict it, say so and say on what.
 
 ## Claim discipline
 
@@ -325,12 +331,17 @@ signal. This is also where we decide whether the delta **amends the answer in pr
 
 **Reconcile before writing a single line** (see *Claim discipline* above). The returns are a corpus
 to be made internally consistent, **not** a bag of quotes to support a synthesis you have already
-decided on. Two passes, both cheap:
+decided on. Three passes, all cheap:
 
 1. **Does anything I retrieved contradict what I am about to assert?** A contradiction in your own
    material outranks the claim, always.
 2. **Every 🔴 line either gets verified now, or is reworded as an open question.** A 🔴 that reaches
    the briefing unchanged is the one the owner pastes into a channel.
+3. **Anything I am about to present as new, and every person I am about to name, gets a
+   `search_vault` first.** You are the only step that holds both the delta and the vault — the
+   sub-agents read external sources and never see it. What comes back outranks the delta's framing
+   (see *Identity discipline* above): it is how a two-month-old fact stops being republished as a
+   scoop, and how a *"(confirmed 04/06)"* card stops being downgraded to *"(unconfirmed)"*.
 
 A sub-agent that reported it could not see reply counts has told you its silence is **unmeasured** —
 carry that through to the briefing rather than rounding it to "nothing happened".

--- a/CLAUDE.engine.md
+++ b/CLAUDE.engine.md
@@ -258,6 +258,23 @@ The main session's context is a **scarce, high-quality resource**. A large conte
 - **Never rebuild a permalink by hand** from an identifier + timestamp (often wrong): reuse the link the tool hands you as-is.
 - **Qualify source reliability**: verbatim (transcript, raw message) > human synthesis > AI synthesis. Flag when you interpret rather than report.
 
+### Identity discipline — read the vault before you write about the people in it
+
+A name you write into the vault does not fade like a guess in a conversation: it becomes the record
+the **next** resolution resolves against. A briefing turned a source's *"Jérémy (front Candor)"* into
+*"Jérémy Hinard"* — a surname that exists nowhere but in that note, and is now indexed.
+
+- **Resolve before you write.** Before naming a person in a note, read what the vault already says
+  about them: the `people/` cards (the active universe's **and** the root's cross-cutting ones) and
+  the organisation notes. The vault outranks both your memory of this session and the source's
+  shorthand.
+- **Never invent the missing half of an identity.** A first name with no surname **stays a first
+  name**: plain text, never `[[people/…]]`, never completed with a surname the source did not give
+  you. Losing a backlink costs a click; a fabricated identity is permanent.
+- **Ask the vault before you call anything new.** A fact is only *new* relative to what the vault
+  already holds, so run a `search_vault` on it before presenting it as news. A card reading *"CTO
+  Visma France (confirmed 04/06)"* was republished as *"(unconfirmed)"* because nobody asked.
+
 ### Claim discipline — the silence you report is the dangerous part
 
 A search returns what is **relevant**, never what is **complete**. So when nothing comes back, that

--- a/CLAUDE.engine.md
+++ b/CLAUDE.engine.md
@@ -283,6 +283,15 @@ the **next** resolution resolves against. A briefing turned a source's *"Jérém
   refuses a person whose first name the vault already holds unless the spec says `distinguish`. And
   when a bare first name matches several cards with nothing to tell them apart, it is **unresolved**:
   plain text, no link.
+- **Say how sure you are.** Conformant is not true: the builder gives every card the same clean
+  frontmatter and the same green `/lint`, so a name read off an org chart and a name inferred from a
+  nickname come out identical. A `people/` card therefore carries a confidence block — what the
+  identity rests on, in the claim discipline's own scale below (✅ observed · 🟡 derived or probable ·
+  🔴 unverified), never a second one; the builder refuses a new person card until the spec carries
+  `confidence` (a level **and** its basis). Answer honestly rather than picking the level that
+  unblocks the write. A card marked 🟡 or 🔴 is a lead, not the vault's answer: re-verify it before
+  resolving anything against it, and never let it become established just for having been written
+  down a while ago.
 
 ### Claim discipline — the silence you report is the dangerous part
 

--- a/CLAUDE.engine.md
+++ b/CLAUDE.engine.md
@@ -274,6 +274,9 @@ the **next** resolution resolves against. A briefing turned a source's *"Jérém
 - **Ask the vault before you call anything new.** A fact is only *new* relative to what the vault
   already holds, so run a `search_vault` on it before presenting it as news. A card reading *"CTO
   Visma France (confirmed 04/06)"* was republished as *"(unconfirmed)"* because nobody asked.
+- **A link is not a person.** Never create a `people/` card merely to satisfy an incoming
+  `[[people/…]]` link: a dangling link is a defect of the link, so repair it where it was written or
+  drop it. Creating the target turns a mis-resolution into the vault's own answer to *who exists*.
 
 ### Claim discipline — the silence you report is the dangerous part
 

--- a/CLAUDE.engine.md
+++ b/CLAUDE.engine.md
@@ -277,6 +277,12 @@ the **next** resolution resolves against. A briefing turned a source's *"Jérém
 - **A link is not a person.** Never create a `people/` card merely to satisfy an incoming
   `[[people/…]]` link: a dangling link is a defect of the link, so repair it where it was written or
   drop it. Creating the target turns a mis-resolution into the vault's own answer to *who exists*.
+- **Say which one.** A first name is rarely unique (one real vault: three Romain, three Marie, two
+  Karim). A `people/` card therefore carries a homonymy block under its title — role, organisation,
+  and the other cards by name — or it moves the ambiguity instead of resolving it; the builder
+  refuses a person whose first name the vault already holds unless the spec says `distinguish`. And
+  when a bare first name matches several cards with nothing to tell them apart, it is **unresolved**:
+  plain text, no link.
 
 ### Claim discipline — the silence you report is the dangerous part
 

--- a/EN-QUOI-C-EST-DIFFERENT.md
+++ b/EN-QUOI-C-EST-DIFFERENT.md
@@ -34,6 +34,7 @@ Concretely, hole by hole:
 | No automatic persistence | Your answers/notes are **never saved**; everything is lost | **Auto-commit hook** (+ *opt-in* push) |
 | No indexing | Search **makes things up** instead of searching your notes | Automatic **incremental reindexing** of the RAG |
 | A note whose header the indexer can't read | The note is **never indexed** — invisible to search — while the counter reads *"pending"*, as if it were on its way | **Refused at write time**, by the engine's own parser, + a **vault ↔ index crosscheck** that names any note the two disagree about |
+| A colleague mentioned by first name only | The model **supplies the surname** it doesn't have, and that invented identity is indexed like any fact — then quoted back to you as one | The name is **resolved against your notes before anything is written**; unresolved, it stays plain text; a card says **which** homonym it is, and how sure that identity is |
 | Conversation not "rooted" in the brain | Mute hooks, out-of-vault answers — *and it seems to work* | Onboarding that **forces opening in the right place** + `pwd` check |
 | `node` installed via nvm, invisible to GUI hooks | Auto-commit **silently broken** | **`run-node`** wrapper that re-resolves the toolchain on every run |
 | Install on a bare machine | Half-working **"Frankenstein"** state, undiagnosable | **"Fail-loud" verification** at install — proves it or fails plainly |
@@ -139,7 +140,8 @@ by using it: your notes, your rules (`CLAUDE.md`), your skills.
    not findable outside the vault): if the right answer comes out, it means the brain genuinely queried
    **your** data and not the Internet. And when a search comes back empty, it tells you **"I found
    nothing"** — never *"nobody decided"*: a silence it has not verified is reported as a silence, not
-   promoted into a fact.
+   promoted into a fact. The same rule applies to **people**: a first name it cannot resolve against
+   your notes stays a first name, never a surname it filled in for you.
 
 And a rare stance: **safe by construction.** The brain **takes no action** on your
 tools — it **reads and answers**, period. Nothing goes out in your name. (Action capabilities can be

--- a/README.md
+++ b/README.md
@@ -340,6 +340,10 @@ tested and fail-loud**. The through-line — **fail loudly rather than pretend**
 - **Silence is reported as silence** — when a search comes back empty, your brain says *"I found nothing,
   here is where I looked"*, instead of turning it into *"nobody decided"*. What it observed and what it
   inferred are told apart, on the page, every time.
+- **It never invents a colleague** — before writing about someone, it looks them up in *your* notes. A
+  first name it can't resolve stays plain text instead of becoming a page for a person who doesn't exist;
+  when your notes hold three Romains, the page says **which** one; and a name it worked out rather than
+  read is written as *probable*, not as fact.
 - **The index is cross-checked against your vault** — the subtler version of the same lie is a note that
   keeps *answering* from the content it was last indexed with. A crosscheck names every note the two
   disagree about, on demand (`verify-index`) and as a session check. *(ADR 0030)*
@@ -364,7 +368,8 @@ tested and fail-loud**. The through-line — **fail loudly rather than pretend**
   `/consolidate` and `/file-back` skills watch the wiki for decay — dangling `[[links]]`, orphan notes,
   stale entity pages, raw captures never filed — and **propose** fixes you confirm (never a silent
   rewrite). Every write goes through a **deterministic, taxonomy-conformant builder**, so a fix can't
-  re-introduce the very defects `/lint` reports. Self-healing at the *content* layer.
+  re-introduce the very defects `/lint` reports — and repairing a broken link is no longer allowed to
+  invent the person it points at. Self-healing at the *content* layer.
 - **A note it couldn't index is refused, not written.** Before writing into your vault, your brain checks
   the note's header with the **engine's own parser** — the very one that indexes it. A note that parser
   would reject is never written at all, instead of being born invisible to search while the counter says
@@ -395,7 +400,7 @@ tested and fail-loud**. The through-line — **fail loudly rather than pretend**
 - **TDD baby-steps**, **green-only commits** (never commit red); **outside-in diamond TDD** for the harness.
 - **Measured, not asserted** — an **eval-set** for retrieval quality (below) and **mutation testing**
   (Stryker) scoring the *tests themselves* **90–97%** across the three engine packages.
-- **ADR-governed** — 34 decisions, each with an explicit `Scope:` and a `Crux`.
+- **ADR-governed** — 37 decisions, each with an explicit `Scope:` and a `Crux`.
 - **QA'd like a product** — the **upgrade/migration path is a release gate** (Windows parity · reconciler ·
   mutation score), so a new engine is proven on existing brains before it ships.
 
@@ -408,9 +413,11 @@ tested and fail-loud**. The through-line — **fail loudly rather than pretend**
   leaderboards. The local **"Gemma inside"** embedder scores **90%**, equal to Ollama and **above the
   Gemini cloud baseline (80%)**: going fully local is **no quality trade-off**.
 - **Test-suite strength**: a **mutation-testing** run (Stryker) scores **90–97%** across the three engine
-  packages — rag **90.4%**, local-mirror **95.6%**, harness scripts **97.3%** — i.e. the share of
-  injected faults the tests actually catch (line coverage can't tell you that). *(pinned to v3.6.2; detail
-  in [`maintainers/mutation/RESULTS.md`](maintainers/mutation/RESULTS.md))*
+  packages — rag **90.4%**, local-mirror **90.4%**, harness scripts **97.3%** — i.e. the share of
+  injected faults the tests actually catch (line coverage can't tell you that). Each figure is that
+  package's last **package-wide** audit; on top of it, **every release re-runs the files it changed**.
+  *(detail, per-release runs and the named debt in
+  [`maintainers/mutation/RESULTS.md`](maintainers/mutation/RESULTS.md))*
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -592,6 +592,16 @@ tailored: it only writes files that `engine-manifest.json` declares Engine-owned
 > (`scripts/update-engine.mjs` + `scripts/lib/**`, both carried by every brain — so the updater can
 > even update **itself**).
 
+### Which version am I on?
+
+Your brain **says so at the start of every session**: a `⚙️ Kenjaku engine v4.6.0` segment in the
+opening banner, on the command line as well as in the Code tab of Claude Desktop. It reads the tag your
+engine was installed or last updated from (`source.ref` in `engine-manifest.json`), so it follows your
+updates instead of freezing at install day. Two silences are deliberate: when the manifest carries no
+usable tag the segment simply **doesn't appear** (rather than showing a number that isn't a Kenjaku
+release), and when a restart is pending the restart nudge takes the floor — until you restart, the
+version you'd read isn't the one answering you. `/rag` repeats the engine version at any time.
+
 ### To trigger it — just ask, in plain conversation
 
 > *"Update your engine."* · *"Is there a newer version of your engine?"* · *"Upgrade the brain's

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -4,8 +4,8 @@
   "engineVersion": {
     "rag": "1.3.0",
     "local-mirror": "0.3.0",
-    "constitutionTemplate": "1.1.0",
-    "scripts": "1.10.0"
+    "constitutionTemplate": "1.2.0",
+    "scripts": "1.11.0"
   },
   "indexSchemaVersion": 2,
   "regimes": {

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -116,6 +116,11 @@ echo '{"type":"topic","title":"Capacity Management","tags":["capacity"],"body":"
 ```
 - Exit **0** = written (prints `✓ Filed back: vault/<path>`); relay the path.
 - Exit **1** = refused (already exists) or invalid → it's a living page, go to 5b.
+- Exit **1** on a `person` whose **first name the vault already holds**: the card must say which one.
+  Add `distinguish` — their role, their organisation, and the homonym cards the message names — and
+  re-run. If the captures do not tell them apart, leave the page unwritten and say so: a card that
+  does not resolve the name only moves the ambiguity into the vault, where the next resolution
+  inherits it (the identity discipline linked above).
 
 ### 5b. Existing page (refresh) → pipe the dated section to the deterministic writer
 Filing never overwrites: a living page is REFRESHED by appending a dated section and bumping its

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -140,6 +140,10 @@ echo '{"path":"topics/capacity-management.md","section":"## 2026-07-17 — <what
   sits outside `vault/`, or **its frontmatter is already damaged** — in which case it names the
   duplicate key and touches nothing, because appending to an unreadable page hides the damage one
   refresh longer.
+- The same spec accepts `"confidence": {"level":…,"basis":…}` — how a person card whose identity was
+  only **probable** gets promoted once the captures actually confirm it. It rewrites the frontmatter
+  field and the card's visible confidence block together, so the page never asserts two different
+  things about itself. Use it when a refresh is what confirmed the name; never hand-edit that key.
 
 > ⚠️ **Why a script and not prose (F12).** Freehand, *"bump the page's `updated:`"* once became
 > *"add a second `updated:`"* on a real page. Two keys is invalid YAML → the indexer could no longer

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -50,6 +50,14 @@ Do not consolidate everything blindly. Prioritise by signal: a name cited by man
 page; a one-off mention or an obvious typo is not (that is a `/lint` dangling-link fix, not a page).
 Pick a handful; tell the user what you're leaving for later.
 
+⚠️ **For a `person` candidate, the count is a priority signal, not evidence that the person exists.**
+It measures how often a link was **written**, and a name invented once and then cited three times
+reads as signal. So resolve the identity first — against the vault's `people/` cards and the
+organisation notes, per the identity discipline in
+[`sync-sources`](../sync-sources/SKILL.md#identity-discipline) — and if the name cannot be resolved,
+say so and leave the page unwritten. A page created here becomes the vault's own answer to *who
+exists*, and every later resolution resolves against it.
+
 ### 3. Fan out — one read-only sub-agent per candidate (parallel, a single message)
 Reuse the `sync-sources` architecture: each sub-agent reads **only its candidate's source captures** and
 returns a compact draft (~500 tokens), so the raw text never floods the main context. Sub-agents are

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -121,6 +121,11 @@ echo '{"type":"topic","title":"Capacity Management","tags":["capacity"],"body":"
   re-run. If the captures do not tell them apart, leave the page unwritten and say so: a card that
   does not resolve the name only moves the ambiguity into the vault, where the next resolution
   inherits it (the identity discipline linked above).
+- Exit **1** on a `person` with no `confidence`: a person card must say what its identity rests on —
+  `{"level":"observed|probable|unverified","basis":"…"}`, the claim discipline's own scale. Consolidation
+  is where this bites hardest: a candidate surfaced by **mention count** has been counted, never
+  verified, so its honest level is rarely `observed`. Say `probable` or `unverified` and name the
+  captures it came from; never pick the level that unblocks the write.
 
 ### 5b. Existing page (refresh) → pipe the dated section to the deterministic writer
 Filing never overwrites: a living page is REFRESHED by appending a dated section and bumping its

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -142,8 +142,8 @@ echo '{"path":"topics/capacity-management.md","section":"## 2026-07-17 — <what
   refresh longer.
 - The same spec accepts `"confidence": {"level":…,"basis":…}` — how a person card whose identity was
   only **probable** gets promoted once the captures actually confirm it. It rewrites the frontmatter
-  field and the card's visible confidence block together, so the page never asserts two different
-  things about itself. Use it when a refresh is what confirmed the name; never hand-edit that key.
+  field and the card's visible confidence block together (writing that block for the first time on a
+  card that predates it), so the page never asserts two different things about itself. Use it when a refresh is what confirmed the name; never hand-edit that key.
 
 > ⚠️ **Why a script and not prose (F12).** Freehand, *"bump the page's `updated:`"* once became
 > *"add a second `updated:`"* on a real page. Two keys is invalid YAML → the indexer could no longer

--- a/engine-skills/consolidate/SKILL.md
+++ b/engine-skills/consolidate/SKILL.md
@@ -91,7 +91,7 @@ TASK:
 
 RULES:
 - Do NOT invent anything absent from the captures.
-- Backlinks kebab-case, no accents, never a first name alone.
+- Backlinks kebab-case, no accents. No full name, no link: the name stays plain text.
 - NEVER a shell (grep/cat/node -e/awk/sed/jq…) to read or split content — use the Read tool; summarise by reasoning.
 """
 )

--- a/engine-skills/file-back/SKILL.md
+++ b/engine-skills/file-back/SKILL.md
@@ -47,6 +47,13 @@ Pick, from the vault taxonomy (see the constitution, §"Note format"):
   unique — a card that does not say *which* Romain moves the ambiguity into the vault instead of
   resolving it, and the next resolution inherits it. See the identity discipline in
   [`sync-sources`](../sync-sources/SKILL.md#identity-discipline).
+- **confidence** (`person` — **required**, the builder refuses without it) → what this card's identity
+  actually rests on: `{"level":"observed|probable|unverified","basis":"…"}`. Same scale as the claim
+  discipline, deliberately: `observed` = you read the full name at a source you can cite, `probable` =
+  you resolved it from context, `unverified` = you could not confirm it. The `basis` says on what (the
+  source, its date, the card it matched). It becomes the card's confidence block and a frontmatter
+  field. Required rather than offered because a conformant card born of a guess is indistinguishable
+  from one born of a signed source, and the vault reads both as truth forever.
 
 ### 2. Propose (never write yet)
 Show the user, plainly: the **target path**, the **type/tags**, the **[[links]]**, and the **body** you
@@ -67,6 +74,9 @@ echo '{"type":"topic","title":"Capacity Management","tags":["capacity"],"body":"
   The message names the homonym cards it found. This is not a tool failure to work around: read those
   cards, and either say which one this is (add `distinguish`, re-run) or, if the name cannot be
   resolved, say so to the user and file nothing — never re-run with a surname you supplied.
+- **Exit 1**, fourth case: a `person` with no `confidence`. Answer it honestly rather than reaching for
+  the level that unblocks the write: `unverified` written down costs nothing, and is exactly what the
+  next resolution needs to know.
 
 ### 3b. Existing living page (person / topic) → append a dated section
 Filing back never overwrites. When the target already exists, **refine it additively**: append a dated

--- a/engine-skills/file-back/SKILL.md
+++ b/engine-skills/file-back/SKILL.md
@@ -91,6 +91,14 @@ section and bump its `updated:`. Keep it conformant, mirroring the builder's sha
 ```
 This edit is the brain's normal confirmed write (the auto-commit hook persists it).
 
+**Promoting a confidence marker.** When a card marked 🟡 or 🔴 is later confirmed, do **not** hand-edit
+its frontmatter (that is how a page ended up with two `updated:` keys and became unreadable). Pipe the
+new level to `/refresh-note`, which rewrites the field **and** the visible block together:
+```bash
+echo '{"path":"people/jane-doe.md","confidence":{"level":"observed","basis":"her own intro in #general, 2026-08-03."}}' \
+  | node scripts/refresh-note.mjs
+```
+
 ## Guardrails
 - **Propose first, write on yes.** This skill never files a note the user hasn't agreed to.
 - **Never overwrite.** New pages go through the builder (which refuses to clobber); existing living

--- a/engine-skills/file-back/SKILL.md
+++ b/engine-skills/file-back/SKILL.md
@@ -41,6 +41,12 @@ Pick, from the vault taxonomy (see the constitution, §"Note format"):
 - **body** → the distilled synthesis, in the user's language. Be concise and self-contained.
 - **links** → the existing notes this connects to, as `[[people/jane-doe]]`, `[[topics/rag]]` paths.
   Prefer targets that **already exist** (run `/lint` if unsure) so you don't create dangling links.
+- **distinguish** (`person` only) → what tells this person apart from everyone the vault already
+  knows by that first name: their role, their organisation, and the other cards by name. It becomes
+  the card's homonymy block, under the title. Give it whenever the first name is not obviously
+  unique — a card that does not say *which* Romain moves the ambiguity into the vault instead of
+  resolving it, and the next resolution inherits it. See the identity discipline in
+  [`sync-sources`](../sync-sources/SKILL.md#identity-discipline).
 
 ### 2. Propose (never write yet)
 Show the user, plainly: the **target path**, the **type/tags**, the **[[links]]**, and the **body** you
@@ -57,6 +63,10 @@ echo '{"type":"topic","title":"Capacity Management","tags":["capacity"],"body":"
 - Exit **0** = written (it prints `✓ Filed back: vault/<path>`); relay that path.
 - Exit **1** = refused (note already exists) or invalid spec; read the message verbatim — if it already
   exists, this is a *living page*, so go to 3b instead.
+- Exit **1**, third case: a `person` whose **first name the vault already holds** and no `distinguish`.
+  The message names the homonym cards it found. This is not a tool failure to work around: read those
+  cards, and either say which one this is (add `distinguish`, re-run) or, if the name cannot be
+  resolved, say so to the user and file nothing — never re-run with a surname you supplied.
 
 ### 3b. Existing living page (person / topic) → append a dated section
 Filing back never overwrites. When the target already exists, **refine it additively**: append a dated

--- a/engine-skills/file-back/SKILL.md
+++ b/engine-skills/file-back/SKILL.md
@@ -93,7 +93,8 @@ This edit is the brain's normal confirmed write (the auto-commit hook persists i
 
 **Promoting a confidence marker.** When a card marked 🟡 or 🔴 is later confirmed, do **not** hand-edit
 its frontmatter (that is how a page ended up with two `updated:` keys and became unreadable). Pipe the
-new level to `/refresh-note`, which rewrites the field **and** the visible block together:
+new level to `/refresh-note`, which rewrites the field **and** the visible block together — and writes
+that block for the first time on a card that predates it, in the builder's own slot:
 ```bash
 echo '{"path":"people/jane-doe.md","confidence":{"level":"observed","basis":"her own intro in #general, 2026-08-03."}}' \
   | node scripts/refresh-note.mjs

--- a/engine-skills/lint/SKILL.md
+++ b/engine-skills/lint/SKILL.md
@@ -45,8 +45,14 @@ node scripts/lint-vault.mjs
 ### 3. Propose fixes (never apply silently)
 Group the findings and, for the ones worth acting on, **suggest the concrete gesture** and ask
 before writing:
-- **Dangling** → fix the target spelling, or create the missing note (offer to synthesize it
-  from the vault, like `open-note` does), or remove the dead link.
+- **Dangling** → fix the target spelling, point the link at the note that does exist, or remove the
+  dead link. Creating the missing note is a fine outcome for a **topic** the vault meant to hold
+  (offer to synthesize it from the vault, like `open-note` does).
+  ⚠️ **Never for a `[[people/…]]` target.** A card created to satisfy an incoming link becomes the
+  vault's own answer to *who exists*, and every later resolution resolves against it — see the
+  identity discipline in [`sync-sources`](../sync-sources/SKILL.md#identity-discipline). Repair the
+  link where it was written, or leave it dangling and say why: a dangling link costs a click, a
+  fabricated person is permanent.
 - **Orphan** → propose where to weave it in: which existing note(s) should gain a `[[link]]` to
   it, or which entity/topic page it belongs under.
 - **Stale entity page** → offer to refresh it from the fresher notes that cite it (a Track-C

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -15,7 +15,7 @@
 | Package | Mutation score | As of | Detail |
 |---|---|---|---|
 | **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only. Not re-measured package-wide since; the [v4.4.0 targeted run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) over the 10 files that release changed reads **93.93 %**, with its two new files at **100 %**. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) over its 6 changed files reads **94.67 %**, with the file it creates at **100 %** |
-| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new). The [v4.6.0 run](#v460--the-vaults-identity-release-scripts-only--2026-08-03) measured the 7 files that release changed: **all seven end at 96 % or above, two at 100 %**, every remaining survivor a pre-listed equivalent |
+| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new). The [v4.6.0 run](#v460--the-vaults-identity-release-scripts-only--2026-08-03) measured the 7 files that release changed: **all seven end at 96 % or above, two at 100 %**, every remaining survivor a pre-listed equivalent. It then ran a **second pass after the review fixes** (those fixes changed production code, so the first numbers no longer covered it): 4 files re-measured, 3 of them at **96.88–100 %**, plus `lib/hooks-reconcile.mjs` — a file this release only grazes — at **78.69 %**, whose 24 remaining survivors are pre-existing and named rather than implied |
 | **local-mirror** | **90.44 %** | 2026-07-28 (v4.2.0) | [re-audit](#full-local-mirror-re-audit--2026-07-28-v420) — +336 mutants since the 95.63 % below (auto-refresh growth); this release's own survivors were found and killed before tagging. The two files v4.3.0 touched were re-measured [after the review fixes](#v430-after-the-review-fixes--2026-07-28): `markdown.ts` **100 %**, `local-mirror.ts` **96.86 %**. **v4.4.0 touches no `src/**` file here — the number carries over, deliberately not re-measured** |
 
 Pinned to the release that ships the hardened tests: **v3.4.2** (local-mirror pinned at 78.69 % there —
@@ -150,7 +150,7 @@ untouched. Eight production files under `scripts/`, measured one by one in two b
 hardened file re-measured**: a hardened-but-unmeasured file has an unknown score, which is the same
 silence this trilogy is about.
 
-| File | First run | At the tag | |
+| File | First run | After this pass | |
 |---|---|---|---|
 | `lib/doc-section.mjs` | **53.33 %** | **100 %** | the finding of this pass — see below; 14/14 killed |
 | `refresh-note.mjs` | 68.52 % | **96.30 %** | 2 survivors, both pre-listed equivalents |
@@ -162,8 +162,12 @@ silence this trilogy is about.
 | `session-status.mjs` | **not measured** | — | the named 0 % top-level tier (below) |
 
 **Every survivor left in the seven files is on the equivalence list written BEFORE the re-run** — which
-is what makes them equivalents rather than an excuse. Aggregates at the tag: **97.07 %** over batch 1's
-two files (239 mutants), **97.84 %** over batch 2's five (231 mutants).
+is what makes them equivalents rather than an excuse. Aggregates for this pass: **97.07 %** over batch
+1's two files (239 mutants), **97.84 %** over batch 2's five (231 mutants).
+
+⚠️ **Three of those numbers are NOT the ones at the tag** — `refresh-note.mjs`, `lib/note-refresh.mjs`
+and `lib/status-hook-output.mjs` were changed again by the review fixes and re-measured; see **the
+second pass** below, which is what the tag ships.
 
 **The finding: `lib/doc-section.mjs` had no test file at all.** It is the slicer that decides **what**
 every doc guard reads — the claim discipline's and the identity discipline's alike — and it was
@@ -209,10 +213,62 @@ it is a refactor of fleet-deployed session scripts, i.e. its own release. Same f
 the child-process tests, and what remains (`process.argv.slice(2)` → `process.argv`) is a true
 equivalent in both CLIs here, since both take their spec on **stdin** and ignore argv entirely.
 
+### The second pass — after the review fixes, because the first numbers no longer covered the code
+
+An independent review of the branch found six defects, all fixed before the tag ([the plan's Step
+12.5](../plans/prospective/field-findings-2026-08-02-action.md)). Those fixes **changed production
+code after the table above was measured**, so four files were re-measured rather than left publishing a
+score earned by earlier lines. That is the whole rule here: a number that predates the code it
+describes is the same silence this trilogy is about.
+
+| File | After the fixes | Treated | At the tag | |
+|---|---|---|---|---|
+| `refresh-note.mjs` | **96.30 %** | — | **96.30 %** | 2 survivors, both already on the equivalence list |
+| `lib/status-hook-output.mjs` | **100 %** | — | **100 %** | |
+| `lib/note-refresh.mjs` | 89.47 % | yes | **96.88 %** | 4 survivors, all equivalents (below) |
+| `lib/hooks-reconcile.mjs` | 77.05 % | yes | **78.69 %**, then the last two on the touched line killed | 24 survivors left, **all pre-existing** (below) |
+
+**`lib/note-refresh.mjs` — twelve of its fourteen survivors sat in the confidence-block insertion
+written the same day, and they all said one thing: only the tidy card was ever fed to it.** Four tests
+for the shapes a hand-edited Obsidian vault actually holds — a `# ` inside a sentence and no heading at
+all, a stub card that ends right after its title (where the walk steps off the end), a line of editor
+whitespace where a blank line is meant, and an indented quotation of someone else's homonymy block. The
+first went red, and the honest repair was to **delete the no-heading special case** rather than patch
+it: `findIndex` returns `-1`, so the walk starts at the top on its own and keeps the blank line the body
+opens with instead of doubling it. A second round then found the **second walk** — the one past the
+homonymy block — still carrying none of the assertions the first had earned; both of its boundary
+mutants were applied by hand to prove each new test kills one.
+
+**`lib/hooks-reconcile.mjs` is NOT this release's file**, and its 78.69 % is not a regression: the
+branch touches exactly one line in it (the `$`-expansion sweep). What the run did buy is the four
+survivors inside the **touched function**, and they are worth the entry:
+
+- **Nothing ever passed a `command` that is not a string**, so every mutant deleting the `typeof` guard
+  survived. `settings.json` is hand-edited by owners; a hook entry whose command is missing — or
+  written as a JSON array — is an ordinary shape, and without the guard it reaches `.replace` and
+  throws a TypeError at session start, on the path whose job is to REPAIR a brain.
+- **The fixture that matters is a non-string whose coercion LOOKS like the broken command.** With only
+  harmless non-strings, `typeof command !== "string"` and `!BROKEN.test(command)` agree on every input
+  and either term can be deleted with the suite green. That one value tells them apart, and it killed
+  the last two survivors (hand-applied, both confirmed).
+- **The `^` anchor was never observed either** — no test placed the broken prefix anywhere but at
+  position 0, and that anchor is what keeps the repair off a USER hook that merely mentions the engine
+  launcher further along.
+
+The remaining 24 survivors live elsewhere in that file (`learnNodePrefix`'s regex and its `?? []`
+defaults, `reconcileHooks`' append arithmetic), **predate this release and are untouched by it** —
+named here rather than swept in under a review fix, and rather than left implied by a package aggregate.
+
+**Equivalents from this second pass, added to the list above:** the `CONFIDENCE_BLOCK` regex `$` tail
+(same class as the two already recorded — redundant without the `s` flag), and the two boundary mutants
+on the homonymy line's own `if`, where `at === lines.length` makes `.test(undefined)` coerce to the
+string `"undefined"` and miss either way.
+
 **Reproduce**: same recipe as v4.5.0 below (worktree at `/Users/tpierrain/Dev/kenjaku-mut-v460`, the
-`rag/node_modules` symlink **verified** before starting — 31 pass / 0 skipped — one or two files per
-run). Logs: `reports/v460-scripts-batch1.log`, `…-batch2.log`, `…-batch1-recheck.log`,
-`…-batch2-recheck.log`.
+`rag/node_modules` symlink **verified** before starting — 31 pass / 0 skipped for the first pass, 22 for
+the second — one or two files per run). Logs: `reports/v460-scripts-batch1.log`, `…-batch2.log`,
+`…-batch1-recheck.log`, `…-batch2-recheck.log`, and for the second pass
+`…-review-fixes-batch1.log`, `…-batch2.log`, `…-batch3.log`, `v460-hooks-reconcile-recheck.log`.
 
 ---
 

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -15,7 +15,7 @@
 | Package | Mutation score | As of | Detail |
 |---|---|---|---|
 | **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only. Not re-measured package-wide since; the [v4.4.0 targeted run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) over the 10 files that release changed reads **93.93 %**, with its two new files at **100 %**. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) over its 6 changed files reads **94.67 %**, with the file it creates at **100 %** |
-| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new) |
+| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new). The [v4.6.0 run](#v460--the-vaults-identity-release-scripts-only--2026-08-03) measured the 7 files that release changed: **all seven end at 96 % or above, two at 100 %**, every remaining survivor a pre-listed equivalent |
 | **local-mirror** | **90.44 %** | 2026-07-28 (v4.2.0) | [re-audit](#full-local-mirror-re-audit--2026-07-28-v420) — +336 mutants since the 95.63 % below (auto-refresh growth); this release's own survivors were found and killed before tagging. The two files v4.3.0 touched were re-measured [after the review fixes](#v430-after-the-review-fixes--2026-07-28): `markdown.ts` **100 %**, `local-mirror.ts` **96.86 %**. **v4.4.0 touches no `src/**` file here — the number carries over, deliberately not re-measured** |
 
 Pinned to the release that ships the hardened tests: **v3.4.2** (local-mirror pinned at 78.69 % there —
@@ -138,6 +138,81 @@ survivors there are **documented equivalent mutants** (unkillable without touchi
 "effective 100 %" on non-equivalents. The lowest never-hardened tiers, the natural next "B5" targets,
 are rag's **embedders** (~82 %) and `search-degradation` / `reindex-scheduler` / `index-freshness`, plus
 local-mirror's `fs-state-store` and `content-hash`.
+
+---
+
+## v4.6.0 — the vault's-identity release (`scripts` only) — 2026-08-03
+
+**Scope decided on the diff** (`main...release/v4.6.0`), the targeted run §5ter prescribes before a tag.
+**No `rag/src` or `local-mirror/src` file changed at all** — this release ships prose carriers (skills,
+constitutions) and harness scripts — so those two packages did not run, and their numbers carry over
+untouched. Eight production files under `scripts/`, measured one by one in two batches, then **every
+hardened file re-measured**: a hardened-but-unmeasured file has an unknown score, which is the same
+silence this trilogy is about.
+
+| File | First run | At the tag | |
+|---|---|---|---|
+| `lib/doc-section.mjs` | **53.33 %** | **100 %** | the finding of this pass — see below; 14/14 killed |
+| `refresh-note.mjs` | 68.52 % | **96.30 %** | 2 survivors, both pre-listed equivalents |
+| `file-back-note.mjs` | 72.81 % | **96.49 %** | 4 survivors, all pre-listed equivalents |
+| `lib/status-hook-output.mjs` | 92.86 % | **100 %** | |
+| `lib/note-refresh.mjs` | 92.31 % | **97.80 %** | 2 survivors, both pre-listed equivalents |
+| `lib/engine-version.mjs` | 95.24 % | **97.62 %** | 1 survivor, a pre-listed equivalent |
+| `lib/filed-note.mjs` | 96.00 % | **97.60 %** | 3 survivors, all pre-listed equivalents |
+| `session-status.mjs` | **not measured** | — | the named 0 % top-level tier (below) |
+
+**Every survivor left in the seven files is on the equivalence list written BEFORE the re-run** — which
+is what makes them equivalents rather than an excuse. Aggregates at the tag: **97.07 %** over batch 1's
+two files (239 mutants), **97.84 %** over batch 2's five (231 mutants).
+
+**The finding: `lib/doc-section.mjs` had no test file at all.** It is the slicer that decides **what**
+every doc guard reads — the claim discipline's and the identity discipline's alike — and it was
+exercised only *through* those guards, against real documents where a degraded slice still happened to
+contain the words they look for. Both "return the whole document" mutants survived. A slicer that
+quietly returns everything turns every sliced guard back into the **flat search it was extracted to
+replace**, and the failure that motivated the extraction (a rule passing on prose that was already
+there for other reasons) comes back with the suite green. This is §5quater one level up: not a checker
+parsing differently from the engine, but a checker reading a different **span** than it claims. It has
+its own tests now — exact slices asserted whole — and **14/14 mutants are dead**.
+
+**The second family is the one v4.5.0 met four times: every test injects its own deps, so the REAL
+ones are observed by nothing.** Both CLIs here (`file-back-note.mjs`, `refresh-note.mjs`) could have
+read no stdin, created no folders and logged nothing with the suite green. Each now runs as a **real
+child process** against a throwaway brain — the only test that reaches the stdin read, the recursive
+`mkdir`, the existence check, the exit code and the entrypoint guard at once.
+
+**And the refusals were asserted by fragments, while that text IS the product here**: the sentence
+saying what a *basis* is, the one saying a card that does not say WHICH one only moves the ambiguity,
+and the one naming what to do instead of overwriting could each vanish with every `assert.match` still
+green. Asserted whole now.
+
+**Equivalents, established by hand (applied, run, reverted) and NOT to be chased:**
+
+- `readFileSync(0, "")` in both CLIs — returns a Buffer, `JSON.parse` coerces it to the same string.
+  Already recorded at v4.5.0 for the guard hook; confirmed identical here.
+- The slug's `^-+|-+$` quantifiers — the preceding `[^a-z0-9]+` collapses any run into **one** hyphen,
+  so two leading hyphens are unreachable (verified on six titles).
+- `/\.md$/` unanchored in `firstNameSegment` — the first name is the first hyphen segment, and no vault
+  path carries `.md` inside it.
+- `split(/\s+/)` → `/\s/` on a **trimmed** title — index 0 is the same either way once leading
+  whitespace is gone.
+- `readFileSync(p, "utf-8")` → `""` on the universe pointer — equivalent *because* the reader was
+  hardened to accept a Buffer (`String(...)`), which is the defence, not an accident.
+- `typeof manifest !== "object"` → `false` — a truthy non-object yields `null` through both paths.
+- Two regex tails where `$` is redundant without the `s` flag (`.*$`, `([\s\S]*)$`).
+
+**The honest bound, unchanged and inherited.** `session-status.mjs` is a top-level script that runs on
+import, so no test can observe it: it stays at **0 %** and was not measured here. The logic it displays
+is covered — that is precisely why `lib/status-hook-output.mjs` exists — but the wiring is not. Closing
+it is a refactor of fleet-deployed session scripts, i.e. its own release. Same for the shared
+`runAsEntrypoint(meta, argv, fn)` named at v4.5.0: two of its three mutants now die per file thanks to
+the child-process tests, and what remains (`process.argv.slice(2)` → `process.argv`) is a true
+equivalent in both CLIs here, since both take their spec on **stdin** and ignore argv entirely.
+
+**Reproduce**: same recipe as v4.5.0 below (worktree at `/Users/tpierrain/Dev/kenjaku-mut-v460`, the
+`rag/node_modules` symlink **verified** before starting — 31 pass / 0 skipped — one or two files per
+run). Logs: `reports/v460-scripts-batch1.log`, `…-batch2.log`, `…-batch1-recheck.log`,
+`…-batch2-recheck.log`.
 
 ---
 

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -559,10 +559,24 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME AT STEP 12.5 — THE RELEASE IS ASSEMBLED, CI IS 7/7, AND IT IS WAITING ON ONE THING:
-> THE OWNER'S `/code-review ultra 55`.** They chose to run it (2026-08-03); I cannot trigger it.
-> **On resume: if the review has landed, treat its findings; if not, ask whether it ran — do not
-> re-do the release work, and do not re-ask the title question.**
+> **⏭️ RESUME HERE — THE REVIEW HAS LANDED, AND THE NEXT ACT IS TO FIX ITS SIX FINDINGS, TDD, IN
+> ORDER ①→⑥.** They are listed with their verification, their fix and their order in Step 12.5's
+> checkbox *"The six findings, in the order I recommend treating them"* — **read them there, they are
+> not restated here, and do NOT re-run the review or re-verify them: each was already re-run against
+> the code, and the traversal was reproduced.** Nothing is started on disk; the branch is at
+> `335817b`, green and pushed.
+>
+> **✅ DECIDED (2026-08-04, by the owner), two calls — do not re-open either:**
+> - **The traversal (③) ships INSIDE v4.6.0**, not as a follow-up. It is pre-existing, but the branch
+>   touches that very function and widens what an escaped write can carry.
+> - **All six are treated in TDD**, red first. For ① and ② that means **two reds each**: the defect
+>   itself, *and* the guard that should have caught it and did not (`identity-discipline.test.mjs`'s
+>   `SKILLS` array never iterates `consolidate`; the F5 audit filters on the literal
+>   `"additionalContext:"` and so cannot see an assignment). Fixing the defect without fixing its
+>   guard would leave this release repeating, a fourth time, the failure it is named after.
+>
+> **Then, and only then, the release tail** (title into the note H1 + PR title, undraft, merge, tag,
+> publish, archive) — it is the last checkbox of Step 12.5 and is unchanged by the review.
 >
 > Done and pushed _(2026-08-03, `e57fc6f` → `2f16a1b`)_: the mutation pass (7 files, measured, treated
 > and **re-measured** — all ≥ 96 %, two at 100 %, every survivor a pre-listed equivalent), the version
@@ -804,7 +818,10 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         the body → the `replace` does nothing while the frontmatter field moves), but it needs a card
         that lacks the block, and no verdict backs it. **Left open, not silently dropped** — settle it
         with a test before claiming either way.
-  - [ ] **The six findings, in the order I recommend treating them.** Fix each one TDD, red first.
+  - [ ] **The six findings, in the order to treat them. ✅ ORDER AND SCOPE APPROVED BY THE OWNER
+        (2026-08-04): all six, TDD, red first, and ③ ships in THIS release.** ① and ② each need **two**
+        reds: the defect, and the guard that missed it. Tick each box with its commit as it lands, so a
+        `/clear` mid-sequence resumes at the first unticked one.
     - [ ] **① `engine-skills/consolidate/SKILL.md:94` — the other write-door still carries the
           wording that MANUFACTURED F7.** Verified: the file still reads *"Backlinks kebab-case, no
           accents, never a first name alone."*, inside a fenced `Agent(prompt=…)` block handed

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -493,9 +493,22 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > the room, so a wrong surname is said to their face. 26 assertions, suite green (1261 pass, 1 skipped
 > Windows-only).
 >
-> **⏭️ RESUME AT STEP 12.2 (F6)** — never create a `people/` note merely to satisfy an incoming link.
-> Nothing is half-written on disk; no decision is pending. Then 12.3 (homonymy), 12.4 (confidence
-> block), 12.5 (release).
+> **✅ Step 12.2 done — F6 IS COMPLETE** _(2026-08-03 · `de2e658`)_. The rule ships on **three**
+> carriers, and the third one is the finding of this pass. The discipline gained its fourth rule
+> (*a link is not a person*) in `sync-sources` EN + FR and both constitutions. But the rule had to
+> land where the gesture is actually **offered**: `/lint` ordered *"Dangling → fix the target
+> spelling, or CREATE THE MISSING NOTE"* with no carve-out, which IS how `stephanie-music.md` came to
+> exist — so the gesture now keeps its topic case and excludes a person target. **And `/lint` hands
+> off to `/consolidate`**, which proposes *"a person `[[mentioned]]` in captures but with no page
+> yet"* ranked by mention count: a fabricated `[[people/…]]` cited three times reads as **signal**,
+> because the count measures how often a link was written, never whether the person exists. Both
+> skills **point at** the producer's section instead of paraphrasing it (two paraphrases are two
+> disciplines). Reach checked, not assumed: `engine-skills/**` is in `replace` and staged skills are
+> provenance-refreshed, so an untouched `/lint` and `/consolidate` reach the deployed fleet.
+> 6 assertions, each red first; suite green (1268 tests, 1267 pass, 1 skipped Windows-only).
+>
+> **⏭️ RESUME AT STEP 12.3 (homonymy)** — a `people/` card must say **which** Romain. Nothing is
+> half-written on disk; no decision is pending. Then 12.4 (confidence block), 12.5 (release).
 
 - [x] **Step 12.0 — SHOW KENJAKU'S VERSION AT SESSION START. ✅ CODE-COMPLETE** _(2026-08-03 ·
       `22de9a2` → `807b9aa`, suite green 1236 pass / 1 skipped Windows-only)_. _(asked by the owner,
@@ -584,9 +597,19 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         prose that was already there for other reasons. ✅ _(2026-08-03)_ —
         `scripts/lib/identity-discipline.test.mjs`, 24 assertions, sharing `doc-section.mjs` with the
         claim guard. Every step was red first; what the red runs taught is in the header note.
-- [ ] **Step 12.2 — F6: repairing a link is not asserting a person exists.** Never create a `people/`
-      note merely to satisfy an incoming link. Evidence and the feedback loop are in P1; the field cost
-      was `people/stephanie-music.md`, a person who occurs **once in the whole vault: in her own title**.
+- [x] **Step 12.2 — F6: repairing a link is not asserting a person exists. ✅ COMPLETE**
+      _(2026-08-03 · `de2e658`)_. Never create a `people/` note merely to satisfy an incoming link.
+      Evidence and the feedback loop are in P1; the field cost was `people/stephanie-music.md`, a
+      person who occurs **once in the whole vault: in her own title**.
+  - [x] The fourth rule of the identity discipline, EN + FR skills + both constitutions.
+  - [x] `/lint`'s dangling remedy: the create-the-note gesture keeps its **topic** case and excludes a
+        `[[people/…]]` target. This is the rule that MANUFACTURED the defect, same shape as F7's
+        "People registry" — the fix repairs an order the engine ships, it does not add a caveat to a
+        neutral one.
+  - [x] `/consolidate`, the door `/lint` hands off to: a person candidate's mention count is a
+        **priority signal, not evidence the person exists**. Resolve first, leave the page unwritten
+        when the name will not resolve.
+  - [x] Both skills **point** at `sync-sources#identity-discipline`; neither restates it.
 - [ ] **Step 12.3 — the homonymy block.** A `people/` note only makes the resolution rule usable if it
       says **which** Romain (3 of them on the field brain, plus 3 Marie, 2 Karim, 2 Caroline, 2 Michael).
       Without it, the notes only move the ambiguity.
@@ -1070,14 +1093,21 @@ coherent ones. This framing is the plan's main proposal and is itself open to ch
         implication: a capability recorded as absent needs an expiry and a re-test, never inheritance.
         Note this is the **mirror image of F10** (a recorded value frozen at capture time), so the two
         may share one mechanism — check before designing.
-- [ ] **F6 — repairing a link and asserting a person exists are conflated.** `people/stephanie-music.md`
+- [x] **F6 — repairing a link and asserting a person exists are conflated.** ✅ **DONE**
+      _(2026-08-03 · `de2e658`)_ — see Step 12.2 for what shipped and where.
+      `people/stephanie-music.md`
       was created 19/07 *"to resolve an incoming link"* from a mis-resolved link; "Stéphanie Music"
       occurred **once in the whole vault: in its own title** (Stéphanie Glad: 382 times).
-  - [ ] The feedback loop: mis-resolved link → note created to satisfy it → that note becomes the
+  - [x] The feedback loop: mis-resolved link → note created to satisfy it → that note becomes the
         vault's truth about who exists → the next resolution resolves **against the fabrication**.
         It survived three weeks and would have corrupted every future resolution.
-  - [ ] Companion rule to F7: **never create a `people/` note merely to satisfy an incoming link.**
-  - [ ] Measured degradation before repair: banner said 28 dangling links, `/lint` reported **36** after
+  - [x] Companion rule to F7: **never create a `people/` note merely to satisfy an incoming link.**
+  - [x] **The engine ORDERED it, in two places.** `/lint` said *"Dangling → … or create the missing
+        note"* with no carve-out; `/consolidate`, the skill `/lint` explicitly hands one-off mentions
+        to, ranks person candidates by **mention count** — so a name F7 invented once and cited three
+        times reads as signal rather than as the defect it is. Both are fixed; both point at the
+        producer's section rather than carrying their own wording.
+  - [x] Measured degradation before repair: banner said 28 dangling links, `/lint` reported **36** after
         one sync session, for **21** existing people notes.
 - [ ] **Presence is not enough — disambiguation is the precondition** (design advance found in the
       field, worth adopting upstream). A `people/` note only makes the resolution rule usable if it

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -795,9 +795,55 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         67-commit silence that preceded v4.5.0's blocker never had a chance to build.
   - [x] **RESULTS.md § v4.6.0 written** _(2026-08-03 · `5b57c7e`)_ — per-file numbers, the finding,
         and every equivalent with the reason it is one.
-  - [ ] **⏸️ WAITING ON THE OWNER'S `/code-review ultra 55`** _(they chose to run it, 2026-08-03)_.
-        It is theirs to trigger — I cannot. **When its verdict lands: treat the findings first**, then
-        the tail below. Nothing else is pending.
+  - [x] **✅ THE REVIEW HAS LANDED** _(2026-08-04)_ — 8 candidates, **6 findings** after verification
+        and dedup. **I re-ran every one of them against the code myself: all six are REAL** (the
+        traversal was reproduced, not reasoned about). Session
+        `https://claude.ai/code/session_01YYtb3j4TFGN9SuP85TTZuA`; it posted **nothing to the PR**.
+        The one candidate that did NOT survive: *"refreshNote promotes the confidence field without
+        adding the visible block"*. Mechanically the no-op IS there (no `> **Confidence** — ` line in
+        the body → the `replace` does nothing while the frontmatter field moves), but it needs a card
+        that lacks the block, and no verdict backs it. **Left open, not silently dropped** — settle it
+        with a test before claiming either way.
+  - [ ] **The six findings, in the order I recommend treating them.** Fix each one TDD, red first.
+    - [ ] **① `engine-skills/consolidate/SKILL.md:94` — the other write-door still carries the
+          wording that MANUFACTURED F7.** Verified: the file still reads *"Backlinks kebab-case, no
+          accents, never a first name alone."*, inside a fenced `Agent(prompt=…)` block handed
+          verbatim to sub-agents, and it holds **no** *"no full name, no link"*. So a sub-agent handed
+          a bare first name is still ordered to produce a `[[people/…]]` link and forbidden from the
+          short form: inventing the surname stays the only exit. **This makes the PR body's claim
+          false** (*"the producer, which every consumer reuses"*). The guard's own comment predicted
+          this drift and its `SKILLS` array simply never iterates the file (`WRITE_DOORS` does, but
+          only checks `distinguish` and the section anchor). Fix = the sync-sources phrasing + add the
+          file to `SKILLS`. **This is the one that matters; it reopens the release's headline defect.**
+    - [ ] **② `scripts/lib/status-hook-output.mjs:30` — the new emitter escapes the F5 audit.**
+          Verified: `grep -c "additionalContext:"` on the file returns **0**, because it assigns
+          (`obj.additionalContext = …`) while the guard filters on the literal `"additionalContext:"`.
+          The pinned list stays at four and goes green. No runtime leak (the payload is ~90 chars) —
+          **what breaks is the guard**, exactly as its own header warns ("a guard that silently stops
+          matching is worse than no guard"). Fix = object-literal form + add to the pinned list + a
+          bound test carrying the `volume IS the defect (F5)` marker.
+    - [ ] **③ `scripts/refresh-note.mjs:66` — vault containment bypassed by a backslash path, and I
+          REPRODUCED it.** `join("/brain/vault", "..\\outside.md")` leaves the backslash literal on
+          POSIX; `toPosix()` then turns it into `/brain/vault/../outside.md`, which **passes**
+          `startsWith(vaultDir + "/")` and is resolved by `fs` to the escaped target. Read AND write.
+          **Pre-existing** (the branch does not introduce it) but the branch widens the payload by
+          forwarding the free-form `confidence.basis` into the written file, and the spec arrives on
+          stdin from an LLM invocation — the injection surface this very release names. Fix =
+          `resolve` + `relative` re-check, plus a backslash test next to the existing `../../` one.
+          **Scope call for the owner: ship it here or as a follow-up.**
+    - [ ] **④ `scripts/lib/note-refresh.mjs:98` — `$` sequences in the basis corrupt the block.** The
+          template **string** handed to `body.replace()` expands `$&`, `` $` ``, `$'`, `$$`. Narrow
+          (needs those characters in prose) but silent, and it lands the page in the exact
+          two-different-things state the comment four lines above swears it prevents. Fix = function
+          replacement.
+    - [ ] **⑤ `.claude/skills/prepare-1-1/SKILL.md:63` — a missing blank line, EN only.** Verified
+          against the FR sibling, which has it. Under CommonMark the "Markers are mandatory" paragraph
+          becomes a lazy continuation of the previous bullet instead of applying to the whole section.
+          Cosmetic for an LLM reader, real EN/FR drift for a human one.
+    - [ ] **⑥ `release-v4.6.0-pr-body.md:31` — the PR body contradicts the note it points at.** The
+          body still says the label *"had been computed since v4.2.0"*; commit `2f16a1b` looked this
+          up in git and corrected the **note** to v3.0.0, without carrying the fix across. A
+          reviewer-facing marketing surface asserting a number the author already disproved.
     - [ ] **Checked at a resume, 2026-08-03**: `gh pr view 55` shows **no review and no comment** on the
           PR, so the verdict has NOT landed yet; the owner confirmed they are launching it now. **On the
           next resume, look at the PR again before asking anything** — and if it has landed, treat the

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -802,6 +802,37 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
           PR, so the verdict has NOT landed yet; the owner confirmed they are launching it now. **On the
           next resume, look at the PR again before asking anything** — and if it has landed, treat the
           findings before touching the tail. The release itself is assembled and needs no re-doing.
+    - [ ] **LAUNCHED and STILL RUNNING, 2026-08-04** — session
+          `https://claude.ai/code/session_01YYtb3j4TFGN9SuP85TTZuA`. It posts **nothing to the PR**
+          (`gh pr view 55` stays at 0 reviews / 0 comments), so the PR is not the place to look: the
+          session page is. State when read: search done (**8 candidates**), verify in progress
+          (2 confirmed / 0 refuted and climbing), dedup pending. ⚠️ **`get_page_text` on that page
+          returned a stale "Révision arrêtée"** while a screenshot showed it live with a counter moving
+          — **trust the screenshot**, not the text extraction.
+    - [ ] **The 8 candidates, recorded so the list survives a `/clear`** (candidates, NOT findings —
+          only the first two are confirmed so far):
+      - [ ] ✅ *confirmed* — `scripts/lib/note-refresh.mjs:92` **the confidence line is corrupted when
+            the basis contains `$` replacement patterns**. Read the code: line 98 passes a template
+            **string** to `body.replace()`, so `$&`, `` $` ``, `$'`, `$1` in the rendered basis are
+            expanded as replacement patterns. Real, narrow, and the fix is a function replacement.
+      - [ ] ✅ *confirmed* — `scripts/lib/status-hook-output.mjs:30` **the new `additionalContext`
+            emitter bypasses the F5 audit guard**.
+      - [ ] ⏳ `scripts/lib/note-refresh.mjs:92` **promotes the `confidence:` field without adding the
+            visible block**. Worth taking seriously even before its verdict: if the body carries no
+            `> **Confidence** — ` line, the `replace` is a silent no-op, so the field moves alone —
+            **exactly** what the comment above it swears cannot happen ("promoted in BOTH places at
+            once", Step 12.4's own claim).
+      - [ ] ⏳ `scripts/lib/note-refresh.mjs:98` — `$`-sequences in the basis treated as special
+            replacements (likely the same defect as the first, a dedup candidate).
+      - [ ] ⏳ `scripts/refresh-note.mjs:84` — vault containment check bypassed by a backslash-escaped
+            path on Linux/macOS.
+      - [ ] ⏳ `engine-skills/consolidate/SKILL.md:50` — the sub-agent prompt still carries the
+            "never a first name alone" rule (a possible F6/F7 leftover).
+      - [ ] ⏳ `.claude/skills/prepare-1-1/SKILL.md:62` — missing blank line before the
+            "Markers are mandatory" paragraph (EN).
+      - [ ] ⏳ `maintainers/plans/prospective/release-v4.6.0-note.md:59` — **the note and the PR body
+            disagree on when the engine version label was first shipped**. A user-facing artifact
+            contradiction, so it belongs to the release tail whatever the verdict.
   - [ ] **The tail, once the review is in** (in this order):
     - [ ] Write the chosen title into the note's H1 **and** the PR title (both still carry a
           `<TITLE …>` placeholder).

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -557,15 +557,19 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME AT STEP 12.5 — THE RELEASE IS ASSEMBLED AND WAITING ON TWO THINGS THAT ARE THE OWNER'S.**
-> Done and pushed _(2026-08-03, `e57fc6f` → `5b57c7e`)_: the mutation pass (7 files, measured, treated
+> **⏭️ RESUME AT STEP 12.5 — THE RELEASE IS ASSEMBLED, CI IS 7/7, AND IT IS WAITING ON ONE THING:
+> THE OWNER'S `/code-review ultra 55`.** They chose to run it (2026-08-03); I cannot trigger it.
+> **On resume: if the review has landed, treat its findings; if not, ask whether it ran — do not
+> re-do the release work, and do not re-ask the title question.**
+>
+> Done and pushed _(2026-08-03, `e57fc6f` → `2f16a1b`)_: the mutation pass (7 files, measured, treated
 > and **re-measured** — all ≥ 96 %, two at 100 %, every survivor a pre-listed equivalent), the version
 > vector, the §10 marketing re-read **with its verdict recorded**, RESULTS.md § v4.6.0, the user-facing
-> note and the PR body. **Draft PR #55 is open and the full matrix is running on it.**
+> note, the PR body, **draft PR #55**, and **CI green on the branch head** (Node 22/24/26 × macOS +
+> Windows + the Windows installer e2e, checked against the head SHA rather than the PR's colour).
 >
-> **What is left, and why it is not mine:** the **release title** (three candidates are in Step 12.5 —
-> v4.5.0's was chosen by the owner, so this one is too), and whether to run `/code-review ultra` on
-> #55. Then the mechanical tail: undraft, merge, tag, publish, archive.
+> **The title is settled — the owner chose `v4.6.0 — The One Where It Asks Which One You Mean`.** It
+> still has to be written into the note's H1 and the PR title, which both carry a placeholder.
 >
 > **Nothing is half-written on disk**, the suite is green (1316 tests, 1315 pass, 1 skipped
 > Windows-only), and the note already covers the `⚙️ Kenjaku engine` startup segment that Step 12.0
@@ -780,20 +784,26 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
   - [x] **PR body written and PR OPEN** _(2026-08-03 · `1eb6c7b`)_ — **draft PR #55**,
         `prospective/release-v4.6.0-pr-body.md`. Its title is a placeholder on purpose (the release
         title is the owner's call, below) and must be rewritten before the merge.
-  - [ ] **The title is the owner's call** — do not mint one alone (v4.5.0's was chosen by them). The
-        series shape is *"The One Where …"*. Three candidates to put to them, none picked unilaterally:
-        **The One Where It Stops Inventing People** · **The One Where It Asks Which One You Mean** ·
-        **The One Where a Name Has to Be Earned**.
-  - [ ] **CI must speak before the tag** (§9): the full matrix is running on **PR #55** (7 checks:
-        Node 22/24/26 × macOS + Windows, plus the Windows installer e2e). Every commit of this branch
-        was pushed as it was made, so the tripwire has been green throughout — the 67-commit silence
-        that preceded v4.5.0's blocker cannot repeat here.
+  - [x] **TITLE CHOSEN BY THE OWNER** _(2026-08-03)_: **`v4.6.0 — The One Where It Asks Which One You
+        Mean`**. Do not re-open it, and do not re-run the three-candidate question. It still has to be
+        written into the note's H1, the PR title (currently a placeholder) and the release itself.
+  - [x] **CI HAS SPOKEN — 7/7 GREEN on the branch head** _(2026-08-03 · `2f16a1b`, PR #55)_: Node
+        22/24/26 × macOS + Windows, plus the Windows installer e2e, plus the tripwire. Verified against
+        the head SHA, not just "the PR looks green". Every commit was pushed as it was made, so the
+        67-commit silence that preceded v4.5.0's blocker never had a chance to build.
   - [x] **RESULTS.md § v4.6.0 written** _(2026-08-03 · `5b57c7e`)_ — per-file numbers, the finding,
         and every equivalent with the reason it is one.
-  - [ ] **Left for the owner, deliberately not done alone**: the **title** (three candidates above),
-        and whether to run `/code-review ultra` on PR #55 before the merge — it is theirs to trigger,
-        not mine. Then: undraft, merge, tag `v4.6.0`, publish the note, archive this plan's release
-        artefacts next to v4.5.0's.
+  - [ ] **⏸️ WAITING ON THE OWNER'S `/code-review ultra 55`** _(they chose to run it, 2026-08-03)_.
+        It is theirs to trigger — I cannot. **When its verdict lands: treat the findings first**, then
+        the tail below. Nothing else is pending.
+  - [ ] **The tail, once the review is in** (in this order):
+    - [ ] Write the chosen title into the note's H1 **and** the PR title (both still carry a
+          `<TITLE …>` placeholder).
+    - [ ] Undraft + merge PR #55, tag `v4.6.0`, publish the release with the note's body.
+    - [ ] Move `release-v4.6.0-note.md` + `release-v4.6.0-pr-body.md` into
+          `maintainers/plans/archived/`, next to v4.5.0's, and record the merge SHA + tag here.
+    - [ ] Then the plan's live work becomes **v4.7.0 (visibility)** — its findings are already listed
+          at the end of Step 11's block.
 
 ## The one pattern behind most of it (the reframe)
 

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -708,6 +708,35 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 - [ ] **Step 12.5 — the release**: mutation pass on what changed, version vector, §10 marketing re-read,
       note + PR body. Same shape as Step 11; its recipe (worktree, batch sizes, the `rag/node_modules`
       symlink) is written there and stays valid.
+  - [x] **Suite green at the tip before starting** _(2026-08-03 · `c53dd5a`)_ — 1297 tests, 1296 pass,
+        1 skipped Windows-only.
+  - [x] **What this release changed, measured** _(`git diff --stat main...HEAD`)_: **no `rag/src` file
+        at all**, so the mutation pass is `scripts` only. Eight production files —
+        `file-back-note.mjs`, `refresh-note.mjs`, `session-status.mjs`, and under `lib/`
+        `filed-note.mjs`, `note-refresh.mjs`, `engine-version.mjs`, `status-hook-output.mjs`,
+        `doc-section.mjs`. `session-status.mjs` is the **named 0 % top-level tier** (no test can import
+        it — that is exactly why `status-hook-output.mjs` exists); it is **not** mutated here, and
+        RESULTS.md says so rather than leaving a silent hole.
+  - [ ] **Mutation batches** (worktree `/Users/tpierrain/Dev/kenjaku-mut-v460`, `rag/node_modules`
+        symlinked and **verified** — 31 pass / 0 skipped before starting, or the write-guard mutants
+        face a suite that cannot judge them).
+    - [ ] **Batch 1** — `lib/filed-note.mjs` + `file-back-note.mjs` (the confidence + homonymy code).
+          Log: `maintainers/mutation/reports/v460-scripts-batch1.log`.
+    - [ ] **Batch 2** — `lib/engine-version.mjs` + `lib/status-hook-output.mjs` (the version segment).
+    - [ ] **Batch 3** — `lib/note-refresh.mjs` + `refresh-note.mjs` + `lib/doc-section.mjs`.
+    - [ ] Treat survivors the way v4.5.0 did: fix what a test can honestly reach, record only genuine
+          equivalents, **re-measure every hardened file** (a hardened-but-unmeasured file has an
+          unknown score, which is the same silence this trilogy is about).
+  - [ ] **Version vector** — bump to `4.6.0` wherever the release number lives, and check
+        `engineVersion.scripts` (left at `1.9.0` deliberately at v4.5.0's step; decide again here).
+  - [ ] **§10 marketing re-read** — README, EN-QUOI-C-EST-DIFFERENT, SETUP, CONNECTORS, the boards
+        through their alt texts. **Record the verdict even when it is boring.** Two known inputs: this
+        release makes the brain *refuse* to write a person card in cases where it used to write one
+        (a new user-visible refusal), and v4.5.0's startup version segment is still unsold.
+  - [ ] **Release note + PR body** — §11 shape (non-dev first), no finding codes, and it must cover
+        the `⚙️ Kenjaku engine v4.5.0` startup segment left over from Step 12.0.
+  - [ ] **The title is the owner's call** — do not mint one alone (v4.5.0's was chosen by them).
+  - [ ] **CI must speak before the tag** (§9): push, watch the full matrix, 7/7 green.
 
 ## The one pattern behind most of it (the reframe)
 

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -615,8 +615,15 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >       - [x] **RESULTS.md § v4.6.0 updated** _(`75d0d5a`)_ — the second pass is its own section, and the
 >             three superseded numbers in the first table are marked as NOT the ones at the tag rather
 >             than left for a reader to reconcile.
-> - [ ] **CI green on the branch head** (checked against the head SHA, never the PR's colour). Running
->       on `2fac4ee` at the time of writing; the previous head was red for the CRLF reason above.
+> - [x] **CI green**, checked against the head SHA rather than the PR's colour: 7/7 on `1e807d6` (all six
+>       fixes + the CRLF repair + the promotion) and again on `75d0d5a` (the mutation hardening + the
+>       re-measure). The commits after it are documentation only; re-check the tip before tagging.
+> - [x] **The release note and the PR body are finished** _(`085b225`, and the live PR body + PR title
+>       are synced on GitHub)_ — the note's `Review & CI` section is written (six defects, all fixed, told
+>       through the two checks that had stopped watching, no finding codes), its mutation table names the
+>       78.69 % file instead of implying everything touched is ≥ 96 %, and two overclaims are repaired in
+>       both artifacts (the producer/consumer reuse, and the promotion writing the visible block on cards
+>       you already have).
 > - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into
 >       `maintainers/plans/archived/`. **Deliberately NOT done autonomously**: publishing is outward-facing
 >       and effectively irreversible, so it waits for the owner's explicit go.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -507,8 +507,18 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > provenance-refreshed, so an untouched `/lint` and `/consolidate` reach the deployed fleet.
 > 6 assertions, each red first; suite green (1268 tests, 1267 pass, 1 skipped Windows-only).
 >
-> **⏭️ RESUME AT STEP 12.3 (homonymy)** — a `people/` card must say **which** Romain. Nothing is
-> half-written on disk; no decision is pending. Then 12.4 (confidence block), 12.5 (release).
+> **⏭️ RESUME AT STEP 12.3 (homonymy)** — a `people/` card must say **which** Romain. Then 12.4
+> (confidence block), 12.5 (release).
+>
+> **✅ DECIDED (2026-08-03, by the owner): 12.3 ships PROSE + A DETERMINISTIC GUARD.** The scope was
+> put to the owner with three options and this is the one chosen — **do not re-open it**. Both doors
+> that create a `people/` card (`/file-back` and `/consolidate`) write through **one** script,
+> `scripts/file-back-note.mjs`, so the check has a single choke point. The builder **refuses** a NEW
+> person card whose first name is already borne by another card until the spec says which one, and the
+> refusal **names the homonyms it found** (so the writer does not have to go looking again). The two
+> rejected options are recorded so they are not re-derived: prose only (*a rule nothing executes* —
+> this release has met that failure twice already), and a non-blocking stderr warning (which renders a
+> caught defect and an ordinary write identically — this trilogy's own defect shape).
 
 - [x] **Step 12.0 — SHOW KENJAKU'S VERSION AT SESSION START. ✅ CODE-COMPLETE** _(2026-08-03 ·
       `22de9a2` → `807b9aa`, suite green 1236 pass / 1 skipped Windows-only)_. _(asked by the owner,
@@ -612,7 +622,18 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
   - [x] Both skills **point** at `sync-sources#identity-discipline`; neither restates it.
 - [ ] **Step 12.3 — the homonymy block.** A `people/` note only makes the resolution rule usable if it
       says **which** Romain (3 of them on the field brain, plus 3 Marie, 2 Karim, 2 Caroline, 2 Michael).
-      Without it, the notes only move the ambiguity.
+      Without it, the notes only move the ambiguity. Scope decided by the owner — see the header note.
+  - [ ] **The prose half** — the identity discipline's fifth rule (*say which one*), `sync-sources`
+        EN + FR, plus both constitutions, in the guard family already shared with the claim discipline.
+        Two sides, and the second is what makes the first usable: a card **says** what distinguishes
+        this person, and a bare first name matching several cards is **unresolved** (so rule 2 applies:
+        plain text, no link) rather than resolved to the nearest one.
+  - [ ] **The deterministic half** — `scripts/file-back-note.mjs` (+ its pure core `lib/filed-note.mjs`):
+        a new `person` card whose first name is already borne by another card is refused until the spec
+        carries what tells them apart; the refusal names the homonyms. Covers `/file-back` **and**
+        `/consolidate`, which both write through it.
+  - [ ] **The two skills document the field** (`file-back`, `consolidate`), pointing at the producer's
+        section rather than restating the rule — the shape F6 and F7 both landed on.
 - [ ] **Step 12.4 — the reliability/confidence block** on any note born from a **probable** rather than
       confirmed resolution, in F18's vocabulary (see the header note above).
 - [ ] **Step 12.5 — the release**: mutation pass on what changed, version vector, §10 marketing re-read,

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -559,7 +559,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ① AND ② ARE DONE AND PUSHED (`e34c3ae`, `53b0560`), RESUME AT ③.**
+> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ①②③ ARE DONE AND PUSHED (`e34c3ae`, `53b0560`, `6c5a072`), RESUME AT ④.**
 > The owner asked for autonomous work (2026-08-04); each fix lands as its own green, pushed commit and
 > its box is ticked here as it lands, so a `/clear` resumes at the first unticked one.
 >
@@ -856,7 +856,15 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
           **what breaks is the guard**, exactly as its own header warns ("a guard that silently stops
           matching is worse than no guard"). Fix = object-literal form + add to the pinned list + a
           bound test carrying the `volume IS the defect (F5)` marker.
-    - [ ] **③ `scripts/refresh-note.mjs:66` — vault containment bypassed by a backslash path, and I
+    - [x] **③ DONE** _(2026-08-04 · `6c5a072`)_ — fixed with `posix.normalize` **before** the comparison,
+          not `resolve`: the Windows brain is simulated on macOS through string-level POSIX form, so
+          `resolve` would have broken that test. The red was a **real child process** (the injected fakes
+          key on literal strings and would have reported the escape as "does not exist" — passing for the
+          wrong reason); it printed `✓ Refreshed: vault/..\outside.md` and overwrote the outside file.
+          Checked, not assumed: the twin door `file-back-note.mjs` derives its path from a slug stripping
+          every non-alphanumeric, so it carries no such hole. Suite green (1320 tests, 1319 pass, 1 skipped
+          Windows-only). Original entry, kept: **`scripts/refresh-note.mjs:66` — vault containment
+          bypassed by a backslash path, and I
           REPRODUCED it.** `join("/brain/vault", "..\\outside.md")` leaves the backslash literal on
           POSIX; `toPosix()` then turns it into `/brain/vault/../outside.md`, which **passes**
           `startsWith(vaultDir + "/")` and is resolved by `fs` to the escaped target. Read AND write.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -559,7 +559,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ① IS DONE AND PUSHED (`e34c3ae`), RESUME AT ②.**
+> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ① AND ② ARE DONE AND PUSHED (`e34c3ae`, `53b0560`), RESUME AT ③.**
 > The owner asked for autonomous work (2026-08-04); each fix lands as its own green, pushed commit and
 > its box is ticked here as it lands, so a `/clear` resumes at the first unticked one.
 >
@@ -842,7 +842,14 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
           this drift and its `SKILLS` array simply never iterates the file (`WRITE_DOORS` does, but
           only checks `distinguish` and the section anchor). Fix = the sync-sources phrasing + add the
           file to `SKILLS`. **This is the one that matters; it reopens the release's headline defect.**
-    - [ ] **② `scripts/lib/status-hook-output.mjs:30` — the new emitter escapes the F5 audit.**
+    - [x] **② DONE** _(2026-08-04 · `53b0560`)_ — the detector is broadened (`/additionalContext\s*[:=]/`,
+          still a pure textual scan, no parse), the pinned list is at **five**, and the version relay
+          carries its own bound (framing **measured** at 69 chars, capped at 90) marked with the audit's
+          own marker. **The emitter kept its assignment form** rather than being bent into an object
+          literal: the key must be ABSENT when a brain cannot name its version, and the guard is what was
+          broken. Two reds, both verified: the detector named the fifth emitter, then the coverage test
+          reported it unbounded. Suite green (1319 tests, 1318 pass, 1 skipped Windows-only). Original
+          entry, kept: **`scripts/lib/status-hook-output.mjs:30` — the new emitter escapes the F5 audit.**
           Verified: `grep -c "additionalContext:"` on the file returns **0**, because it assigns
           (`obj.additionalContext = …`) while the guard filters on the literal `"additionalContext:"`.
           The pinned list stays at four and goes green. No runtime leak (the payload is ~90 chars) —

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -557,13 +557,19 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME AT STEP 12.5 — the release.** Mutation pass on what v4.6.0 changed, version vector, §10
-> marketing re-read, note + PR body. Its recipe (worktree at `/Users/tpierrain/Dev/kenjaku-mut-v460`
-> — NOT the scratchpad, the `rag/node_modules` symlink, one-or-two files per batch ≈ 6 min under the
-> 10-min cap) is written in Step 11 and stays valid. **Also still open from Step 12.0**, and easy to
-> miss because its box is checked: the note must cover the new `⚙️ Kenjaku engine v4.5.0` startup
-> segment, and the F3 wording (v4.7.0) must share this release's vocabulary. Nothing is half-written on
-> disk and no decision is pending.
+> **⏭️ RESUME AT STEP 12.5 — THE RELEASE IS ASSEMBLED AND WAITING ON TWO THINGS THAT ARE THE OWNER'S.**
+> Done and pushed _(2026-08-03, `e57fc6f` → `5b57c7e`)_: the mutation pass (7 files, measured, treated
+> and **re-measured** — all ≥ 96 %, two at 100 %, every survivor a pre-listed equivalent), the version
+> vector, the §10 marketing re-read **with its verdict recorded**, RESULTS.md § v4.6.0, the user-facing
+> note and the PR body. **Draft PR #55 is open and the full matrix is running on it.**
+>
+> **What is left, and why it is not mine:** the **release title** (three candidates are in Step 12.5 —
+> v4.5.0's was chosen by the owner, so this one is too), and whether to run `/code-review ultra` on
+> #55. Then the mechanical tail: undraft, merge, tag, publish, archive.
+>
+> **Nothing is half-written on disk**, the suite is green (1316 tests, 1315 pass, 1 skipped
+> Windows-only), and the note already covers the `⚙️ Kenjaku engine` startup segment that Step 12.0
+> left open. Still true for later: the F3 wording (v4.7.0) must share this release's vocabulary.
 >
 > **✅ DECIDED (2026-08-03, by the owner): 12.3 ships PROSE + A DETERMINISTIC GUARD.** The scope was
 > put to the owner with three options and this is the one chosen — **do not re-open it**. Both doors
@@ -734,8 +740,12 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
           guards, against documents where a degraded slice still contained the words they look for.
           Both "return the whole document" mutants survived, which silently turns every sliced guard
           back into the flat search it was extracted to replace. It has its own tests now (14/14 dead).
-    - [ ] **Re-measure** (running): batch 1's two files, then batch 2's five. A hardened-but-unmeasured
-          file has an unknown score, which is the same silence this trilogy is about.
+    - [x] **RE-MEASURED, and all seven came back clean** _(2026-08-03 · `5b57c7e`, logs
+          `…-batch1-recheck.log` + `…-batch2-recheck.log`)_ — `doc-section` 53.33 → **100 %**,
+          `refresh-note` 68.52 → **96.30 %**, `file-back-note` 72.81 → **96.49 %**,
+          `status-hook-output` 92.86 → **100 %**, `note-refresh` 92.31 → **97.80 %**,
+          `engine-version` 95.24 → **97.62 %**, `filed-note` 96.00 → **97.60 %**. **Every survivor
+          left is on the equivalence list written before the run.** Recorded in RESULTS.md § v4.6.0.
     - [x] **Equivalents, established by hand and NOT to be chased** _(each mutant applied, run, and
           reverted)_: `readFileSync(0, "")` in both CLIs (returns a Buffer, `JSON.parse` coerces it —
           already recorded at v4.5.0 for the guard hook); the slug's `^-+|-+$` quantifiers (the
@@ -767,13 +777,23 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         `maintainers/plans/prospective/release-v4.6.0-note.md`, §11 shape, no finding codes, and it
         carries the startup version segment left over from Step 12.0. Two placeholders on purpose: the
         title, and the mutation/CI blocks (filled from measurements, not from intent).
-  - [ ] **PR body** — same shape as `archived/release-v4.5.0-pr-body.md`.
+  - [x] **PR body written and PR OPEN** _(2026-08-03 · `1eb6c7b`)_ — **draft PR #55**,
+        `prospective/release-v4.6.0-pr-body.md`. Its title is a placeholder on purpose (the release
+        title is the owner's call, below) and must be rewritten before the merge.
   - [ ] **The title is the owner's call** — do not mint one alone (v4.5.0's was chosen by them). The
         series shape is *"The One Where …"*. Three candidates to put to them, none picked unilaterally:
         **The One Where It Stops Inventing People** · **The One Where It Asks Which One You Mean** ·
         **The One Where a Name Has to Be Earned**.
-  - [ ] **CI must speak before the tag** (§9): push, watch the full matrix, 7/7 green.
-  - [ ] **RESULTS.md § v4.6.0** — the per-file numbers, the two findings, and the equivalents above.
+  - [ ] **CI must speak before the tag** (§9): the full matrix is running on **PR #55** (7 checks:
+        Node 22/24/26 × macOS + Windows, plus the Windows installer e2e). Every commit of this branch
+        was pushed as it was made, so the tripwire has been green throughout — the 67-commit silence
+        that preceded v4.5.0's blocker cannot repeat here.
+  - [x] **RESULTS.md § v4.6.0 written** _(2026-08-03 · `5b57c7e`)_ — per-file numbers, the finding,
+        and every equivalent with the reason it is one.
+  - [ ] **Left for the owner, deliberately not done alone**: the **title** (three candidates above),
+        and whether to run `/code-review ultra` on PR #55 before the merge — it is theirs to trigger,
+        not mine. Then: undraft, merge, tag `v4.6.0`, publish the note, archive this plan's release
+        artefacts next to v4.5.0's.
 
 ## The one pattern behind most of it (the reframe)
 

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -442,22 +442,62 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > 🟡 derived or probable / 🔴 negative-or-behavioural-unverified, with *"safe to paste into a message to
 > another human"* as the threshold that matters. v4.6.0's confidence block marks a **people note born
 > from a probable resolution**; it must speak that same three-marker language (decided at F18, §4.5).
+>
+> **⏭️ RESUME HERE: Step 12.1, F7.** Step 12.0 (the owner's version-at-startup request) is code-complete
+> and pushed on `release/v4.6.0`; what it still owes belongs to the release step, not to now. Nothing
+> else is in flight, no decision is pending, and the branch is green (1236 pass, 1 skipped Windows-only).
 
-- [ ] **Step 12.0 — SHOW KENJAKU'S VERSION AT SESSION START.** _(asked by the owner, 2026-08-03:
-      « j'aimerai que tu rajoutes la version de Kenjaku au démarrage … à la prochaine release »)_ Small,
-      independent of the identity work, so it goes first and cannot be squeezed out by it.
-  - [ ] **Do NOT invent a version, and do not mint a second helper.** `scripts/lib/engine-version.mjs`
+- [x] **Step 12.0 — SHOW KENJAKU'S VERSION AT SESSION START. ✅ CODE-COMPLETE** _(2026-08-03 ·
+      `22de9a2` → `807b9aa`, suite green 1236 pass / 1 skipped Windows-only)_. _(asked by the owner,
+      2026-08-03: « j'aimerai que tu rajoutes la version de Kenjaku au démarrage … à la prochaine
+      release »)_ Small, independent of the identity work, so it went first.
+  - [x] **The label, chosen by the owner: `⚙️ Kenjaku engine v4.5.0`.** Asked because it is a real
+        product decision, not a detail: the engine had **never** said the word "Kenjaku" to a generated
+        brain (zero occurrences in both constitutions, every script and every skill — measured, not
+        assumed), so this is the product's name entering the brain's own surface for the first time.
+        The 🧠 of the mock-up became ⚙️ because 🧠 is already the RAG line's marker, and two identical
+        markers in one banner is this trilogy's own defect shape.
+  - [x] **Do NOT invent a version, and do not mint a second helper.** `scripts/lib/engine-version.mjs`
         already turns the brain's `engine-manifest.json` into the user-facing label (ADR 0017): the git
         **tag** the brain was installed/updated from (`source.ref`), falling back to `engineVersion.rag`,
         and **null** when nothing is usable → then no segment at all, rather than a made-up number.
-  - [ ] **Why it is invisible today, and this is the actual finding**: that label's only surface was the
+  - [x] **Two labels now share ONE resolution** (`installRef`), and their difference is the point: the
+        status-line label says *"engine"*, which claims nothing about which product, so it may keep its
+        fallback to `engineVersion.rag`; the startup segment says *"Kenjaku engine"*, so it may only ever
+        show a real install ref. **`rag` 1.3.0 has never been a Kenjaku release number** — an owner
+        reading "Kenjaku engine 1.3.0" would report a version that does not exist. **No ref → no
+        segment**, and naming that state out loud stays F3's job in v4.7.0.
+  - [x] **Why it was invisible, and this is the actual finding**: that label's only surface was the
         **statusLine**, and ADR 0036 had the engine *retreat* from the statusLine (it was clobbering the
-        owner's own). `scripts/status-line.mjs` still computes it; nothing renders it. So the version did
+        owner's own). `scripts/status-line.mjs` still computes it; nothing rendered it. So the version did
         not "never exist" — it **stopped being shown** and nobody noticed. Say it that way in the note.
-  - [ ] **Both channels or it is half-shipped**: `systemMessage` (CLI terminal only) **and**
+  - [x] **Both channels, or it is half-shipped**: `systemMessage` (CLI terminal only) **and**
         `hookSpecificOutput.additionalContext` (the ONLY channel the Code tab of Claude Desktop renders,
         via the agent's chat relay — ADR 0036's channel matrix). Shipping the CLI half alone would
-        reproduce this release's own reframe: "shown" and "not shown" rendered identically to us.
+        reproduce this release's own reframe: "shown" and "not shown" rendered identically to us. Both
+        ride a pure seam, `scripts/lib/status-hook-output.mjs`, because `session-status.mjs` is one of
+        the top-level scripts no test can import (named debt).
+  - [x] **Found by field-checking it, and NOT cosmetic: a pending restart outranks the version**
+        _(`807b9aa`)_. The new segment had taken the lead from the `⚠️ RESTART Claude` nudge, which holds
+        it for a written reason — until the owner restarts, nothing they read comes from the engine they
+        now have. And that is exactly when the claim is false: `update-engine` rewrites `source.ref` to
+        the **new** tag while the **old** code is still answering (`update-engine.mjs:312`). On the CLI
+        the restart line above it qualifies the version; on Desktop it would not, since the restart nudge
+        does not ride `additionalContext`. So a pending restart demotes the segment **and drops its chat
+        relay entirely**.
+  - [x] **Field-verified on a THROWAWAY CLONE, never on this repo** — both channels carry
+        `⚙️ Kenjaku engine v4.5.0`, and the launcher itself (no `source`) stays silent, which is the
+        intended silence. ⚠️ **The lesson not to re-learn**: running `session-status.mjs` by hand here
+        first fired its own SessionStart side effects (sweep + auto-commit of the working tree, an
+        `auto: session-start sweep` commit swallowing the wiring edit — reset, nothing lost, nothing
+        pushed). The memory `never-smoke-run-sessionstart-hooks` says exactly this. **Smoke-run a
+        SessionStart hook in a clone, never in the repo you are working in.**
+  - [x] **Delivery checked, not assumed**: `scripts/lib/**` and `scripts/session-status.mjs` are both in
+        the manifest's `replace` regime, so the seam and the wiring reach the fleet on the next
+        `/update-engine`; `engine-manifest.json` is in **no** regime and is rewritten by `update-engine`
+        itself, so the displayed version follows updates instead of freezing at install day.
+  - [ ] **Left for the release step**: the note + §10 re-read (the version is a user-visible surface), and
+        deciding whether `SETUP.md` should say where the version is read from.
   - [ ] Sibling to watch, **not** to merge: **F3** (v4.7.0) separates *"no engine update available"* from
         *"the target version is simply unknown"*. That one is about the **target**; this one is about the
         **installed** version. They must share one vocabulary — settle the wording here, since this ships

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -580,7 +580,16 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   the "Which one" block — WHICH one before HOW SURE), two reds first, and both write-door skills say
 >   so. **Do not re-open it as "left open".**
 >
-> **What remains, in order** — the plan's own tail, unchanged by the review:
+> **What remains, in order** — the plan's own tail, plus one item the fixes themselves created:
+> - [ ] **RE-MEASURE MUTATION ON WHAT THE FIXES CHANGED.** RESULTS.md § v4.6.0 was measured **before**
+>       these seven commits, and four production files changed since: `scripts/lib/note-refresh.mjs`,
+>       `scripts/refresh-note.mjs`, `scripts/lib/hooks-reconcile.mjs`, `scripts/lib/status-hook-output.mjs`.
+>       Publishing the old numbers over new lines is exactly the "a score implying coverage it does not
+>       have" failure this repo refuses. Worktree `/Users/tpierrain/Dev/kenjaku-mut-v460` (reset to the
+>       head, `rag/node_modules` symlinked and **verified** — 22 pass / 0 skipped). Batch 1
+>       (note-refresh + refresh-note) launched 2026-08-04, log
+>       `maintainers/mutation/reports/v460-review-fixes-batch1.log`; batch 2 is the other two files.
+>       Treat survivors the way every earlier batch was treated, then update RESULTS.md § v4.6.0.
 > - [ ] **CI green on the branch head** (checked against the head SHA, never the PR's colour). Running
 >       on `2fac4ee` at the time of writing; the previous head was red for the CRLF reason above.
 > - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -462,14 +462,23 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > - Guard: `scripts/lib/identity-discipline.test.mjs`, 12 assertions, sharing `scripts/lib/doc-section.mjs`
 >   with the claim guard so the two cannot judge different documents.
 >
+> **✅ The novelty check is IN** _(2026-08-03)_ — F7's last rule with no carrier now has two, and the
+> second one is the finding of this pass. The prose rule went into `## Identity discipline` (EN + FR):
+> nothing is *new* until the vault has been asked, with the Hossam case verbatim (a *"(confirmed
+> 04/06)"* card downgraded to *"(unconfirmed)"*). But a rule stated only there is a rule **nothing
+> executes** — so it also went into the **operative** step, as a third numbered reconcile pass in
+> `Step 3 — Synthesis`. That step is the only one that can run it: the sub-agents read external
+> sources and **never see the vault**, so "this is new" is asserted in the main context or nowhere.
+> The guard pins the intro count too (`Two passes` must be gone), because a promise of two passes
+> above a list of three is how the third one reads as optional. 16 assertions, suite green (1251 pass,
+> 1 skipped Windows-only).
+>
 > **The next bullets of Step 12.1, in order** (each one red-first, same shape as above):
-> 1. **`search_vault` before calling any fact "new"** — the field note republished a two-month-old fact
->    as a scoop. Not yet written anywhere; it is the last F7 rule with no carrier.
-> 2. **The constitutions (EN + FR)** — the identity discipline exists only in the two skills so far. Add
+> 1. **The constitutions (EN + FR)** — the identity discipline exists only in the two skills so far. Add
 >    it to `CLAUDE.engine.md` + `templates/fr/CLAUDE.engine.md` and extend the guard's table to them
 >    (the claim guard's `CONSTITUTIONS` array is the model). Reach caveat, unchanged: the constitution is
 >    in **no** regime, so it reaches new installs only — never the only carrier.
-> 3. **`prepare-1-1` must POINT at the producer's identity section** rather than paraphrase it, exactly
+> 2. **`prepare-1-1` must POINT at the producer's identity section** rather than paraphrase it, exactly
 >    as the claim guard already forces for the claim discipline (`sync-sources/SKILL.md#` anchor test).
 > Then Step 12.2 (F6), 12.3 (homonymy), 12.4 (confidence block), 12.5 (release).
 
@@ -547,9 +556,11 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         path against the universes layout) and the organisation notes. Resolution is already tier-3 in
         F18's table (*"and every identity resolution"*), so this is that tier's missing procedure, not a
         new doctrine.
-  - [ ] A `search_vault` before calling any fact **new** — the field note republished a two-month-old
+  - [x] A `search_vault` before calling any fact **new** — the field note republished a two-month-old
         fact as a scoop, and asserted *"Hossam, CTO Visma France (non confirmé)"* while
-        `people/hossam-laanait.md` said *"confirmé 04/06"*.
+        `people/hossam-laanait.md` said *"confirmé 04/06"*. ✅ _(2026-08-03)_ — shipped on **two**
+        surfaces, the prose rule and the third reconcile pass of `Step 3 — Synthesis`, because the
+        sub-agents never see the vault. See the header note for what that split turned up.
   - [ ] The control sits in the **producer** (`sync-sources`), not in each consumer: `prepare-1-1` reuses
         that fan-out, and two paraphrases are two disciplines (the rule F18 already locked by test).
   - [ ] Guard: extend the `claim-discipline` family with an identity guard, EN + FR, skills + both

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -796,6 +796,10 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
   - [ ] **⏸️ WAITING ON THE OWNER'S `/code-review ultra 55`** _(they chose to run it, 2026-08-03)_.
         It is theirs to trigger — I cannot. **When its verdict lands: treat the findings first**, then
         the tail below. Nothing else is pending.
+    - [ ] **Checked at a resume, 2026-08-03**: `gh pr view 55` shows **no review and no comment** on the
+          PR, so the verdict has NOT landed yet; the owner confirmed they are launching it now. **On the
+          next resume, look at the PR again before asking anything** — and if it has landed, treat the
+          findings before touching the tail. The release itself is assembled and needs no re-doing.
   - [ ] **The tail, once the review is in** (in this order):
     - [ ] Write the chosen title into the note's H1 **and** the PR title (both still carry a
           `<TITLE …>` placeholder).

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -566,9 +566,23 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > body and in the **PR title on GitHub** (`cc0a3ae`); the live PR body was re-synced, so the surface a
 > reviewer reads no longer carries the disproved number.
 >
+> **Two things landed AFTER the six, both worth not re-deriving:**
+> - **The guard shipped with ⑤ was CRLF-blind, and Windows caught it** _(`6d3d7c8`)_. It compared
+>   against `"\n\n"`; git checks these files out with CRLF, so all three Windows cells went red on
+>   typography while macOS stayed green. **Third time this repo meets that shape** — the tripwire on
+>   the push is what found it, which is exactly §9's purpose. Line endings are normalised before the
+>   comparison now, verified against a CRLF string directly rather than through the LF checkout.
+> - **The seventh review candidate is SETTLED, and the verdict is that it WAS a defect** _(`2fac4ee`)_.
+>   "The promotion moves the confidence field without adding the visible block": real, and it matters
+>   because every card written before v4.6.0 has no block — promoting one produced a card that says how
+>   sure it is to a `grep` and nothing at all to a human in Obsidian, while every card the builder
+>   writes shows the marker. The block is now written in the builder's own slot (under the H1, **after**
+>   the "Which one" block — WHICH one before HOW SURE), two reds first, and both write-door skills say
+>   so. **Do not re-open it as "left open".**
+>
 > **What remains, in order** — the plan's own tail, unchanged by the review:
 > - [ ] **CI green on the branch head** (checked against the head SHA, never the PR's colour). Running
->       on `cc0a3ae` at the time of writing.
+>       on `2fac4ee` at the time of writing; the previous head was red for the CRLF reason above.
 > - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into
 >       `maintainers/plans/archived/`. **Deliberately NOT done autonomously**: publishing is outward-facing
 >       and effectively irreversible, so it waits for the owner's explicit go.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -473,12 +473,18 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > above a list of three is how the third one reads as optional. 16 assertions, suite green (1251 pass,
 > 1 skipped Windows-only).
 >
-> **The next bullets of Step 12.1, in order** (each one red-first, same shape as above):
-> 1. **The constitutions (EN + FR)** — the identity discipline exists only in the two skills so far. Add
->    it to `CLAUDE.engine.md` + `templates/fr/CLAUDE.engine.md` and extend the guard's table to them
->    (the claim guard's `CONSTITUTIONS` array is the model). Reach caveat, unchanged: the constitution is
->    in **no** regime, so it reaches new installs only — never the only carrier.
-> 2. **`prepare-1-1` must POINT at the producer's identity section** rather than paraphrase it, exactly
+> **✅ The constitutions carry it now** _(2026-08-03)_ — a condensed `### Identity discipline` in
+> `CLAUDE.engine.md` + `templates/fr/CLAUDE.engine.md`, sitting immediately above the claim discipline
+> because a name is what the claim discipline's tier 3 is mostly about. Asserted against the **same
+> patterns** as the skills (the claim guard's own rule: two paraphrases of one discipline are two
+> disciplines), via a `CONSTITUTIONS` block modelled on it. Reach caveat unchanged and NOT a reason to
+> have skipped it: the skills are in `merge` and reach the fleet, the constitution is in no regime and
+> reaches new installs only, which is why the skill carriers were written first. 24 assertions, suite
+> green (1259 pass, 1 skipped Windows-only). One deliberate FR deviation: the heading uses a colon,
+> not an em dash, per the French typography rule.
+>
+> **The next bullet of Step 12.1** (red-first, same shape as above):
+> 1. **`prepare-1-1` must POINT at the producer's identity section** rather than paraphrase it, exactly
 >    as the claim guard already forces for the claim discipline (`sync-sources/SKILL.md#` anchor test).
 > Then Step 12.2 (F6), 12.3 (homonymy), 12.4 (confidence block), 12.5 (release).
 
@@ -563,9 +569,11 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         sub-agents never see the vault. See the header note for what that split turned up.
   - [ ] The control sits in the **producer** (`sync-sources`), not in each consumer: `prepare-1-1` reuses
         that fan-out, and two paraphrases are two disciplines (the rule F18 already locked by test).
-  - [ ] Guard: extend the `claim-discipline` family with an identity guard, EN + FR, skills + both
+  - [x] Guard: extend the `claim-discipline` family with an identity guard, EN + FR, skills + both
         constitutions. **Red first**, and check what the red run teaches — F18's first pass went green on
-        prose that was already there for other reasons.
+        prose that was already there for other reasons. ✅ _(2026-08-03)_ —
+        `scripts/lib/identity-discipline.test.mjs`, 24 assertions, sharing `doc-section.mjs` with the
+        claim guard. Every step was red first; what the red runs taught is in the header note.
 - [ ] **Step 12.2 — F6: repairing a link is not asserting a person exists.** Never create a `people/`
       note merely to satisfy an incoming link. Evidence and the feedback loop are in P1; the field cost
       was `people/stephanie-music.md`, a person who occurs **once in the whole vault: in her own title**.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -559,7 +559,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ①②③ ARE DONE AND PUSHED (`e34c3ae`, `53b0560`, `6c5a072`), RESUME AT ④.**
+> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ①②③④ ARE DONE AND PUSHED (`e34c3ae`, `53b0560`, `6c5a072`, `9377c17` + `41cf186`), RESUME AT ⑤ (the two doc findings).**
 > The owner asked for autonomous work (2026-08-04); each fix lands as its own green, pushed commit and
 > its box is ticked here as it lands, so a `/clear` resumes at the first unticked one.
 >
@@ -873,7 +873,15 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
           stdin from an LLM invocation — the injection surface this very release names. Fix =
           `resolve` + `relative` re-check, plus a backslash test next to the existing `../../` one.
           **Scope call for the owner: ship it here or as a follow-up.**
-    - [ ] **④ `scripts/lib/note-refresh.mjs:98` — `$` sequences in the basis corrupt the block.** The
+    - [x] **④ DONE** _(2026-08-04 · `9377c17`, plus the class sweep `41cf186`)_ — function replacement.
+          The red printed the corruption in full (the ✅ block containing the old 🟡 block). Then the
+          **class** was swept rather than the instance patched: `repairWin32NodePrefix` injects the
+          owner's own folder path (`$` and `&` are legal in a Windows folder name) and was fixed the same
+          way, red first on `my$$brain` → `my$brain`; `restampUniverse` looks identical but is **not
+          reachable** (its only caller normalises the name, stripping every non-alphanumeric) — checked,
+          recorded, not "fixed". Suite green (1322 tests, 1321 pass, 1 skipped Windows-only). Original
+          entry, kept: **`scripts/lib/note-refresh.mjs:98` — `$` sequences in the basis corrupt the
+          block.** The
           template **string** handed to `body.replace()` expands `$&`, `` $` ``, `$'`, `$$`. Narrow
           (needs those characters in prose) but silent, and it lands the page in the exact
           two-different-things state the comment four lines above swears it prevents. Fix = function

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -507,8 +507,34 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > provenance-refreshed, so an untouched `/lint` and `/consolidate` reach the deployed fleet.
 > 6 assertions, each red first; suite green (1268 tests, 1267 pass, 1 skipped Windows-only).
 >
-> **⏭️ RESUME AT STEP 12.3 (homonymy)** — a `people/` card must say **which** Romain. Then 12.4
-> (confidence block), 12.5 (release).
+> **✅ Step 12.3 done — THE HOMONYMY BLOCK IS COMPLETE** _(2026-08-03 · `c0187a5` → `9b6c64c`)_. Both
+> halves shipped, and the finding of the pass is where the deterministic half could sit: **both doors
+> that create a `people/` card write through ONE script**, so the check is a single choke point rather
+> than a caveat repeated in two skills. `scripts/file-back-note.mjs` now refuses a new `person` whose
+> first name the vault already holds unless the spec carries `distinguish`, and the refusal **names
+> the homonym cards it found** (root **and** every universe subtree — the same reach the resolution
+> rule reads). The answer lands in the card itself, above the body, as `> **Which one** — …`.
+> The prose half is the discipline's fifth rule, *say which one*, on the four carriers F7 and F6 used;
+> its second half is what makes the block worth writing: a bare first name matching several cards is
+> **unresolved**, so rule 2 applies (plain text, no link) instead of resolving to the nearest one.
+> Reach checked, not assumed: `scripts/file-back-note.mjs`, `scripts/lib/**` and `engine-skills/**`
+> are all in `replace`, `sync-sources` in `merge` — the fleet gets every carrier but the constitution.
+> Suite green (1285 tests, 1284 pass, 1 skipped Windows-only).
+>
+> Two things worth not re-learning:
+> - **`type === "person"` was never the SOLE cause in any test** — a hand-applied mutant dropping it
+>   survived, because every fixture that reached the guard was already a person. Killed by filing a
+>   **topic** whose slug shares that first segment (`topics/romain-rolland.md` next to
+>   `people/romain-durand.md`), which is also the honest statement of the rule's scope: nothing is
+>   ever resolved to a topic. Same shape as the TDD skill's §9.
+> - **A doc-guard pattern that spans a wrapped line goes red for typography, not for meaning.** The FR
+>   constitution lost `/non résolu/i` to a line break between the two words. Keep a guarded phrase on
+>   one line when writing the carrier.
+>
+> **⏭️ RESUME AT STEP 12.4** — the reliability/confidence block on a note born from a **probable**
+> rather than confirmed resolution, in F18's vocabulary (✅ observed / 🟡 derived or probable / 🔴
+> unverified; see the vocabulary paragraph at the top of Step 12). Nothing is half-written on disk and
+> no decision is pending. Then 12.5 (release).
 >
 > **✅ DECIDED (2026-08-03, by the owner): 12.3 ships PROSE + A DETERMINISTIC GUARD.** The scope was
 > put to the owner with three options and this is the one chosen — **do not re-open it**. Both doors
@@ -620,19 +646,20 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         **priority signal, not evidence the person exists**. Resolve first, leave the page unwritten
         when the name will not resolve.
   - [x] Both skills **point** at `sync-sources#identity-discipline`; neither restates it.
-- [ ] **Step 12.3 — the homonymy block.** A `people/` note only makes the resolution rule usable if it
+- [x] **Step 12.3 — the homonymy block. ✅ COMPLETE** _(2026-08-03 · `c0187a5` → `9b6c64c`)_.
+      A `people/` note only makes the resolution rule usable if it
       says **which** Romain (3 of them on the field brain, plus 3 Marie, 2 Karim, 2 Caroline, 2 Michael).
       Without it, the notes only move the ambiguity. Scope decided by the owner — see the header note.
-  - [ ] **The prose half** — the identity discipline's fifth rule (*say which one*), `sync-sources`
+  - [x] **The prose half** — the identity discipline's fifth rule (*say which one*), `sync-sources`
         EN + FR, plus both constitutions, in the guard family already shared with the claim discipline.
         Two sides, and the second is what makes the first usable: a card **says** what distinguishes
         this person, and a bare first name matching several cards is **unresolved** (so rule 2 applies:
         plain text, no link) rather than resolved to the nearest one.
-  - [ ] **The deterministic half** — `scripts/file-back-note.mjs` (+ its pure core `lib/filed-note.mjs`):
+  - [x] **The deterministic half** — `scripts/file-back-note.mjs` (+ its pure core `lib/filed-note.mjs`):
         a new `person` card whose first name is already borne by another card is refused until the spec
         carries what tells them apart; the refusal names the homonyms. Covers `/file-back` **and**
         `/consolidate`, which both write through it.
-  - [ ] **The two skills document the field** (`file-back`, `consolidate`), pointing at the producer's
+  - [x] **The two skills document the field** (`file-back`, `consolidate`), pointing at the producer's
         section rather than restating the rule — the shape F6 and F7 both landed on.
 - [ ] **Step 12.4 — the reliability/confidence block** on any note born from a **probable** rather than
       confirmed resolution, in F18's vocabulary (see the header note above).
@@ -1130,7 +1157,8 @@ coherent ones. This framing is the plan's main proposal and is itself open to ch
         producer's section rather than carrying their own wording.
   - [x] Measured degradation before repair: banner said 28 dangling links, `/lint` reported **36** after
         one sync session, for **21** existing people notes.
-- [ ] **Presence is not enough — disambiguation is the precondition** (design advance found in the
+- [x] **Presence is not enough — disambiguation is the precondition** ✅ **DONE** _(2026-08-03 ·
+      `c0187a5` → `9b6c64c`)_ — see Step 12.3 for what shipped and where. (design advance found in the
       field, worth adopting upstream). A `people/` note only makes the resolution rule usable if it
       carries an explicit **homonymy block**: the brain had 3 Romain, 3 Marie, 2 Karim, 2 Caroline,
       2 Michael. Without it, notes only move the ambiguity.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -720,23 +720,60 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
   - [ ] **Mutation batches** (worktree `/Users/tpierrain/Dev/kenjaku-mut-v460`, `rag/node_modules`
         symlinked and **verified** — 31 pass / 0 skipped before starting, or the write-guard mutants
         face a suite that cannot judge them).
-    - [ ] **Batch 1** — `lib/filed-note.mjs` + `file-back-note.mjs` (the confidence + homonymy code).
-          Log: `maintainers/mutation/reports/v460-scripts-batch1.log`.
-    - [ ] **Batch 2** — `lib/engine-version.mjs` + `lib/status-hook-output.mjs` (the version segment).
-    - [ ] **Batch 3** — `lib/note-refresh.mjs` + `refresh-note.mjs` + `lib/doc-section.mjs`.
-    - [ ] Treat survivors the way v4.5.0 did: fix what a test can honestly reach, record only genuine
-          equivalents, **re-measure every hardened file** (a hardened-but-unmeasured file has an
-          unknown score, which is the same silence this trilogy is about).
-  - [ ] **Version vector** — bump to `4.6.0` wherever the release number lives, and check
-        `engineVersion.scripts` (left at `1.9.0` deliberately at v4.5.0's step; decide again here).
-  - [ ] **§10 marketing re-read** — README, EN-QUOI-C-EST-DIFFERENT, SETUP, CONNECTORS, the boards
-        through their alt texts. **Record the verdict even when it is boring.** Two known inputs: this
-        release makes the brain *refuse* to write a person card in cases where it used to write one
-        (a new user-visible refusal), and v4.5.0's startup version segment is still unsold.
-  - [ ] **Release note + PR body** — §11 shape (non-dev first), no finding codes, and it must cover
-        the `⚙️ Kenjaku engine v4.5.0` startup segment left over from Step 12.0.
-  - [ ] **The title is the owner's call** — do not mint one alone (v4.5.0's was chosen by them).
+    - [x] **Batch 1 done and TREATED** _(2026-08-03 · `7879454`, log `…/v460-scripts-batch1.log`)_ —
+          `filed-note.mjs` **96.00 %** (5), `file-back-note.mjs` **72.81 %** (31 + 1 timeout). Both
+          families this release keeps meeting: the real deps observed by nothing (fixed by one real
+          child process against a throwaway brain, which is also the only thing that reaches the stdin
+          read, the recursive mkdir and the entrypoint guard) and refusal text asserted by fragments
+          (now asserted whole — that text IS the product here).
+    - [x] **Batch 2 done and TREATED** _(2026-08-03 · `bd6f995`, log `…/v460-scripts-batch2.log`)_ —
+          `doc-section.mjs` **53.33 %** (14), `refresh-note.mjs` **68.52 %** (17 + 1 timeout),
+          `note-refresh.mjs` **92.31 %** (7), `engine-version.mjs` **95.24 %** (2),
+          `status-hook-output.mjs` **92.86 %** (1). **The finding: `doc-section.mjs` had no test file
+          at all** — the slicer that decides what every doc guard reads, exercised only through those
+          guards, against documents where a degraded slice still contained the words they look for.
+          Both "return the whole document" mutants survived, which silently turns every sliced guard
+          back into the flat search it was extracted to replace. It has its own tests now (14/14 dead).
+    - [ ] **Re-measure** (running): batch 1's two files, then batch 2's five. A hardened-but-unmeasured
+          file has an unknown score, which is the same silence this trilogy is about.
+    - [x] **Equivalents, established by hand and NOT to be chased** _(each mutant applied, run, and
+          reverted)_: `readFileSync(0, "")` in both CLIs (returns a Buffer, `JSON.parse` coerces it —
+          already recorded at v4.5.0 for the guard hook); the slug's `^-+|-+$` quantifiers (the
+          preceding `[^a-z0-9]+` collapse makes two leading hyphens unreachable — verified on six
+          titles); `/\.md$/` unanchored in `firstNameSegment` (the first name is the first hyphen
+          segment, and no vault path carries `.md` inside it); `typeof manifest !== "object"` (a
+          truthy non-object yields null through both paths anyway); and two regex tails where `$` is
+          redundant without the `s` flag (`.*$` and `([\s\S]*)$`).
+    - [ ] **Still open, and NOT this release's debt**: the shared `runAsEntrypoint(meta, argv, fn)`
+          (3 mutants × 10+ scripts, named at v4.5.0). Two of the three now die per file thanks to the
+          child-process tests; what remains is `process.argv.slice(2)` → `process.argv`, a true
+          equivalent in both CLIs here since both take their spec on **stdin** and ignore argv.
+  - [x] **Version vector done** _(2026-08-03 · `e4d2110`)_ — measured first: `rag/` and
+        `local-mirror/` are untouched by this branch, so only `scripts` 1.10.0 → **1.11.0** and
+        `constitutionTemplate` 1.1.0 → **1.2.0**. `indexSchemaVersion` stays **2** — no reindex, which
+        is what the note promises.
+  - [x] **§10 marketing re-read done** _(2026-08-03 · `e4d2110`)_. **Made TRUE and now sold**: the
+        brain no longer invents a colleague (README §A, next to "silence is reported as silence" —
+        same defect family, identity half; §C's builder bullet; EN-QUOI's hole-by-hole table + §4.4),
+        and the startup version segment (SETUP §10 answers "which version am I on", including the two
+        deliberate silences). **Made FALSE: nothing** — no promise this release contradicts.
+        **Found stale while re-reading**: 34 ADRs → 37, and local-mirror's mutation score quoted at
+        95.6 % while RESULTS.md has read 90.4 % since v4.2.0 (an overclaim by five points, now
+        corrected and framed as "each package's last package-wide audit"). **Boards: re-read through
+        their alt texts, NOT re-rendered** — `board-reliability` shows "34 ADRs", a snapshot that now
+        under-claims, which is not a false promise; nothing on any board asserts something the code
+        stopped doing.
+  - [x] **Release note drafted** _(2026-08-03 · `f507942`)_ —
+        `maintainers/plans/prospective/release-v4.6.0-note.md`, §11 shape, no finding codes, and it
+        carries the startup version segment left over from Step 12.0. Two placeholders on purpose: the
+        title, and the mutation/CI blocks (filled from measurements, not from intent).
+  - [ ] **PR body** — same shape as `archived/release-v4.5.0-pr-body.md`.
+  - [ ] **The title is the owner's call** — do not mint one alone (v4.5.0's was chosen by them). The
+        series shape is *"The One Where …"*. Three candidates to put to them, none picked unilaterally:
+        **The One Where It Stops Inventing People** · **The One Where It Asks Which One You Mean** ·
+        **The One Where a Name Has to Be Earned**.
   - [ ] **CI must speak before the tag** (§9): push, watch the full matrix, 7/7 green.
+  - [ ] **RESULTS.md § v4.6.0** — the per-file numbers, the two findings, and the equivalents above.
 
 ## The one pattern behind most of it (the reframe)
 

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -443,9 +443,35 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > another human"* as the threshold that matters. v4.6.0's confidence block marks a **people note born
 > from a probable resolution**; it must speak that same three-marker language (decided at F18, §4.5).
 >
-> **⏭️ RESUME HERE: Step 12.1, F7.** Step 12.0 (the owner's version-at-startup request) is code-complete
-> and pushed on `release/v4.6.0`; what it still owes belongs to the release step, not to now. Nothing
-> else is in flight, no decision is pending, and the branch is green (1236 pass, 1 skipped Windows-only).
+> **⏭️ RESUME HERE: Step 12.1, F7 — part 1 is DONE and pushed, resume at its remaining bullets.**
+> Branch `release/v4.6.0`, green and pushed (1248 tests, 1247 pass, 1 skipped Windows-only; CI green on
+> the version commits). Nothing is half-written on disk, no decision is pending.
+>
+> **What is already done on F7** _(2026-08-03 · `9790c90`)_ — and the correction that shrinks the rest:
+> - **A large part of F7 had ALREADY SHIPPED with v4.5.0's claim pass.** Measured, not assumed: the
+>   sub-agent prompts and `prepare-1-1` already carry *"a bare first name stays a bare first name"*,
+>   *"the vault outranks the delta on anything about a person — read `vault/people/<name>.md` before
+>   asserting who someone is"*, and the Hossam case verbatim. **EN and FR are in parity** — the drift I
+>   went looking for is not there. Do not re-derive this; do not re-write those rules.
+> - **What was genuinely missing, and now ships**: the producer's own named **`## Identity discipline`**
+>   section (EN + FR `sync-sources`), and the removal of the contradiction that MANUFACTURED the field
+>   defect — "People registry" ordered *"`[[people/jane]]` is forbidden"* next to *"create the backlinks
+>   even if the target page doesn't exist"*, so an agent handed a bare first name had one exit: invent
+>   the surname. The same pair sat in the **operative** text (the bullets handed to the sub-agents, all
+>   four files); they now state the action (*"no full name, no link"*) instead of only the ban.
+> - Guard: `scripts/lib/identity-discipline.test.mjs`, 12 assertions, sharing `scripts/lib/doc-section.mjs`
+>   with the claim guard so the two cannot judge different documents.
+>
+> **The next bullets of Step 12.1, in order** (each one red-first, same shape as above):
+> 1. **`search_vault` before calling any fact "new"** — the field note republished a two-month-old fact
+>    as a scoop. Not yet written anywhere; it is the last F7 rule with no carrier.
+> 2. **The constitutions (EN + FR)** — the identity discipline exists only in the two skills so far. Add
+>    it to `CLAUDE.engine.md` + `templates/fr/CLAUDE.engine.md` and extend the guard's table to them
+>    (the claim guard's `CONSTITUTIONS` array is the model). Reach caveat, unchanged: the constitution is
+>    in **no** regime, so it reaches new installs only — never the only carrier.
+> 3. **`prepare-1-1` must POINT at the producer's identity section** rather than paraphrase it, exactly
+>    as the claim guard already forces for the claim discipline (`sync-sources/SKILL.md#` anchor test).
+> Then Step 12.2 (F6), 12.3 (homonymy), 12.4 (confidence block), 12.5 (release).
 
 - [x] **Step 12.0 — SHOW KENJAKU'S VERSION AT SESSION START. ✅ CODE-COMPLETE** _(2026-08-03 ·
       `22de9a2` → `807b9aa`, suite green 1236 pass / 1 skipped Windows-only)_. _(asked by the owner,

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -594,10 +594,20 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >       hand-edited vault holds (a `# ` inside a sentence / no heading at all, a stub card ending right
 >       after its title, a line of editor whitespace, an indented quotation of a homonymy block). The
 >       first went red and the repair was to **delete** the no-heading special case, not patch it.
->       - [ ] **Batch 2 running**: `note-refresh.mjs` (re-measure) + `status-hook-output.mjs`, log
->             `…/v460-review-fixes-batch2.log`.
->       - [ ] **Batch 3 still to run**: `scripts/lib/hooks-reconcile.mjs`.
->       - [ ] **Then update RESULTS.md § v4.6.0** with the per-file numbers and the survivor verdicts.
+>       - [x] **Batch 2 done** _(log `…/v460-review-fixes-batch2.log`)_ — **`status-hook-output.mjs`
+>             100 %**, **`note-refresh.mjs` 89.47 → 94.53 %**. Three of its seven survivors were
+>             reachable, all in the SECOND walk (past the homonymy block), which had been left without
+>             the assertions the first walk got. **Treated** _(`3e0d362`)_, both mutants hand-applied to
+>             prove each new test kills one.
+>       - [x] **The four survivors left in `note-refresh.mjs` are EQUIVALENTS** — do not chase them: the
+>             two regex `$` tails (redundant without the `s` flag; the `FRONTMATTER_RE` one was already
+>             on record) and the two boundary mutants on the homonymy line's own `if`, where
+>             `at === lines.length` makes `.test(undefined)` coerce to the string "undefined" and miss
+>             either way.
+>       - [ ] **Batch 3 running**: `hooks-reconcile.mjs` (never mutated in this release) +
+>             `note-refresh.mjs` (confirmation run), log `…/v460-review-fixes-batch3.log`.
+>       - [ ] **Then update RESULTS.md § v4.6.0** with the per-file numbers and the survivor verdicts,
+>             saying plainly that these four files were re-measured AFTER the review fixes.
 > - [ ] **CI green on the branch head** (checked against the head SHA, never the PR's colour). Running
 >       on `2fac4ee` at the time of writing; the previous head was red for the CRLF reason above.
 > - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -173,7 +173,9 @@
 >
 > **v4.7.0 (visibility) stays behind v4.6.0** and keeps its own findings: F13, F3, F10, F8, F9, F2, plus
 > the two banner defects routed there from P0 (a cached verdict rendered with live authority; an
-> `unknown` check displayed under "found a problem" — the latter already pinned by a test that names it).
+> `unknown` check displayed under "found a problem" — the latter already pinned by a test that names it),
+> plus **F19, the always-loaded instruction layer that only ever grows** (raised and measured
+> 2026-08-04, filed in P3 — its numbers are there, do not re-measure them).
 
 ## Step 11 — the v4.5.0 release — ✅ SHIPPED (2026-08-03, tag `v4.5.0`, PR #54, CI 7/7)
 
@@ -1334,6 +1336,49 @@ coherent ones. This framing is the plan's main proposal and is itself open to ch
 
 ### P3 — visibility, safety and ergonomics
 
+- [ ] **F19 — the always-loaded instruction layer only ever grows, and nothing measures whether it
+      still works. 🔜 v4.7.0 CANDIDATE** _(raised by the owner, 2026-08-04: « on n'arrête pas de faire
+      grossir la constitution … est-ce qu'on n'est pas devenu un peu obèse, avec un impact sur le bon
+      fonctionnement du second brain ? ». Measured the same day: the intuition **holds on the trend**
+      and **misses on the mechanism**. The numbers below are measured, not estimated — do not
+      re-derive them.)_
+  - [ ] **What is actually always in context in a generated brain.** `CLAUDE.md` rendered ~6 KB +
+        `CLAUDE.engine.md` **31.3 KB EN / 35.2 KB FR** (pulled in by its `@` import) + **~9.7 KB** of
+        skill frontmatter descriptions + the startup banner (already bounded, see below) ≈ **51 KB for
+        an FR brain, roughly 15-17k tokens, ~8 % of a 200k window**. SKILL.md **bodies** (up to 26 KB
+        for `local-mirror`) load only on invocation, and `filterCopyable` keeps `maintainers/**` out of
+        a brain entirely — so `CONVENTIONS.md` (36 KB), this plan (1500+ lines) and the ADRs cost a
+        deployed brain **nothing**. **Capacity is NOT the problem**: say so plainly rather than letting
+        the worry stand.
+  - [ ] **The trend is real, and it is a one-way ratchet.** The engine constitution sat at **23 504
+        bytes for eight releases** (v3.6.0 → v4.4.0), then **28 391** (v4.5.0, +21 %), then **31 280**
+        (v4.6.0, +10 %) — **+33 % over this trilogy alone**. Every commit that has ever touched the
+        file is `+N -0`, with a single exception (`+14 -9`): **it has never shrunk**. And since v4.5.0
+        its text is pinned by **32 doc-guard assertions**, so deleting a sentence now goes red. The
+        ratchet is ours, built in the last two releases.
+  - [ ] **The defect is not the size, it is the missing feedback loop.** Code is judged by mutation
+        score; prose is judged by doc guards that assert **presence**. Nothing measures **effect** — a
+        guard proves a rule is written, never that the model behaves differently. So a release can only
+        add, and can never learn that an older rule stopped earning its place. **37 imperatives**
+        (`NEVER`/`ALWAYS`/`MUST`) and **133 rule lines** now compete for attention at every turn.
+  - [ ] **The discipline already exists in this repo, applied to the wrong surface** —
+        `universe-reminder.test.mjs` bounds the session-start payload at **500 characters**, with a
+        failure message reading *"the startup payload grew back to N chars"*. 500 characters are
+        watched under a microscope while 35 200 are unwatched.
+  - [ ] **Candidate work, in this order. Scope NOT decided with the owner yet** — they asked for these
+        measurements to be filed as a v4.7.0 candidate (2026-08-04), which is a filing decision, not an
+        approval of the three items below.
+    - [ ] A **size budget test on both constitutions**, pinned at today's byte count: a ratchet that
+          can only go **down**, unless an explicit decision raises it. The missing net, one test.
+    - [ ] A **subtraction pass** in place of the usual addition pass. Two targets already measured:
+          `## Expected Claude Code behaviors` (**14.8 KB**, 11 subsections, half the file), and the
+          always-loaded descriptions of `switch` (**1 550 B**) and `local-mirror` (**1 543 B**) — 3 KB
+          of permanent cost for two optional features. Note the obstacle before starting: the doc
+          guards make removal red by construction, so a subtraction pass edits guards and prose
+          together, deliberately.
+    - [ ] **The only honest test of a rule's efficacy is behavioural** — an eval run against a real
+          brain. This repo has never had one. That is a project of its own, not a line item here, and
+          it is what would let a later release *remove* with evidence instead of by taste.
 - [x] **F1 — vault-only confidential material is printed at every SessionStart. ✅ COMPLETE**
       _(2026-08-03 · `9c67ea9` → `4b7b467`)_. The universe profile
       was dumped verbatim in the banner, including a passage explicitly tagged

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -581,7 +581,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   so. **Do not re-open it as "left open".**
 >
 > **What remains, in order** — the plan's own tail, plus one item the fixes themselves created:
-> - [ ] **RE-MEASURE MUTATION ON WHAT THE FIXES CHANGED.** RESULTS.md § v4.6.0 was measured **before**
+> - [x] **RE-MEASURE MUTATION ON WHAT THE FIXES CHANGED — DONE** _(2026-08-04)_. RESULTS.md § v4.6.0 was measured **before**
 >       these seven commits, and four production files changed since: `scripts/lib/note-refresh.mjs`,
 >       `scripts/refresh-note.mjs`, `scripts/lib/hooks-reconcile.mjs`, `scripts/lib/status-hook-output.mjs`.
 >       Publishing the old numbers over new lines is exactly the "a score implying coverage it does not
@@ -604,10 +604,17 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >             on record) and the two boundary mutants on the homonymy line's own `if`, where
 >             `at === lines.length` makes `.test(undefined)` coerce to the string "undefined" and miss
 >             either way.
->       - [ ] **Batch 3 running**: `hooks-reconcile.mjs` (never mutated in this release) +
->             `note-refresh.mjs` (confirmation run), log `…/v460-review-fixes-batch3.log`.
->       - [ ] **Then update RESULTS.md § v4.6.0** with the per-file numbers and the survivor verdicts,
->             saying plainly that these four files were re-measured AFTER the review fixes.
+>       - [x] **Batch 3 done and TREATED** _(`5194a9e`, logs `…/v460-review-fixes-batch3.log`,
+>             `…/v460-hooks-reconcile-recheck.log`)_ — `note-refresh.mjs` confirmed at **96.88 %**, and
+>             **`hooks-reconcile.mjs` 77.05 → 78.69 %**, then its last two survivors on the touched line
+>             killed. That file is **not this release's** (the branch grazes one line of it), so its 24
+>             remaining survivors are recorded as pre-existing rather than swept in. What the run bought:
+>             nothing had ever fed the repair a non-string `command`, nor placed the broken prefix
+>             anywhere but at position 0 — and the fixture that tells the guard's two terms apart is a
+>             non-string whose coercion LOOKS like the broken command.
+>       - [x] **RESULTS.md § v4.6.0 updated** _(`75d0d5a`)_ — the second pass is its own section, and the
+>             three superseded numbers in the first table are marked as NOT the ones at the tag rather
+>             than left for a reader to reconcile.
 > - [ ] **CI green on the branch head** (checked against the head SHA, never the PR's colour). Running
 >       on `2fac4ee` at the time of writing; the previous head was red for the CRLF reason above.
 > - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -483,10 +483,19 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > green (1259 pass, 1 skipped Windows-only). One deliberate FR deviation: the heading uses a colon,
 > not an em dash, per the French typography rule.
 >
-> **The next bullet of Step 12.1** (red-first, same shape as above):
-> 1. **`prepare-1-1` must POINT at the producer's identity section** rather than paraphrase it, exactly
->    as the claim guard already forces for the claim discipline (`sync-sources/SKILL.md#` anchor test).
-> Then Step 12.2 (F6), 12.3 (homonymy), 12.4 (confidence block), 12.5 (release).
+> **✅ The consumer POINTS now, and that closed Step 12.1** _(2026-08-03)_ — `prepare-1-1` (EN + FR) got
+> its own `## Identity discipline` section that links the producer's **section** (not merely the file:
+> it has linked `../sync-sources/SKILL.md` for the fan-out since long before this, so a bare file link
+> would have gone green on prose that predates the fix). The two bullets it used to carry in its own
+> words are gone: *"the vault outranks the delta…"* and *"a bare first name stays a bare first name"*
+> were **true today and free to drift tomorrow**, which is the whole reason the control sits in the
+> producer. What stays is what only a 1-1 knows: every person in that file is one of the two people in
+> the room, so a wrong surname is said to their face. 26 assertions, suite green (1261 pass, 1 skipped
+> Windows-only).
+>
+> **⏭️ RESUME AT STEP 12.2 (F6)** — never create a `people/` note merely to satisfy an incoming link.
+> Nothing is half-written on disk; no decision is pending. Then 12.3 (homonymy), 12.4 (confidence
+> block), 12.5 (release).
 
 - [x] **Step 12.0 — SHOW KENJAKU'S VERSION AT SESSION START. ✅ CODE-COMPLETE** _(2026-08-03 ·
       `22de9a2` → `807b9aa`, suite green 1236 pass / 1 skipped Windows-only)_. _(asked by the owner,
@@ -543,11 +552,12 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         *"the target version is simply unknown"*. That one is about the **target**; this one is about the
         **installed** version. They must share one vocabulary — settle the wording here, since this ships
         first, exactly as F18's confidence scale was settled before v4.6.0 reuses it.
-- [ ] **Step 12.1 — F7: resolve against the vault BEFORE writing.** The first move, because the exposure
+- [x] **Step 12.1 — F7: resolve against the vault BEFORE writing. ✅ COMPLETE** _(2026-08-03 · `9790c90`
+      → `cbd8818` → `861ec64` → this commit)_. The first move, because the exposure
       is live: it fires at every briefing and every 1-1 prep until it ships, and correcting the note does
       not stop it (proven — it recurred the same evening on the other laptop, against a vault that
       carried the right answer).
-  - [ ] **The mechanism is IN THE SKILL, not in the model's imagination** _(read 2026-08-03,
+  - [x] **The mechanism is IN THE SKILL, not in the model's imagination** _(read 2026-08-03,
         `.claude/skills/sync-sources/SKILL.md:66-71`)_. Its "People registry" section says, in the same
         breath, **"never a first name alone — `[[people/jane]]` is forbidden"** *and* **"create the
         backlinks even if the target page doesn't exist"**. Handed *"Jérémy (front Candor)"*, a sub-agent
@@ -555,9 +565,9 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         (*"Jérémy Hinard"*). So this is not a fix bolted onto a neutral rule — it **repairs a rule the
         engine ships**, which is why the fix must land here and not brain-side (patching it in a brain
         freezes that brain, F5).
-  - [ ] A bare first name stays **plain text, no link** — never `[[people/…]]`, never a surname supplied
+  - [x] A bare first name stays **plain text, no link** — never `[[people/…]]`, never a surname supplied
         by the model. Losing a backlink is cheap; a fabricated identity is permanent and gets indexed.
-  - [ ] Before writing a person, **read the vault**: resolve each cited person against
+  - [x] Before writing a person, **read the vault**: resolve each cited person against
         `vault/*/people/` (universe subtrees included — the skill still says `vault/people/`, check that
         path against the universes layout) and the organisation notes. Resolution is already tier-3 in
         F18's table (*"and every identity resolution"*), so this is that tier's missing procedure, not a
@@ -567,7 +577,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         `people/hossam-laanait.md` said *"confirmé 04/06"*. ✅ _(2026-08-03)_ — shipped on **two**
         surfaces, the prose rule and the third reconcile pass of `Step 3 — Synthesis`, because the
         sub-agents never see the vault. See the header note for what that split turned up.
-  - [ ] The control sits in the **producer** (`sync-sources`), not in each consumer: `prepare-1-1` reuses
+  - [x] The control sits in the **producer** (`sync-sources`), not in each consumer: `prepare-1-1` reuses
         that fan-out, and two paraphrases are two disciplines (the rule F18 already locked by test).
   - [x] Guard: extend the `claim-discipline` family with an identity guard, EN + FR, skills + both
         constitutions. **Red first**, and check what the red run teaches — F18's first pass went green on

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -624,16 +624,27 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >       78.69 % file instead of implying everything touched is ≥ 96 %, and two overclaims are repaired in
 >       both artifacts (the producer/consumer reuse, and the promotion writing the visible block on cards
 >       you already have).
-> - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into
->       `maintainers/plans/archived/`. **Deliberately NOT done autonomously**: publishing is outward-facing
->       and effectively irreversible, so it waits for the owner's explicit go.
+> - [ ] **⏭️ THE ONLY REMAINING STEP — the public tail. Ask the owner first; it is outward-facing and
+>       effectively irreversible, which is why it was deliberately NOT done autonomously.** In order,
+>       and nothing here needs re-deriving:
+>   - [ ] **Re-check CI on the tip** (`gh run list --branch release/v4.6.0`), against the head SHA, never
+>         the PR's colour. It was green on `701b45b`; only documentation commits followed the last code
+>         change.
+>   - [ ] `gh pr ready 55` (undraft), then merge. The PR title and body are already correct on GitHub.
+>   - [ ] Tag **`v4.6.0`** on the merge commit and publish the release, whose text is
+>         `maintainers/plans/prospective/release-v4.6.0-note.md` (its H1 already carries the chosen
+>         title, `The One Where It Asks Which One You Mean`).
+>   - [ ] **Archive** both artifacts into `maintainers/plans/archived/` as
+>         `release-v4.6.0-note.md` and `release-v4.6.0-pr-body.md` — the shape Step 11 used for v4.5.0.
+>   - [ ] **This plan file is NOT archived**: v4.7.0 (visibility) still lives in it — F13, F3, F10, F8,
+>         F9, F2, the two banner defects routed from P0, and F19. Update the header note to make v4.7.0
+>         the live work once v4.6.0 is out.
 >
-> **THE REVIEW HAS LANDED, AND THE ACT IS TO FIX ITS SIX FINDINGS, TDD, IN
-> ORDER ①→⑥.** They are listed with their verification, their fix and their order in Step 12.5's
-> checkbox *"The six findings, in the order I recommend treating them"* — **read them there, they are
-> not restated here, and do NOT re-run the review or re-verify them: each was already re-run against
-> the code, and the traversal was reproduced.** Nothing is started on disk; the branch is at
-> `335817b`, green and pushed.
+> **HISTORY, kept because it explains the six fixes above.** The review landed 2026-08-04 with six
+> findings, each verified against the code before being written down (the traversal was reproduced, not
+> reasoned about). They are listed one by one, with their verification and their fix, in Step 12.5's
+> checkbox *"The six findings, in the order to treat them"* — all six are now ticked there. **Do NOT
+> re-run the review and do not re-verify them.**
 >
 > **✅ DECIDED (2026-08-04, by the owner), two calls — do not re-open either:**
 > - **The traversal (③) ships INSIDE v4.6.0**, not as a follow-up. It is pre-existing, but the branch

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -531,10 +531,39 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   constitution lost `/non résolu/i` to a line break between the two words. Keep a guarded phrase on
 >   one line when writing the carrier.
 >
-> **⏭️ RESUME AT STEP 12.4** — the reliability/confidence block on a note born from a **probable**
-> rather than confirmed resolution, in F18's vocabulary (✅ observed / 🟡 derived or probable / 🔴
-> unverified; see the vocabulary paragraph at the top of Step 12). Nothing is half-written on disk and
-> no decision is pending. Then 12.5 (release).
+> **✅ Step 12.4 done — THE CONFIDENCE BLOCK IS COMPLETE** _(2026-08-03 · `e61002f` → `180e4de`)_.
+> Both halves shipped, in F18's vocabulary reused verbatim (✅ observed / 🟡 derived or probable / 🔴
+> unverified — the guard pins the middle marker's exact words, because a second scale here would be a
+> second discipline). The deterministic half: `renderFiledNote` renders a `> **Confidence** — …` block
+> above the body **and** a `confidence:` frontmatter field (F18 §4.6 — a caveat left in prose is one
+> the next session absorbs as confidence), a level outside the scale and a marker with no basis are
+> both refused rather than rendered leniently, and `scripts/file-back-note.mjs` **refuses a new person
+> card without it**. Required rather than offered, deliberately: left optional, its absence would mean
+> *confirmed*, which is silence rendered as confidence. The prose half is the discipline's sixth rule,
+> *say how sure you are*, on the same four carriers as rules 4 and 5. Reach unchanged and checked:
+> `scripts/**` and `engine-skills/**` in `replace`, `sync-sources` in `merge`, the constitution in no
+> regime.
+>
+> Two things worth not re-learning:
+> - **The rule needed a GESTURE, or the marker rots into the decoration it replaces.** A card marked 🟡
+>   had no supported way to ever say anything else, so "re-verify before resolving against it" had
+>   nowhere to record its outcome — and readers learn to ignore a marker that never changes.
+>   `scripts/refresh-note.mjs` now promotes a card, rewriting the **field and the visible block
+>   together** (rewriting one alone leaves the page asserting two different things about itself), through
+>   the **same renderer** as the builder. Freehand was never an option: hand-editing frontmatter is what
+>   put two `updated:` keys on one page and made it unreadable (F12).
+> - **A `ReferenceError` is not a fail-first.** The `/refresh-note` seam test first "went red" on
+>   `fakeDeps is not defined` — I had written the helper shape of a *different* test file. Re-verified by
+>   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
+>   anything.
+>
+> **⏭️ RESUME AT STEP 12.5 — the release.** Mutation pass on what v4.6.0 changed, version vector, §10
+> marketing re-read, note + PR body. Its recipe (worktree at `/Users/tpierrain/Dev/kenjaku-mut-v460`
+> — NOT the scratchpad, the `rag/node_modules` symlink, one-or-two files per batch ≈ 6 min under the
+> 10-min cap) is written in Step 11 and stays valid. **Also still open from Step 12.0**, and easy to
+> miss because its box is checked: the note must cover the new `⚙️ Kenjaku engine v4.5.0` startup
+> segment, and the F3 wording (v4.7.0) must share this release's vocabulary. Nothing is half-written on
+> disk and no decision is pending.
 >
 > **✅ DECIDED (2026-08-03, by the owner): 12.3 ships PROSE + A DETERMINISTIC GUARD.** The scope was
 > put to the owner with three options and this is the one chosen — **do not re-open it**. Both doors
@@ -661,8 +690,21 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         `/consolidate`, which both write through it.
   - [x] **The two skills document the field** (`file-back`, `consolidate`), pointing at the producer's
         section rather than restating the rule — the shape F6 and F7 both landed on.
-- [ ] **Step 12.4 — the reliability/confidence block** on any note born from a **probable** rather than
-      confirmed resolution, in F18's vocabulary (see the header note above).
+- [x] **Step 12.4 — the reliability/confidence block. ✅ COMPLETE** _(2026-08-03 · `e61002f` →
+      `180e4de`)_ on any note born from a **probable** rather than confirmed resolution, in F18's
+      vocabulary (see the header note above for what shipped and the two lessons).
+  - [x] **The prose half** — the identity discipline's sixth rule (*say how sure you are*),
+        `sync-sources` EN + FR plus both constitutions, in the guard family shared with the claim
+        discipline. Two sides again: the card **says** what its identity rests on, and at read time a
+        card marked 🟡 or 🔴 is a **lead, not the vault's answer** (re-verified, never inherited).
+  - [x] **The deterministic half** — `scripts/lib/filed-note.mjs` renders the block **and** a
+        `confidence:` frontmatter field; `scripts/file-back-note.mjs` refuses a new `person` card
+        without it; a bad level or a basis-less marker is refused, never rendered leniently.
+  - [x] **The promotion gesture** — `scripts/refresh-note.mjs` rewrites the field and the visible
+        block together, through the builder's own renderer. Without it the marker could never change,
+        which is how it would have rotted back into decoration.
+  - [x] **The two skills document the field** (`file-back`, `consolidate`), the latter saying why a
+        mention-count candidate is rarely `observed`.
 - [ ] **Step 12.5 — the release**: mutation pass on what changed, version vector, §10 marketing re-read,
       note + PR body. Same shape as Step 11; its recipe (worktree, batch sizes, the `rag/node_modules`
       symlink) is written there and stays valid.
@@ -1162,9 +1204,10 @@ coherent ones. This framing is the plan's main proposal and is itself open to ch
       field, worth adopting upstream). A `people/` note only makes the resolution rule usable if it
       carries an explicit **homonymy block**: the brain had 3 Romain, 3 Marie, 2 Karim, 2 Caroline,
       2 Michael. Without it, notes only move the ambiguity.
-- [ ] **Conformant ≠ true.** A deterministic builder guarantees *form* (naming convention, green lint),
-      not *substance*. Consider requiring a reliability/confidence block on any note born from a
-      **probable** rather than confirmed resolution.
+- [x] **Conformant ≠ true.** ✅ **DONE** _(2026-08-03 · `e61002f` → `180e4de`)_ — see Step 12.4 for what
+      shipped and where. A deterministic builder guarantees *form* (naming convention, green lint), not
+      *substance*, so a person card now carries a reliability/confidence block saying what its identity
+      rests on, and the builder refuses to write one without it.
 
 ### P2 — the freeze trap, and no path back upstream
 

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -559,7 +559,11 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME HERE — THE REVIEW HAS LANDED, AND THE NEXT ACT IS TO FIX ITS SIX FINDINGS, TDD, IN
+> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ① IS DONE AND PUSHED (`e34c3ae`), RESUME AT ②.**
+> The owner asked for autonomous work (2026-08-04); each fix lands as its own green, pushed commit and
+> its box is ticked here as it lands, so a `/clear` resumes at the first unticked one.
+>
+> **THE REVIEW HAS LANDED, AND THE ACT IS TO FIX ITS SIX FINDINGS, TDD, IN
 > ORDER ①→⑥.** They are listed with their verification, their fix and their order in Step 12.5's
 > checkbox *"The six findings, in the order I recommend treating them"* — **read them there, they are
 > not restated here, and do NOT re-run the review or re-verify them: each was already re-run against
@@ -822,7 +826,13 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         (2026-08-04): all six, TDD, red first, and ③ ships in THIS release.** ① and ② each need **two**
         reds: the defect, and the guard that missed it. Tick each box with its commit as it lands, so a
         `/clear` mid-sequence resumes at the first unticked one.
-    - [ ] **① `engine-skills/consolidate/SKILL.md:94` — the other write-door still carries the
+    - [x] **① DONE** _(2026-08-04 · `e34c3ae`)_ — the wording is the producer's own action form, and
+          the guard's carrier list is now **derived from the repo**: every `SKILL.md` under the three
+          skill roots that hands a fenced `prompt="""` to a sub-agent must be listed, or it goes red.
+          Two reds, both verified fail-first: the coverage assertion named
+          `engine-skills/consolidate/SKILL.md` before the fix, then the phrasing assertion failed on it.
+          Suite green (1318 tests, 1317 pass, 1 skipped Windows-only). Original entry, kept:
+          **`engine-skills/consolidate/SKILL.md:94` — the other write-door still carries the
           wording that MANUFACTURED F7.** Verified: the file still reads *"Backlinks kebab-case, no
           accents, never a first name alone."*, inside a fenced `Agent(prompt=…)` block handed
           verbatim to sub-agents, and it holds **no** *"no full name, no link"*. So a sub-agent handed

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -587,9 +587,17 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >       Publishing the old numbers over new lines is exactly the "a score implying coverage it does not
 >       have" failure this repo refuses. Worktree `/Users/tpierrain/Dev/kenjaku-mut-v460` (reset to the
 >       head, `rag/node_modules` symlinked and **verified** — 22 pass / 0 skipped). Batch 1
->       (note-refresh + refresh-note) launched 2026-08-04, log
->       `maintainers/mutation/reports/v460-review-fixes-batch1.log`; batch 2 is the other two files.
->       Treat survivors the way every earlier batch was treated, then update RESULTS.md § v4.6.0.
+>       (note-refresh + refresh-note) done, log `…/v460-review-fixes-batch1.log`: **`refresh-note.mjs`
+>       96.30 %** — its 2 survivors are the equivalents already on record (`readFileSync(0, "")`, the
+>       argv guard) — and **`note-refresh.mjs` 89.47 %**, whose 12 of 14 survivors sat in the block
+>       insertion written the same day. **Treated** _(`6ff9915`)_: four tests for the shapes a
+>       hand-edited vault holds (a `# ` inside a sentence / no heading at all, a stub card ending right
+>       after its title, a line of editor whitespace, an indented quotation of a homonymy block). The
+>       first went red and the repair was to **delete** the no-heading special case, not patch it.
+>       - [ ] **Batch 2 running**: `note-refresh.mjs` (re-measure) + `status-hook-output.mjs`, log
+>             `…/v460-review-fixes-batch2.log`.
+>       - [ ] **Batch 3 still to run**: `scripts/lib/hooks-reconcile.mjs`.
+>       - [ ] **Then update RESULTS.md § v4.6.0** with the per-file numbers and the survivor verdicts.
 > - [ ] **CI green on the branch head** (checked against the head SHA, never the PR's colour). Running
 >       on `2fac4ee` at the time of writing; the previous head was red for the CRLF reason above.
 > - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -559,9 +559,19 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   hand-removing the forwarding: it then failed on the assertion, which is the only red that proves
 >   anything.
 >
-> **⏭️ RESUME HERE — THE SIX FIXES ARE UNDER WAY: ①②③④ ARE DONE AND PUSHED (`e34c3ae`, `53b0560`, `6c5a072`, `9377c17` + `41cf186`), RESUME AT ⑤ (the two doc findings).**
-> The owner asked for autonomous work (2026-08-04); each fix lands as its own green, pushed commit and
-> its box is ticked here as it lands, so a `/clear` resumes at the first unticked one.
+> **⏭️ RESUME HERE — ALL SIX REVIEW FIXES ARE DONE AND PUSHED. WHAT IS LEFT IS THE RELEASE TAIL, AND
+> ITS PUBLIC HALF IS THE OWNER'S CALL.** Done autonomously 2026-08-04, each in TDD with the red verified
+> first, each its own green pushed commit: ① `e34c3ae`, ② `53b0560`, ③ `6c5a072`, ④ `9377c17` (+ the
+> class sweep `41cf186`), ⑤ `f7a00fc`, ⑥ `b3cabf9`. The chosen title is now in the note's H1, in the PR
+> body and in the **PR title on GitHub** (`cc0a3ae`); the live PR body was re-synced, so the surface a
+> reviewer reads no longer carries the disproved number.
+>
+> **What remains, in order** — the plan's own tail, unchanged by the review:
+> - [ ] **CI green on the branch head** (checked against the head SHA, never the PR's colour). Running
+>       on `cc0a3ae` at the time of writing.
+> - [ ] **Undraft, merge, tag `v4.6.0`, publish the release, archive the note + PR body** into
+>       `maintainers/plans/archived/`. **Deliberately NOT done autonomously**: publishing is outward-facing
+>       and effectively irreversible, so it waits for the owner's explicit go.
 >
 > **THE REVIEW HAS LANDED, AND THE ACT IS TO FIX ITS SIX FINDINGS, TDD, IN
 > ORDER ①→⑥.** They are listed with their verification, their fix and their order in Step 12.5's
@@ -822,7 +832,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
         the body → the `replace` does nothing while the frontmatter field moves), but it needs a card
         that lacks the block, and no verdict backs it. **Left open, not silently dropped** — settle it
         with a test before claiming either way.
-  - [ ] **The six findings, in the order to treat them. ✅ ORDER AND SCOPE APPROVED BY THE OWNER
+  - [x] **The six findings, in the order to treat them — ALL SIX DONE** _(2026-08-04)_. **✅ ORDER AND SCOPE APPROVED BY THE OWNER
         (2026-08-04): all six, TDD, red first, and ③ ships in THIS release.** ① and ② each need **two**
         reds: the defect, and the guard that missed it. Tick each box with its commit as it lands, so a
         `/clear` mid-sequence resumes at the first unticked one.
@@ -886,11 +896,19 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
           (needs those characters in prose) but silent, and it lands the page in the exact
           two-different-things state the comment four lines above swears it prevents. Fix = function
           replacement.
-    - [ ] **⑤ `.claude/skills/prepare-1-1/SKILL.md:63` — a missing blank line, EN only.** Verified
+    - [x] **⑤ DONE** _(2026-08-04 · `f7a00fc`)_ — the blank line is in, and the rule is **guarded in both
+          locales** rather than merely repaired (the two files are meant to be each other's mirror): the
+          assertion was red on EN and green on FR before the fix. Original entry, kept:
+          **`.claude/skills/prepare-1-1/SKILL.md:63` — a missing blank line, EN only.** Verified
           against the FR sibling, which has it. Under CommonMark the "Markers are mandatory" paragraph
           becomes a lazy continuation of the previous bullet instead of applying to the whole section.
           Cosmetic for an LLM reader, real EN/FR drift for a human one.
-    - [ ] **⑥ `release-v4.6.0-pr-body.md:31` — the PR body contradicts the note it points at.** The
+    - [x] **⑥ DONE** _(2026-08-04 · `b3cabf9`, synced to GitHub)_ — v4.2.0 → **v3.0.0** (with the first
+          commit named), plus two corrections the fixes above made necessary: the wording rule is stated
+          in the producer **and** in `/consolidate` (so the body no longer claims a reuse the second
+          write-door never performed), and Verification now carries the review's six findings, guards
+          first. The **live PR body was updated**, not just the file. Original entry, kept:
+          **`release-v4.6.0-pr-body.md:31` — the PR body contradicts the note it points at.** The
           body still says the label *"had been computed since v4.2.0"*; commit `2f16a1b` looked this
           up in git and corrected the **note** to v3.0.0, without carrying the fix across. A
           reviewer-facing marketing surface asserting a number the author already disproved.

--- a/maintainers/plans/prospective/release-v4.6.0-note.md
+++ b/maintainers/plans/prospective/release-v4.6.0-note.md
@@ -57,8 +57,8 @@ Ask for **`/update-engine`** once, then restart your session if it says so.
 - **Where it reaches.** The skills and scripts that carry the rules are refreshed on any brain that did
   not tailor them, so `/update-engine` is enough. The constitution half reaches new installs, as always.
 - **The version line was not missing — it had stopped being shown.** The label had been computed since
-  v4.2.0, but its only surface was the status line, which the engine deliberately gave back to you in
-  v4.4.0. It now rides both session-start channels (terminal and the Claude Desktop Code tab). Two
+  v3.0.0, but its only surface was the status line, which the engine gave back to you in v4.4.0 rather
+  than keep clobbering the one you had set. It now rides both session-start channels (terminal and the Claude Desktop Code tab). Two
   silences are on purpose: no usable tag, no line at all — rather than a number that is not a Kenjaku
   release — and a pending restart still takes the floor, because until you restart, the version you would
   read is not the one answering you.

--- a/maintainers/plans/prospective/release-v4.6.0-note.md
+++ b/maintainers/plans/prospective/release-v4.6.0-note.md
@@ -65,7 +65,30 @@ Ask for **`/update-engine`** once, then restart your session if it says so.
 
 ### Mutation-score snapshot, pinned to v4.6.0
 
-<!-- filled from maintainers/mutation/RESULTS.md § v4.6.0 once the three batches are treated -->
+Not line coverage: every number below is what survived deliberately breaking the code and re-running
+the suite. The seven files this release changed were measured one by one — no `rag` or `local-mirror`
+file changed, so those packages carry over untouched rather than being re-measured for nothing.
+
+| Package | Mutation score | What was measured |
+|---|---|---|
+| **scripts** (harness) | **all 7 changed files at 96 % or above, two at 100 %** | per file; every remaining survivor is a listed equivalent mutant |
+| **rag** | **94.67 %** | its v4.5.0 figure — untouched by this release |
+| **local-mirror** | **90.44 %** | its v4.2.0 audit — untouched by this release |
+
+**The finding is worth stating plainly, because it is the same shape as the release itself.** The small
+function that decides *which section of a document* our documentation guards read had **no test of its
+own**: it was only ever exercised through those guards, on real documents where a degraded reading
+still happened to contain the words they were looking for. Deliberately breaking it so that it returns
+the **whole document** left every guard green — which would have quietly turned each of them back into
+the loose search they were written to replace. It has its own tests now, and every injected fault dies.
+
+**The honest bound.** `session-status.mjs` scores **0 %**: it is a top-level script that runs on import,
+so no test can observe it. The logic it displays is covered — that is exactly why the version segment
+was built as a separate, testable piece — but its wiring is not. That hole is **inherited, not new**,
+and closing it is a release of its own rather than something to do on the eve of a tag.
+
+A published release is frozen, so these numbers stay true for this tag forever. Full detail:
+[`maintainers/mutation/RESULTS.md`](maintainers/mutation/RESULTS.md).
 
 ### Review & CI
 

--- a/maintainers/plans/prospective/release-v4.6.0-note.md
+++ b/maintainers/plans/prospective/release-v4.6.0-note.md
@@ -38,8 +38,9 @@ Ask for **`/update-engine`** once, then restart your session if it says so.
   backlinks even if the target page doesn't exist"*. Handed *"Jérémy (front Candor)"*, an agent obeying
   both had exactly two exits: drop the link, or invent a surname. It invented. The fix repairs the order
   itself — *no full name, no link* — rather than adding a caveat next to it, and it lands in the
-  **producer** (`sync-sources`), which every consumer already reuses: two paraphrases of one discipline
-  are two disciplines that drift.
+  **producer** (`sync-sources`) as well as in the second door that writes a person's page, which was
+  still handing its own helpers the forbidding pair. Every other consumer points at the producer rather
+  than restating it: two paraphrases of one discipline are two disciplines that drift.
 - **A rule stated only in prose is a rule nothing executes.** So each half of this release has a carrier
   that runs. *Is this really new?* became a third reconcile pass in the synthesis step — the only place
   that can run it, since the sub-agents read external sources and never see the vault. *Which one?* and
@@ -51,7 +52,9 @@ Ask for **`/update-engine`** once, then restart your session if it says so.
   rather than offered: left optional, its absence would come to mean *confirmed*, which is silence
   rendered as certainty — this trilogy's own defect shape. And it can change: `/refresh-note` promotes a
   page through the same renderer that built it, rewriting field and block together, because a marker that
-  can never move is decoration and readers learn to ignore it.
+  can never move is decoration and readers learn to ignore it. On a card written **before** this release
+  — every card you already have — the promotion writes that visible block for the first time, so the
+  page tells you how sure it is instead of keeping it in the header where only a search would find it.
 - **The same vocabulary as v4.5.0, deliberately.** ✅ observed / 🟡 probable / 🔴 unverified is the scale
   that release introduced for claims; a second scale for identity would have been a second discipline.
 - **Where it reaches.** The skills and scripts that carry the rules are refreshed on any brain that did
@@ -71,7 +74,8 @@ file changed, so those packages carry over untouched rather than being re-measur
 
 | Package | Mutation score | What was measured |
 |---|---|---|
-| **scripts** (harness) | **all 7 changed files at 96 % or above, two at 100 %** | per file; every remaining survivor is a listed equivalent mutant |
+| **scripts** (harness) | **all 7 changed files at 96 % or above, two at 100 %** | per file; every remaining survivor is a listed equivalent mutant. Re-measured **after** the review fixes below, because those fixes changed code the first numbers no longer described |
+| ↳ one file this release only grazes | **78.69 %** | `hooks-reconcile.mjs`, changed by a single line here. Named rather than hidden in an average: its remaining gaps pre-date this release |
 | **rag** | **94.67 %** | its v4.5.0 figure — untouched by this release |
 | **local-mirror** | **90.44 %** | its v4.2.0 audit — untouched by this release |
 
@@ -92,4 +96,21 @@ A published release is frozen, so these numbers stay true for this tag forever. 
 
 ### Review & CI
 
-<!-- filled once /code-review and the full matrix have spoken -->
+**An independent review of this release found six defects, and all six were fixed before the tag** —
+each one reproduced first, so nothing was repaired on a hunch. Two of them are the ones worth telling
+you about, because they are the same shape as the release itself: **two of our own automatic checks had
+quietly stopped watching**. One was reading a hand-written list of files that never included the second
+place where your brain writes a person's page — so the headline rule of this very release was passing
+while that other door still told the assistant to invent the missing surname. The other was looking for
+a phrase that a newer piece of code no longer spells the same way, so a fifth source of session-start
+text was invisible to it. Both now work out for themselves what they are supposed to watch, instead of
+being told once and trusting the list forever.
+
+The other four: a page-refresh could be walked **outside your vault** by a path written with Windows
+backslashes (reproduced on a real brain, and the same class of mistake was then searched for and fixed
+wherever it could be reached), a `$` in a quoted source could corrupt the confidence line it was being
+written into, and an English page had a missing blank line its French twin did not.
+
+**CI**: the full matrix — Node 22, 24 and 26 on macOS and Windows, plus the Windows install
+end-to-end — green on the commit being tagged, checked against that commit rather than against the
+colour of a page.

--- a/maintainers/plans/prospective/release-v4.6.0-note.md
+++ b/maintainers/plans/prospective/release-v4.6.0-note.md
@@ -1,0 +1,72 @@
+# v4.6.0 — <TITLE: the owner's call, see the three candidates in the plan>
+
+**Your brain stops inventing the people it writes about.** When a colleague comes up by first name only,
+it now looks them up in *your* notes before writing a word — and when it cannot tell which one you mean,
+it says so instead of picking.
+
+### What you get
+
+- 🙅 **No more invented surnames.** Handed a bare *"Jérémy"*, your brain used to complete the name to
+  make a link work, and that invented person was then saved and searched like a real one. A first name it
+  cannot resolve now stays plain text.
+- 📇 **Your notes get the last word on who someone is.** Before writing about a person, it reads the page
+  your vault already holds about them — so a fact you confirmed two months ago is no longer re-announced
+  as news, or contradicted by today's guess.
+- 🔗 **Repairing a broken link no longer conjures up a person.** Tidying your wiki could create a page for
+  someone who exists nowhere else in your vault — not any more; the offer keeps its topic case and stops
+  at people.
+- 👥 **Three Romains? The page says which one.** A new person page has to carry what tells them apart, and
+  your brain refuses to write it otherwise — naming the pages it already found. A bare first name matching
+  several people counts as *unresolved*, not as the nearest match.
+- 🎯 **A page says how sure it is.** Identity worked out rather than read is marked ✅ observed,
+  🟡 probable or 🔴 unverified — right on the page — and can be promoted later, when you confirm it.
+- ⚙️ **Your brain tells you which engine it runs.** A `⚙️ Kenjaku engine v4.6.0` line at the start of each
+  session. It had been computed for months and shown nowhere.
+
+### What you have to do
+
+Ask for **`/update-engine`** once, then restart your session if it says so.
+
+**This release does not re-read your notes** — nothing to wait for, nothing in your vault is modified.
+
+---
+
+### Under the hood
+
+- **The defect was a rule the engine shipped, not a mood of the model.** The `sync-sources` skill ordered,
+  in the same breath, *"never a first name alone, `[[people/jane]]` is forbidden"* and *"create the
+  backlinks even if the target page doesn't exist"*. Handed *"Jérémy (front Candor)"*, an agent obeying
+  both had exactly two exits: drop the link, or invent a surname. It invented. The fix repairs the order
+  itself — *no full name, no link* — rather than adding a caveat next to it, and it lands in the
+  **producer** (`sync-sources`), which every consumer already reuses: two paraphrases of one discipline
+  are two disciplines that drift.
+- **A rule stated only in prose is a rule nothing executes.** So each half of this release has a carrier
+  that runs. *Is this really new?* became a third reconcile pass in the synthesis step — the only place
+  that can run it, since the sub-agents read external sources and never see the vault. *Which one?* and
+  *how sure?* became refusals in the one script both note-creating doors write through, so they cannot be
+  argued with: a new person card whose first name the vault already holds is refused until the spec says
+  what tells them apart, and the refusal names the homonyms it found.
+- **Confidence is a field, not a flourish.** It is written into the page's header as well as the visible
+  block, because a caveat left in prose is one the next session absorbs as confidence. It is **required**
+  rather than offered: left optional, its absence would come to mean *confirmed*, which is silence
+  rendered as certainty — this trilogy's own defect shape. And it can change: `/refresh-note` promotes a
+  page through the same renderer that built it, rewriting field and block together, because a marker that
+  can never move is decoration and readers learn to ignore it.
+- **The same vocabulary as v4.5.0, deliberately.** ✅ observed / 🟡 probable / 🔴 unverified is the scale
+  that release introduced for claims; a second scale for identity would have been a second discipline.
+- **Where it reaches.** The skills and scripts that carry the rules are refreshed on any brain that did
+  not tailor them, so `/update-engine` is enough. The constitution half reaches new installs, as always.
+- **The version line was not missing — it had stopped being shown.** The label had been computed since
+  v4.2.0, but its only surface was the status line, which the engine deliberately gave back to you in
+  v4.4.0. It now rides both session-start channels (terminal and the Claude Desktop Code tab). Two
+  silences are on purpose: no usable tag, no line at all — rather than a number that is not a Kenjaku
+  release — and a pending restart still takes the floor, because until you restart, the version you would
+  read is not the one answering you.
+
+### Mutation-score snapshot, pinned to v4.6.0
+
+<!-- filled from maintainers/mutation/RESULTS.md § v4.6.0 once the three batches are treated -->
+
+### Review & CI
+
+<!-- filled once /code-review and the full matrix have spoken -->

--- a/maintainers/plans/prospective/release-v4.6.0-note.md
+++ b/maintainers/plans/prospective/release-v4.6.0-note.md
@@ -1,4 +1,4 @@
-# v4.6.0 — <TITLE: the owner's call, see the three candidates in the plan>
+# v4.6.0 — The One Where It Asks Which One You Mean
 
 **Your brain stops inventing the people it writes about.** When a colleague comes up by first name only,
 it now looks them up in *your* notes before writing a word — and when it cannot tell which one you mean,

--- a/maintainers/plans/prospective/release-v4.6.0-pr-body.md
+++ b/maintainers/plans/prospective/release-v4.6.0-pr-body.md
@@ -14,8 +14,8 @@ created for a colleague who occurs exactly once in the whole vault: in her own t
 - **The defect was an order the engine shipped.** `sync-sources` said, in the same breath, *"never a
   first name alone, `[[people/jane]]` is forbidden"* and *"create the backlinks even if the target page
   doesn't exist"*. An agent obeying both had two exits: drop the link, or invent the surname. It
-  invented. The rule now states the action — *no full name, no link* — in the **producer**, which every
-  consumer reuses.
+  invented. The rule now states the action — *no full name, no link* — in the **producer** and in the
+  second write-door, `/consolidate`, which handed its own sub-agents the same forbidding pair.
 - **Resolve before writing, and ask the vault whether it is even new.** The novelty check is a third
   reconcile pass in the synthesis step, the only place that can run it: the sub-agents read external
   sources and never see the vault.
@@ -28,7 +28,8 @@ created for a colleague who occurs exactly once in the whole vault: in her own t
   refuses one that does not say what its identity rests on. `/refresh-note` promotes a card later,
   rewriting the field and the visible block together through the builder's own renderer.
 - **The engine says which version it is**, on both session-start channels — a label that had been
-  computed since v4.2.0 and rendered nowhere since the engine gave the status line back to its owner.
+  computed since v3.0.0 (first commit `aaa0f64`) and rendered nowhere since v4.4.0, when the engine
+  gave the status line back to its owner.
 
 ### Choices worth reviewing
 
@@ -52,3 +53,13 @@ created for a colleague who occurs exactly once in the whole vault: in her own t
   replace. Fixed, 14/14 dead.
 - Suites green at every commit; the marketing surface re-read per §10, with its verdict recorded in the
   plan (including the boring half: the boards were re-read and deliberately not re-rendered).
+- **An independent review of this branch found six defects, and all six are fixed here**, each in TDD
+  with the red verified first. Two of them were **guards that had stopped watching**, which is the more
+  useful half: the identity guard iterated a hand-written list of four files that never included
+  `/consolidate` — so the release's headline rule read green while the other write-door still ordered
+  the invention — and the F5 startup-payload audit filtered on a literal `additionalContext:`, so an
+  emitter that *assigns* the key was its invisible fifth. Both now derive what they watch from the repo.
+  The other four: a vault-containment check a backslash path walked straight out of (reproduced against
+  a real brain, and its class swept — one sibling fixed, one shown unreachable), a `$` sequence in
+  free-form prose that spliced the old confidence block into the new one, and a missing blank line that
+  made a section-wide rule render as one bullet's tail in EN only.

--- a/maintainers/plans/prospective/release-v4.6.0-pr-body.md
+++ b/maintainers/plans/prospective/release-v4.6.0-pr-body.md
@@ -1,0 +1,54 @@
+## v4.6.0 — <TITLE: the owner's call>
+
+Second of the trilogy that came out of one evening on a real deployed brain. v4.5.0 stopped silence from
+passing for good news; this one stops the vault from **poisoning itself**. The brain was writing *about
+people* without ever reading what the vault already said about them — so a bare *"Jérémy"* became a
+surname that exists nowhere, a fact confirmed two months earlier was republished as news, and a page was
+created for a colleague who occurs exactly once in the whole vault: in her own title.
+
+**The user-facing note is the source of truth for what ships:**
+[`maintainers/plans/prospective/release-v4.6.0-note.md`](maintainers/plans/prospective/release-v4.6.0-note.md).
+
+### What is in it
+
+- **The defect was an order the engine shipped.** `sync-sources` said, in the same breath, *"never a
+  first name alone, `[[people/jane]]` is forbidden"* and *"create the backlinks even if the target page
+  doesn't exist"*. An agent obeying both had two exits: drop the link, or invent the surname. It
+  invented. The rule now states the action — *no full name, no link* — in the **producer**, which every
+  consumer reuses.
+- **Resolve before writing, and ask the vault whether it is even new.** The novelty check is a third
+  reconcile pass in the synthesis step, the only place that can run it: the sub-agents read external
+  sources and never see the vault.
+- **Repairing a link is not asserting a person exists.** `/lint`'s create-the-missing-note remedy keeps
+  its topic case and stops at people; `/consolidate` says a mention count is a priority signal, never
+  evidence.
+- **Homonymy and confidence are deterministic refusals, not advice.** Both doors that create a
+  `people/` card write through one script, so `scripts/file-back-note.mjs` refuses a new person whose
+  first name the vault already holds until the spec says which one (naming the homonyms it found), and
+  refuses one that does not say what its identity rests on. `/refresh-note` promotes a card later,
+  rewriting the field and the visible block together through the builder's own renderer.
+- **The engine says which version it is**, on both session-start channels — a label that had been
+  computed since v4.2.0 and rendered nowhere since the engine gave the status line back to its owner.
+
+### Choices worth reviewing
+
+- **Required, not optional, for confidence.** Left optional, an absent marker would come to mean
+  *confirmed* — silence rendered as certainty, which is this trilogy's own defect shape.
+- **One vocabulary.** ✅ observed / 🟡 derived or probable / 🔴 unverified is v4.5.0's scale, reused
+  verbatim and pinned by the guard: a second scale here would be a second discipline.
+- **Prose is never the only carrier.** Every rule that could be shipped as a check was: this release
+  met the "a rule nothing executes" failure twice before adopting that stance.
+- **Reach, checked rather than assumed.** `scripts/**` and `engine-skills/**` are in `replace`,
+  `sync-sources` in `merge`, so the fleet gets every carrier on `/update-engine`; the constitution is
+  in no regime and reaches new installs, which is why the skill carriers were written first.
+
+### Verification
+
+- **CI** on this branch: Node 22/24/26 × macOS + Windows, plus the Windows installer end-to-end.
+- **Mutation pass on the eight production files this release changed**, per file rather than averaged.
+  Its finding is worth the reviewer's minute: `scripts/lib/doc-section.mjs` — the slicer that decides
+  what every doc guard reads — had **no test of its own**, and both "return the whole document" mutants
+  survived. That silently turns every sliced guard back into the flat search it was extracted to
+  replace. Fixed, 14/14 dead.
+- Suites green at every commit; the marketing surface re-read per §10, with its verdict recorded in the
+  plan (including the boring half: the boards were re-read and deliberately not re-rendered).

--- a/maintainers/plans/prospective/release-v4.6.0-pr-body.md
+++ b/maintainers/plans/prospective/release-v4.6.0-pr-body.md
@@ -1,4 +1,4 @@
-## v4.6.0 — <TITLE: the owner's call>
+## v4.6.0 — The One Where It Asks Which One You Mean
 
 Second of the trilogy that came out of one evening on a real deployed brain. v4.5.0 stopped silence from
 passing for good news; this one stops the vault from **poisoning itself**. The brain was writing *about

--- a/scripts/file-back-note.mjs
+++ b/scripts/file-back-note.mjs
@@ -11,15 +11,17 @@
 //
 //   echo '<json spec>' | node scripts/file-back-note.mjs
 //
-// Spec: { type, title, tags[], body, links?[], date?, distinguish? } — date is
-// required for dated types (decision, meeting); `distinguish` is the homonymy
-// block, and a person whose first name the vault already holds is REFUSED until
-// it is given. Exits 0 when written, 1 when refused/error.
+// Spec: { type, title, tags[], body, links?[], date?, distinguish?, confidence? }
+// — date is required for dated types (decision, meeting); `distinguish` is the
+// homonymy block, and a person whose first name the vault already holds is
+// REFUSED until it is given; `confidence` ({level, basis}) is what the card's
+// identity rests on, and a person is REFUSED without it. Exits 0 when written,
+// 1 when refused/error.
 // ─────────────────────────────────────────────────────────────────────────────
 import { readFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { renderFiledNote, homonymCards } from "./lib/filed-note.mjs";
+import { renderFiledNote, homonymCards, CONFIDENCE } from "./lib/filed-note.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
 import { readActiveUniverse, vaultRagDir } from "./lib/universes.mjs";
 
@@ -102,6 +104,21 @@ export function runFileBack(argv, deps = realFileBackDeps) {
     spec = JSON.parse(deps.readInput());
   } catch (err) {
     deps.error(`✗ Invalid JSON spec on stdin: ${err.message}`);
+    return 1;
+  }
+
+  // A person card that does not say what its identity rests on is REFUSED, not
+  // written silently: the builder guarantees form, and a conformant card born of
+  // a guess is indistinguishable from one born of a signed source — which is how
+  // a surname that exists nowhere became the vault's answer to "who is Jérémy".
+  // Required rather than offered: left optional, absence would mean "confirmed".
+  if (spec.type === "person" && !spec.confidence) {
+    deps.error(
+      `✗ vault/ — a person card must say how sure its identity is.\n` +
+        `  Add "confidence": { "level": …, "basis": … } to the spec, where level is one of ` +
+        `${Object.keys(CONFIDENCE).join(", ")},\n` +
+        `  and basis says what the resolution rests on (the source, its date, the card it matched).`,
+    );
     return 1;
   }
 

--- a/scripts/file-back-note.mjs
+++ b/scripts/file-back-note.mjs
@@ -11,13 +11,15 @@
 //
 //   echo '<json spec>' | node scripts/file-back-note.mjs
 //
-// Spec: { type, title, tags[], body, links?[], date? } — date required for
-// dated types (decision, meeting). Exits 0 when written, 1 when refused/error.
+// Spec: { type, title, tags[], body, links?[], date?, distinguish? } — date is
+// required for dated types (decision, meeting); `distinguish` is the homonymy
+// block, and a person whose first name the vault already holds is REFUSED until
+// it is given. Exits 0 when written, 1 when refused/error.
 // ─────────────────────────────────────────────────────────────────────────────
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { renderFiledNote } from "./lib/filed-note.mjs";
+import { renderFiledNote, homonymCards } from "./lib/filed-note.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
 import { readActiveUniverse, vaultRagDir } from "./lib/universes.mjs";
 
@@ -26,6 +28,41 @@ import { readActiveUniverse, vaultRagDir } from "./lib/universes.mjs";
 // break the string match against the vault path and the existence check. Cf.
 // installer toPosix / document-scanner.
 const toPosix = (p) => p.split("\\").join("/");
+
+// Every `people/` card the vault holds, vault-relative: the root's cross-cutting
+// ones AND each universe's own subtree — the same reach the identity discipline
+// asks a resolution to read, so the guard sees what the reader would see. The
+// listing is injected (`io.list` → [{ name, isDirectory }], empty when absent).
+export function listPeopleCards(io, vaultDir) {
+  const cards = [];
+  const collect = (prefix) => {
+    for (const entry of io.list(`${vaultDir}/${prefix}people`)) {
+      if (!entry.isDirectory && entry.name.endsWith(".md"))
+        cards.push(`${prefix}people/${entry.name}`);
+    }
+  };
+  collect("");
+  for (const entry of io.list(vaultDir)) {
+    if (entry.isDirectory && entry.name !== "people") collect(`${entry.name}/`);
+  }
+  return cards;
+}
+
+// The real directory listing. A folder that is not there is "no cards", never a
+// crash: a brain whose vault holds no people/ yet is the ordinary first-week
+// state, and the guard must stay silent then rather than block every write.
+export const realListIo = {
+  list: (dir) => {
+    try {
+      return readdirSync(dir, { withFileTypes: true }).map((entry) => ({
+        name: entry.name,
+        isDirectory: entry.isDirectory(),
+      }));
+    } catch {
+      return [];
+    }
+  },
+};
 
 // Real wiring — the side effects, injected so runFileBack stays unit-testable.
 export const realFileBackDeps = {
@@ -44,6 +81,11 @@ export const realFileBackDeps = {
     ),
   readInput: () => readFileSync(0, "utf8"),
   exists: (p) => existsSync(p),
+  // What the vault already says about who exists — read at write time, because
+  // the model demonstrably does not check (a bare "Jérémy" became a surname that
+  // exists nowhere else). POSIX-formed like the write path, for one comparison
+  // shape across platforms.
+  peopleCards: () => listPeopleCards(realListIo, toPosix(join(process.cwd(), "vault"))),
   writeFile: (p, content) => {
     mkdirSync(dirname(p), { recursive: true });
     writeFileSync(p, content);
@@ -78,6 +120,25 @@ export function runFileBack(argv, deps = realFileBackDeps) {
         `Refine that living page by appending a dated section instead.`,
     );
     return 1;
+  }
+
+  // A person filed under a first name the vault already holds must say WHICH
+  // one, or the card only moves the ambiguity: the identity discipline's
+  // "resolve against the vault" then meets an answer several cards wide.
+  if (spec.type === "person" && !spec.distinguish) {
+    const homonyms = homonymCards(note.path, deps.peopleCards());
+    if (homonyms.length > 0) {
+      const firstName = String(spec.title).trim().split(/\s+/)[0];
+      const many = homonyms.length > 1;
+      deps.error(
+        `✗ vault/${note.path} — ${homonyms.length} ${many ? "cards" : "card"} ` +
+          `already ${many ? "carry" : "carries"} the first name "${firstName}":\n` +
+          homonyms.map((c) => `    ${c}`).join("\n") +
+          `\n  A card that does not say WHICH ${firstName} only moves the ambiguity.` +
+          `\n  Add "distinguish" to the spec (role, org, and what tells them apart), then re-run.`,
+      );
+      return 1;
+    }
   }
 
   deps.writeFile(absPath, note.content);

--- a/scripts/file-back-note.test.mjs
+++ b/scripts/file-back-note.test.mjs
@@ -1,7 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { runFileBack } from "./file-back-note.mjs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runFileBack, listPeopleCards, realListIo, realFileBackDeps } from "./file-back-note.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // file-back-note — the thin CLI glue over the pure filed-note core (ADR 0009
@@ -22,6 +26,7 @@ function fakeDeps(overrides = {}) {
     universe: () => overrides.universe ?? "default",
     readInput: () => overrides.input ?? "{}",
     exists: (p) => existing.has(p),
+    peopleCards: () => overrides.peopleCards ?? [],
     writeFile: (p, content) => writes.push({ path: p, content }),
     log: (line) => logs.push(line),
     error: (line) => errors.push(line),
@@ -48,7 +53,12 @@ test("runFileBack — writes a conformant note under vault/, logs the path, exit
 });
 
 test("runFileBack — files the note under the ACTIVE universe, stamping universe:", () => {
-  const spec = JSON.stringify({ type: "person", title: "Jane Doe", tags: ["team"], body: "b" });
+  const spec = JSON.stringify({
+    type: "person",
+    title: "Jane Doe",
+    tags: ["team"],
+    body: "b",
+  });
   const { deps, logs, writes } = fakeDeps({ input: spec, universe: "acme" });
   const code = runFileBack([], deps);
   assert.equal(code, 0);
@@ -58,7 +68,12 @@ test("runFileBack — files the note under the ACTIVE universe, stamping univers
 });
 
 test("runFileBack — refuses to overwrite an existing note, writes nothing, exits 1", () => {
-  const spec = JSON.stringify({ type: "topic", title: "RAG", tags: ["x"], body: "b" });
+  const spec = JSON.stringify({
+    type: "topic",
+    title: "RAG",
+    tags: ["x"],
+    body: "b",
+  });
   const { deps, errors, writes } = fakeDeps({
     input: spec,
     existing: ["/brain/vault/topics/rag.md"],
@@ -78,10 +93,169 @@ test("runFileBack — invalid JSON on stdin is a fail-loud error, exits 1", () =
 });
 
 test("runFileBack — a spec the core rejects (empty tags) surfaces as exit 1, no write", () => {
-  const spec = JSON.stringify({ type: "topic", title: "X", tags: [], body: "b" });
+  const spec = JSON.stringify({
+    type: "topic",
+    title: "X",
+    tags: [],
+    body: "b",
+  });
   const { deps, errors, writes } = fakeDeps({ input: spec });
   const code = runFileBack([], deps);
   assert.equal(code, 1);
   assert.equal(writes.length, 0);
   assert.match(errors[0], /at least one tag|non-empty/i);
+});
+
+// ── The homonymy guard: a card that does not say WHICH Romain ───────────────
+// Both doors that create a `people/` card (`/file-back` and `/consolidate`)
+// write through this one script, so the check has a single choke point. The
+// field brain carried 3 Romain, 3 Marie, 2 Karim, 2 Caroline and 2 Michael: a
+// new card filed under a first name the vault already holds does not merely
+// look ambiguous, it makes the identity discipline's "resolve against the
+// vault" unusable — the vault's own answer is then three cards wide.
+//
+// Deterministic and refusing, on purpose (the F12 lesson `/consolidate` already
+// carries): the builder KNOWS what the vault holds, and a warning that writes
+// the card anyway renders a caught defect and an ordinary write identically.
+
+test("runFileBack — refuses a person whose first name the vault already holds, naming the homonyms", () => {
+  const spec = JSON.stringify({
+    type: "person",
+    title: "Romain Lefèvre",
+    tags: ["acme"],
+    body: "SRE, joined in March.",
+  });
+  const { deps, errors, writes } = fakeDeps({
+    input: spec,
+    peopleCards: ["people/marie-curie.md", "acme/people/romain-durand.md", "people/romain.md"],
+  });
+  const code = runFileBack([], deps);
+  assert.equal(code, 1);
+  assert.equal(writes.length, 0, "nothing is written until the card says which one");
+  const said = errors.join("\n");
+  assert.match(
+    said,
+    /acme\/people\/romain-durand\.md/,
+    "the writer must not have to go looking again",
+  );
+  assert.match(said, /people\/romain\.md/, "every homonym is named, not just the first");
+  assert.doesNotMatch(said, /marie-curie/, "a card bearing another first name is not a homonym");
+  assert.match(said, /2 cards already carry the first name "Romain"/, "the count and its plural");
+  assert.match(said, /distinguish/, "the refusal must name the field that unblocks it");
+});
+
+test("runFileBack — ONE homonym is refused too, and reads as one card, not '1 cards'", () => {
+  const spec = JSON.stringify({
+    type: "person",
+    title: "Marie Dupont",
+    tags: ["acme"],
+    body: "b",
+  });
+  const { deps, errors, writes } = fakeDeps({
+    input: spec,
+    peopleCards: ["people/marie-curie.md"],
+  });
+  assert.equal(runFileBack([], deps), 1);
+  assert.equal(writes.length, 0);
+  assert.match(errors.join("\n"), /1 card already carries the first name "Marie"/);
+});
+
+test("runFileBack — a person that DOES say which one is written, homonyms and all", () => {
+  const spec = JSON.stringify({
+    type: "person",
+    title: "Romain Lefèvre",
+    tags: ["acme"],
+    body: "SRE, joined in March.",
+    distinguish: "SRE at Acme — not [[people/romain-durand]] (product).",
+  });
+  const { deps, logs, errors, writes } = fakeDeps({
+    input: spec,
+    peopleCards: ["acme/people/romain-durand.md"],
+  });
+  assert.equal(runFileBack([], deps), 0);
+  assert.deepEqual(errors, [], "the guard is a door, not a wall");
+  assert.equal(writes[0].path, "/brain/vault/people/romain-lefevre.md");
+  assert.match(
+    writes[0].content,
+    /# Romain Lefèvre\n\n> \*\*Which one\*\* — SRE at Acme — not \[\[people\/romain-durand\]\] \(product\)\.\n\nSRE, joined in March\.\n$/,
+    "the answer lands in the card itself, above the body, where the next resolution reads it",
+  );
+  assert.deepEqual(logs, ["✓ Filed back: vault/people/romain-lefevre.md"]);
+});
+
+test("runFileBack — the homonymy guard is about PEOPLE: a topic sharing that first segment is written", () => {
+  // `topics/romain-rolland.md` next to `people/romain-durand.md` is not an
+  // identity collision at all — nothing will ever be resolved to a topic.
+  const spec = JSON.stringify({
+    type: "topic",
+    title: "Romain Rolland",
+    tags: ["x"],
+    body: "b",
+  });
+  const { deps, errors, writes } = fakeDeps({
+    input: spec,
+    peopleCards: ["people/romain-durand.md"],
+  });
+  assert.equal(runFileBack([], deps), 0);
+  assert.deepEqual(errors, []);
+  assert.equal(writes[0].path, "/brain/vault/topics/romain-rolland.md");
+});
+
+// ── The real listing: which people cards the vault actually holds ───────────
+// The guard is only as honest as what it is handed. Kept behind an io seam so
+// every branch is reachable (§6): a vault with no people/ at all, the root's
+// cross-cutting cards, and each universe's own subtree — the three shapes the
+// resolution rule reads.
+
+test("listPeopleCards — collects the root's cards and every universe's, ignoring non-notes", () => {
+  const io = {
+    list: (dir) =>
+      ({
+        "/brain/vault": [
+          { name: "people", isDirectory: true },
+          { name: "acme", isDirectory: true },
+          { name: "topics", isDirectory: true },
+          { name: "README.md", isDirectory: false },
+        ],
+        "/brain/vault/people": [
+          { name: "jane-doe.md", isDirectory: false },
+          { name: ".DS_Store", isDirectory: false },
+          { name: "drafts", isDirectory: true },
+        ],
+        "/brain/vault/acme/people": [{ name: "romain-durand.md", isDirectory: false }],
+        "/brain/vault/topics/people": [],
+      })[dir] ?? [],
+  };
+  assert.deepEqual(listPeopleCards(io, "/brain/vault"), [
+    "people/jane-doe.md",
+    "acme/people/romain-durand.md",
+  ]);
+});
+
+test("realListIo — maps a real folder's entries, and reads a missing one as 'no cards'", () => {
+  const dir = mkdtempSync(join(tmpdir(), "file-back-list-"));
+  mkdirSync(join(dir, "drafts"));
+  writeFileSync(join(dir, "jane-doe.md"), "x");
+  assert.deepEqual(
+    realListIo.list(dir).sort((a, b) => a.name.localeCompare(b.name)),
+    [
+      { name: "drafts", isDirectory: true },
+      { name: "jane-doe.md", isDirectory: false },
+    ],
+  );
+  // A brain with no people/ yet is the ordinary first-week state, not a crash.
+  assert.deepEqual(realListIo.list(join(dir, "nope")), []);
+});
+
+test("realFileBackDeps.peopleCards — reads the vault under the CURRENT brain folder", () => {
+  const brain = mkdtempSync(join(tmpdir(), "file-back-brain-"));
+  mkdirSync(join(brain, "vault", "acme", "people"), { recursive: true });
+  writeFileSync(join(brain, "vault", "acme", "people", "romain-durand.md"), "x");
+  const previous = process.cwd();
+  try {
+    process.chdir(brain);
+    assert.deepEqual(realFileBackDeps.peopleCards(), ["acme/people/romain-durand.md"]);
+  } finally {
+    process.chdir(previous);
+  }
 });

--- a/scripts/file-back-note.test.mjs
+++ b/scripts/file-back-note.test.mjs
@@ -1,9 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { runFileBack, listPeopleCards, realListIo, realFileBackDeps } from "./file-back-note.mjs";
 
@@ -82,7 +84,25 @@ test("runFileBack — refuses to overwrite an existing note, writes nothing, exi
   const code = runFileBack([], deps);
   assert.equal(code, 1);
   assert.equal(writes.length, 0);
-  assert.match(errors[0], /topics\/rag\.md already exists.*never overwrites/i);
+  // Whole: the second sentence is the only one telling the writer what to do
+  // INSTEAD, and a refusal without it reads as a dead end.
+  assert.equal(
+    errors[0],
+    "✗ vault/topics/rag.md already exists — filing back never overwrites. " +
+      "Refine that living page by appending a dated section instead.",
+  );
+});
+
+test("runFileBack — a Windows brain path is compared and written in POSIX form", () => {
+  // On Windows join() yields backslashes; the vault path is matched as a string
+  // and handed to the existence check, so one mixed form on either side is a
+  // note written where nothing looks for it. Fed on purpose here: CI runs the
+  // suite on macOS too, where nothing else tells this apart from the identity.
+  const spec = JSON.stringify({ type: "topic", title: "RAG", tags: ["x"], body: "b" });
+  const { deps, writes } = fakeDeps({ input: spec });
+  deps.cwd = () => "C:\\brains\\mind-palace";
+  assert.equal(runFileBack([], deps), 0);
+  assert.equal(writes[0].path, "C:/brains/mind-palace/vault/topics/rag.md");
 });
 
 test("runFileBack — invalid JSON on stdin is a fail-loud error, exits 1", () => {
@@ -144,6 +164,37 @@ test("runFileBack — refuses a person whose first name the vault already holds,
   assert.doesNotMatch(said, /marie-curie/, "a card bearing another first name is not a homonym");
   assert.match(said, /2 cards already carry the first name "Romain"/, "the count and its plural");
   assert.match(said, /distinguish/, "the refusal must name the field that unblocks it");
+  // Asserted WHOLE, not by fragment: this text is the product here — the two
+  // lines that say why the card is refused and what unblocks it could each go
+  // missing with every match above still green, leaving a bare list of paths.
+  assert.equal(
+    errors[0],
+    '✗ vault/people/romain-lefevre.md — 2 cards already carry the first name "Romain":\n' +
+      "    acme/people/romain-durand.md\n" +
+      "    people/romain.md\n" +
+      "  A card that does not say WHICH Romain only moves the ambiguity.\n" +
+      '  Add "distinguish" to the spec (role, org, and what tells them apart), then re-run.',
+  );
+});
+
+test("runFileBack — the first name it quotes back survives a stray leading space", () => {
+  // Models hand over titles with stray whitespace; untrimmed, the message would
+  // name the first name as "" while still refusing — a refusal that cannot be
+  // acted on.
+  const spec = JSON.stringify({
+    type: "person",
+    title: " Romain Lefèvre",
+    tags: ["acme"],
+    body: "b",
+    confidence: { level: "observed", basis: "the Acme org chart, 2026-03." },
+  });
+  const { deps, errors } = fakeDeps({
+    input: spec,
+    peopleCards: ["acme/people/romain-durand.md"],
+  });
+  assert.equal(runFileBack([], deps), 1);
+  assert.match(errors[0], /the first name "Romain"/);
+  assert.match(errors[0], /WHICH Romain only moves the ambiguity/);
 });
 
 test("runFileBack — ONE homonym is refused too, and reads as one card, not '1 cards'", () => {
@@ -212,6 +263,16 @@ test("runFileBack — refuses a person card that does not say how sure its ident
     /observed.*probable.*unverified/s,
     "and the scale it accepts, so the writer does not invent a fourth level",
   );
+  // Whole, for the same reason as the homonymy refusal: the sentence saying what
+  // a basis IS is the only thing standing between "confidence" and a field
+  // filled with the word "yes".
+  assert.equal(
+    errors[0],
+    "✗ vault/ — a person card must say how sure its identity is.\n" +
+      '  Add "confidence": { "level": …, "basis": … } to the spec, where level is one of ' +
+      "observed, probable, unverified,\n" +
+      "  and basis says what the resolution rests on (the source, its date, the card it matched).",
+  );
 });
 
 test("runFileBack — the homonymy guard is about PEOPLE: a topic sharing that first segment is written", () => {
@@ -263,6 +324,36 @@ test("listPeopleCards — collects the root's cards and every universe's, ignori
   ]);
 });
 
+test("listPeopleCards — asks for exactly the folders a resolution reads, and no others", () => {
+  // The fake RECORDS what it is handed: without that, "walks the universe
+  // subtrees" and "walks everything at the root" are the same call — a file
+  // mistaken for a folder, or `people/` walked into itself, both come back
+  // empty and read as correct.
+  const asked = [];
+  const io = {
+    list: (dir) => {
+      asked.push(dir);
+      return (
+        {
+          "/brain/vault": [
+            { name: "people", isDirectory: true },
+            { name: "acme", isDirectory: true },
+            { name: "notes.md", isDirectory: false },
+          ],
+          "/brain/vault/people": [{ name: "jane-doe.md", isDirectory: false }],
+          "/brain/vault/acme/people": [{ name: "romain-durand.md", isDirectory: false }],
+        }[dir] ?? []
+      );
+    },
+  };
+  listPeopleCards(io, "/brain/vault");
+  assert.deepEqual(
+    asked,
+    ["/brain/vault/people", "/brain/vault", "/brain/vault/acme/people"],
+    "the root's cards, the vault listing, then each universe's people/ — nothing else",
+  );
+});
+
 test("realListIo — maps a real folder's entries, and reads a missing one as 'no cards'", () => {
   const dir = mkdtempSync(join(tmpdir(), "file-back-list-"));
   mkdirSync(join(dir, "drafts"));
@@ -276,6 +367,79 @@ test("realListIo — maps a real folder's entries, and reads a missing one as 'n
   );
   // A brain with no people/ yet is the ordinary first-week state, not a crash.
   assert.deepEqual(realListIo.list(join(dir, "nope")), []);
+});
+
+// ── The real wiring, run the way the brain runs it ─────────────────────────
+// Every test above injects its own deps, so `realFileBackDeps` and the
+// entrypoint guard were observed by nothing: the whole file could be wired to
+// write nowhere, read no stdin and log nothing, with the suite still green.
+// One real child process closes that: it is the only thing here that reaches
+// the stdin read, the recursive mkdir, the existence check and the exit code.
+
+test("file-back-note, as a real process — reads stdin, creates the folders, exits 0", () => {
+  const brain = mkdtempSync(join(tmpdir(), "file-back-e2e-"));
+  const spec = JSON.stringify({
+    type: "topic",
+    title: "Capacity Management",
+    tags: ["rag"],
+    body: "The distilled answer.",
+  });
+  const run = (input) =>
+    spawnSync(process.execPath, [fileURLToPath(new URL("./file-back-note.mjs", import.meta.url))], {
+      cwd: brain,
+      input,
+      encoding: "utf8",
+    });
+
+  // No vault/ at all — the ordinary shape of a brand-new brain. Two levels are
+  // missing, so a non-recursive mkdir fails here and a recursive one does not.
+  const first = run(spec);
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(first.stdout.trim(), "✓ Filed back: vault/topics/capacity-management.md");
+  const written = readFileSync(join(brain, "vault", "topics", "capacity-management.md"), "utf8");
+  const today = new Date().toISOString().slice(0, 10);
+  assert.match(written, new RegExp(`^---\\ntype: topic\\ncreated: ${today}\\nupdated: ${today}\\n`));
+  assert.match(written, /\n# Capacity Management\n\nThe distilled answer\.\n$/);
+
+  // And the same spec twice does not overwrite the first one.
+  const second = run(spec);
+  assert.equal(second.status, 1);
+  assert.match(second.stderr, /already exists — filing back never overwrites/);
+});
+
+test("file-back-note, as a real process — files under the universe the pointer names", () => {
+  const brain = mkdtempSync(join(tmpdir(), "file-back-universe-"));
+  mkdirSync(join(brain, ".vault-rag"), { recursive: true });
+  writeFileSync(join(brain, ".vault-rag", "active-universe"), "acme\n");
+  writeFileSync(
+    join(brain, ".vault-rag", "universes.json"),
+    JSON.stringify({ universes: ["acme"] }),
+  );
+  const run = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL("./file-back-note.mjs", import.meta.url))],
+    {
+      cwd: brain,
+      input: JSON.stringify({ type: "topic", title: "Billing", tags: ["x"], body: "b" }),
+      encoding: "utf8",
+    },
+  );
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stdout.trim(), "✓ Filed back: vault/acme/topics/billing.md");
+  assert.match(
+    readFileSync(join(brain, "vault", "acme", "topics", "billing.md"), "utf8"),
+    /\nuniverse: acme\n---\n/,
+  );
+});
+
+test("realFileBackDeps — the real ports are what they claim, field by field", () => {
+  assert.equal(realFileBackDeps.cwd(), process.cwd());
+  assert.equal(realFileBackDeps.today(), new Date().toISOString().slice(0, 10));
+  assert.match(realFileBackDeps.today(), /^\d{4}-\d{2}-\d{2}$/, "a date stamp, not an instant");
+  assert.equal(realFileBackDeps.log, realFileBackDeps.log);
+  assert.equal(typeof realFileBackDeps.exists, "function");
+  assert.equal(realFileBackDeps.exists(process.cwd()), true);
+  assert.equal(realFileBackDeps.exists(join(process.cwd(), "no-such-file-here")), false);
 });
 
 test("realFileBackDeps.peopleCards — reads the vault under the CURRENT brain folder", () => {

--- a/scripts/file-back-note.test.mjs
+++ b/scripts/file-back-note.test.mjs
@@ -58,6 +58,7 @@ test("runFileBack — files the note under the ACTIVE universe, stamping univers
     title: "Jane Doe",
     tags: ["team"],
     body: "b",
+    confidence: { level: "observed", basis: "her own intro in #general, 2026-07-17." },
   });
   const { deps, logs, writes } = fakeDeps({ input: spec, universe: "acme" });
   const code = runFileBack([], deps);
@@ -124,6 +125,7 @@ test("runFileBack — refuses a person whose first name the vault already holds,
     title: "Romain Lefèvre",
     tags: ["acme"],
     body: "SRE, joined in March.",
+    confidence: { level: "observed", basis: "the Acme org chart, 2026-03." },
   });
   const { deps, errors, writes } = fakeDeps({
     input: spec,
@@ -150,6 +152,7 @@ test("runFileBack — ONE homonym is refused too, and reads as one card, not '1 
     title: "Marie Dupont",
     tags: ["acme"],
     body: "b",
+    confidence: { level: "observed", basis: "the Acme org chart." },
   });
   const { deps, errors, writes } = fakeDeps({
     input: spec,
@@ -167,6 +170,7 @@ test("runFileBack — a person that DOES say which one is written, homonyms and 
     tags: ["acme"],
     body: "SRE, joined in March.",
     distinguish: "SRE at Acme — not [[people/romain-durand]] (product).",
+    confidence: { level: "observed", basis: "the Acme org chart, 2026-03." },
   });
   const { deps, logs, errors, writes } = fakeDeps({
     input: spec,
@@ -177,10 +181,37 @@ test("runFileBack — a person that DOES say which one is written, homonyms and 
   assert.equal(writes[0].path, "/brain/vault/people/romain-lefevre.md");
   assert.match(
     writes[0].content,
-    /# Romain Lefèvre\n\n> \*\*Which one\*\* — SRE at Acme — not \[\[people\/romain-durand\]\] \(product\)\.\n\nSRE, joined in March\.\n$/,
-    "the answer lands in the card itself, above the body, where the next resolution reads it",
+    /# Romain Lefèvre\n\n> \*\*Which one\*\* — SRE at Acme — not \[\[people\/romain-durand\]\] \(product\)\.\n\n> \*\*Confidence\*\* — ✅ observed · the Acme org chart, 2026-03\.\n\nSRE, joined in March\.\n$/,
+    "both answers land in the card itself, above the body, in that order: which one, then how sure",
   );
   assert.deepEqual(logs, ["✓ Filed back: vault/people/romain-lefevre.md"]);
+});
+
+// ── Conformant ≠ true: the card must say what its identity rests on ─────────
+// The builder guarantees FORM — right path, complete frontmatter, green lint —
+// and the vault then reads that form as substance. A card resolved from a bare
+// "Jérémy (front Candor)" came out looking exactly like one resolved from a
+// signed org chart, and became what every later resolution resolved against.
+// So the level is REQUIRED on a person, not offered: left optional, its absence
+// would mean "confirmed", which is silence rendered as confidence.
+
+test("runFileBack — refuses a person card that does not say how sure its identity is", () => {
+  const spec = JSON.stringify({
+    type: "person",
+    title: "Jérémy Hinard",
+    tags: ["candor"],
+    body: "Front-end at Candor.",
+  });
+  const { deps, errors, writes } = fakeDeps({ input: spec });
+  assert.equal(runFileBack([], deps), 1);
+  assert.equal(writes.length, 0, "an unbacked identity must not reach the vault at all");
+  const said = errors.join("\n");
+  assert.match(said, /confidence/, "the refusal must name the field that unblocks it");
+  assert.match(
+    said,
+    /observed.*probable.*unverified/s,
+    "and the scale it accepts, so the writer does not invent a fourth level",
+  );
 });
 
 test("runFileBack — the homonymy guard is about PEOPLE: a topic sharing that first segment is written", () => {

--- a/scripts/lib/claim-discipline.test.mjs
+++ b/scripts/lib/claim-discipline.test.mjs
@@ -173,6 +173,27 @@ for (const { locale, path } of SKILLS.filter((s) => s.name === "prepare-1-1")) {
   });
 }
 
+// ── The markers rule applies to the SECTION, not to the last bullet ────────
+// Found by review, EN only, verified against the FR sibling which had it right:
+// a missing blank line makes "Markers are mandatory here too…" a lazy
+// continuation of the preceding list item under CommonMark, so the rule that
+// governs the whole section renders as a tail of one bullet about reconciling.
+// Cosmetic to an LLM reader, real EN/FR drift to a human one — and this file is
+// read by both.
+for (const { locale, path } of SKILLS.filter((s) => s.name === "prepare-1-1")) {
+  test(`${locale} prepare-1-1: the markers rule stands on its own, not as a bullet's tail`, () => {
+    const marker = locale === "FR" ? /^Les marqueurs sont obligatoires/m : /^Markers are mandatory/m;
+    const text = read(path);
+    const at = text.search(marker);
+    assert.notEqual(at, -1, "the markers rule must still be there at the start of a line");
+    assert.equal(
+      text.slice(0, at).endsWith("\n\n"),
+      true,
+      "without a blank line above it, CommonMark folds the rule into the previous bullet",
+    );
+  });
+}
+
 // ── A recorded absence is a measurement, and measurements expire ───────────
 // The vault had written down, as a PERMANENT limitation, that "the Slack
 // connector does not expose permalinks", propagated it into several notes, and

--- a/scripts/lib/claim-discipline.test.mjs
+++ b/scripts/lib/claim-discipline.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { docSection } from "./doc-section.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // F18 — the claim discipline must exist on EVERY surface that produces an
@@ -31,29 +32,10 @@ import { dirname, join } from "node:path";
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const read = (rel) => readFileSync(join(REPO_ROOT, rel), "utf8");
 
-// Slice the discipline SECTION out of a document — from its heading to the next
-// heading of the same or a higher level — and assert inside that slice only.
-//
-// This is deliberate, and the first red run is why: asserting on the whole file
-// let three rules pass on words that were already there for other reasons
-// ("your FIRST reply of the session" matched /repl(y|ies)/, "contradictory rules"
-// matched /contradict/). A rule that passes because of unrelated prose is a rule
-// nobody is actually carrying. Slicing also asserts something the flat search
-// could not: the rules live TOGETHER, as one discipline, instead of being
-// scattered where no reader meets them as a whole.
-function disciplineSection(text, heading) {
-  const start = text.search(heading);
-  if (start === -1) return "";
-  const level = (text.slice(start).match(/^#+/) ?? ["#"])[0].length;
-  // Start looking for the NEXT heading only after the current heading's own line —
-  // otherwise the very first thing found is the heading we started from, and every
-  // section slices down to a single "#".
-  const nl = text.indexOf("\n", start);
-  if (nl === -1) return text.slice(start);
-  const rest = text.slice(nl + 1);
-  const end = rest.search(new RegExp(`^#{1,${level}} `, "m"));
-  return end === -1 ? text.slice(start) : text.slice(start, nl + 1 + end);
-}
+// The discipline SECTION of a document, sliced from its heading to the next
+// heading of the same or a higher level — asserted inside that slice only, for
+// the reasons written in doc-section.mjs (the identity guard shares it).
+const disciplineSection = docSection;
 
 const HEADING_EN = /^#+ Claim discipline/m;
 const HEADING_FR = /^#+ Discipline d'affirmation/m;

--- a/scripts/lib/claim-discipline.test.mjs
+++ b/scripts/lib/claim-discipline.test.mjs
@@ -183,7 +183,11 @@ for (const { locale, path } of SKILLS.filter((s) => s.name === "prepare-1-1")) {
 for (const { locale, path } of SKILLS.filter((s) => s.name === "prepare-1-1")) {
   test(`${locale} prepare-1-1: the markers rule stands on its own, not as a bullet's tail`, () => {
     const marker = locale === "FR" ? /^Les marqueurs sont obligatoires/m : /^Markers are mandatory/m;
-    const text = read(path);
+    // Line endings normalised FIRST: git checks these files out with CRLF on
+    // Windows, so a guard comparing against "\n\n" fails there on typography
+    // rather than on meaning — the failure this repo has now met three times
+    // (CONVENTIONS §9). What is asserted is the blank line, not its bytes.
+    const text = read(path).split("\r\n").join("\n");
     const at = text.search(marker);
     assert.notEqual(at, -1, "the markers rule must still be there at the start of a line");
     assert.equal(

--- a/scripts/lib/doc-section.mjs
+++ b/scripts/lib/doc-section.mjs
@@ -1,0 +1,29 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// doc-section.mjs — slice ONE section out of a Markdown document: from its
+// heading down to the next heading of the same or a higher level.
+//
+// Why the doc guards need this rather than a flat search over the file: asserting
+// on a whole file lets a rule pass on words that were already there for other
+// reasons (F18's first red run — "your FIRST reply of the session" matched
+// /repl(y|ies)/, "contradictory rules" matched /contradict/). A rule that passes
+// because of unrelated prose is a rule nobody is actually carrying. Slicing also
+// asserts something a flat search cannot: that the rules live TOGETHER, as one
+// discipline, instead of being scattered where no reader meets them as a whole.
+//
+// Extracted from claim-discipline.test.mjs when the identity guard needed the
+// same cut: two guards slicing differently would judge two different documents.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function docSection(text, heading) {
+  const start = text.search(heading);
+  if (start === -1) return "";
+  const level = (text.slice(start).match(/^#+/) ?? ["#"])[0].length;
+  // Start looking for the NEXT heading only after the current heading's own line —
+  // otherwise the very first thing found is the heading we started from, and every
+  // section slices down to a single "#".
+  const nl = text.indexOf("\n", start);
+  if (nl === -1) return text.slice(start);
+  const rest = text.slice(nl + 1);
+  const end = rest.search(new RegExp(`^#{1,${level}} `, "m"));
+  return end === -1 ? text.slice(start) : text.slice(start, nl + 1 + end);
+}

--- a/scripts/lib/doc-section.test.mjs
+++ b/scripts/lib/doc-section.test.mjs
@@ -1,0 +1,80 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { docSection } from "./doc-section.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// doc-section — the cut every doc guard reads through. It had no test of its
+// own: both guard families exercised it only indirectly, against real
+// documents where a degraded slice still happened to contain the words they
+// were looking for. That is the fiction the file exists to prevent, one level
+// up — a slicer that quietly returns the whole document turns every sliced
+// guard back into the flat search it was extracted from, and nothing goes red.
+// So: exact slices, asserted whole.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const DOC = [
+  "# Title",
+  "",
+  "Intro prose.",
+  "",
+  "## Identity discipline",
+  "",
+  "Rule 1.",
+  "",
+  "### A sub-rule",
+  "",
+  "Still inside the section.",
+  "",
+  "## Claim discipline",
+  "",
+  "Rule elsewhere.",
+  "",
+].join("\n");
+
+test("docSection — cuts at the next heading of the SAME level, sub-headings included", () => {
+  assert.equal(
+    docSection(DOC, /^## Identity discipline/m),
+    ["## Identity discipline", "", "Rule 1.", "", "### A sub-rule", "", "Still inside the section.", "", ""].join(
+      "\n",
+    ),
+  );
+});
+
+test("docSection — a HIGHER-level heading ends the section too", () => {
+  const doc = ["## Section", "", "Body.", "", "# Next chapter", "", "Elsewhere.", ""].join("\n");
+  assert.equal(docSection(doc, /^## Section/m), ["## Section", "", "Body.", "", ""].join("\n"));
+});
+
+test("docSection — the LAST section runs to the end of the document", () => {
+  assert.equal(
+    docSection(DOC, /^## Claim discipline/m),
+    ["## Claim discipline", "", "Rule elsewhere.", ""].join("\n"),
+  );
+});
+
+test("docSection — a heading that is not there is an EMPTY slice, never a stray tail", () => {
+  // The guards read this as "the section is missing" and go red. Anything else
+  // — the last character of the file, a fragment — is a rule judged against
+  // text it has nothing to do with.
+  assert.equal(docSection(DOC, /^## Nowhere to be found/m), "");
+});
+
+test("docSection — a document ending ON its heading line, with no newline after it", () => {
+  const doc = "# Title\n\nProse.\n\n## Trailing heading";
+  assert.equal(docSection(doc, /^## Trailing heading/m), "## Trailing heading");
+});
+
+test("docSection — a pattern matching mid-line falls back to level 1, not to the next '#' it finds", () => {
+  // The heading level is read at the START of the match. A pattern that lands
+  // mid-line has no leading '#' there, and the fallback must be the widest
+  // level (1) — reading a deeper '#' further down would cut the section at a
+  // sub-heading and hide half of it from the guard.
+  const doc = ["Prose mentioning Identity discipline here.", "", "### Deep", "", "x", "", "# Chapter", "", "y", ""].join(
+    "\n",
+  );
+  assert.equal(
+    docSection(doc, /Identity discipline here\./),
+    ["Identity discipline here.", "", "### Deep", "", "x", "", ""].join("\n"),
+  );
+});

--- a/scripts/lib/engine-version.mjs
+++ b/scripts/lib/engine-version.mjs
@@ -1,18 +1,29 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// engine-version.mjs — pure helper that turns an engine-manifest.json into the
-// short, user-facing version label shown OFFLINE in the status-line (ADR 0017).
+// engine-version.mjs — pure helpers that turn an engine-manifest.json into the
+// short, user-facing version labels shown OFFLINE (zero network, zero coupling).
 //
 // The displayed version is the git TAG the brain was generated / last-updated
 // from — i.e. the manifest's `source.ref`, recorded at install (Phase 1). It is
 // NOT a hand-maintained number: a tag is an intentional, maintainer-controlled
-// release act, read here with zero network and zero coupling.
+// release act.
+//
+// TWO labels, one resolution, and the difference between them is deliberate:
+//   • `formatEngineVersion` — the status-line label (ADR 0017). Says "engine",
+//     which claims nothing about WHICH product, so it can fall back to the `rag`
+//     package number when the brain recorded no source.
+//   • `startupVersionLine` — the session-start segment (owner's request,
+//     2026-08-03). Says "Kenjaku engine", so it may only ever show a real install
+//     ref: `engineVersion.rag` (1.3.0) has never been a Kenjaku release number
+//     (v4.5.0), and an owner reading "Kenjaku engine 1.3.0" would report a version
+//     that does not exist. No ref → no segment. Naming that state out loud
+//     ("version unknown") belongs to F3, in v4.7.0.
 //
 // Fallbacks (never invent a version):
 //   • `source.ref` present (any string — semver tag OR a branch/commit) → show it
 //     verbatim. The semver-vs-not distinction only matters to the (deferred)
 //     "update available" check, never to this display.
 //   • no usable `source.ref` (e.g. the launcher records no `source`) → last
-//     resort `engineVersion.rag`.
+//     resort `engineVersion.rag`, for the status-line label ONLY (see above).
 //   • nothing usable / missing / invalid manifest → null (the caller emits no
 //     segment — fail-silent).
 // ─────────────────────────────────────────────────────────────────────────────
@@ -21,11 +32,25 @@ function nonEmptyString(value) {
   return typeof value === "string" && value.trim() !== "";
 }
 
+// The one reader of "which engine point was this brain installed from" — shared,
+// so the two labels can never disagree about what the brain is running.
+function installRef(manifest) {
+  const ref = manifest?.source?.ref;
+  return nonEmptyString(ref) ? ref : null;
+}
+
+// The session-start segment, or null when this brain cannot say which Kenjaku
+// release it came from.
+export function startupVersionLine(manifest) {
+  const ref = installRef(manifest);
+  return ref === null ? null : `⚙️ Kenjaku engine ${ref}`;
+}
+
 export function formatEngineVersion(manifest) {
   if (!manifest || typeof manifest !== "object") return null;
 
-  const ref = manifest.source?.ref;
-  if (nonEmptyString(ref)) return `engine ${ref}`;
+  const ref = installRef(manifest);
+  if (ref !== null) return `engine ${ref}`;
 
   const rag = manifest.engineVersion?.rag;
   if (nonEmptyString(rag)) return `engine ${rag}`;

--- a/scripts/lib/engine-version.mjs
+++ b/scripts/lib/engine-version.mjs
@@ -46,6 +46,17 @@ export function startupVersionLine(manifest) {
   return ref === null ? null : `⚙️ Kenjaku engine ${ref}`;
 }
 
+// The startup segment read from disk, with I/O injected so both the branch and
+// its fail-silent twin stay reachable from a test.
+export function readStartupVersionLine({ manifestPath, existsSync, readFileSync }) {
+  if (!existsSync(manifestPath)) return null;
+  try {
+    return startupVersionLine(JSON.parse(readFileSync(manifestPath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
 export function formatEngineVersion(manifest) {
   if (!manifest || typeof manifest !== "object") return null;
 

--- a/scripts/lib/engine-version.test.mjs
+++ b/scripts/lib/engine-version.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { formatEngineVersion } from "./engine-version.mjs";
+import { formatEngineVersion, startupVersionLine } from "./engine-version.mjs";
 
 test("formatEngineVersion — semver tag ref → 'engine <tag>'", () => {
   assert.equal(
@@ -40,4 +40,49 @@ test("formatEngineVersion — missing/invalid manifest → null", () => {
   assert.equal(formatEngineVersion(undefined), null);
   assert.equal(formatEngineVersion("nope"), null);
   assert.equal(formatEngineVersion(42), null);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The SESSION-START segment (owner's request, 2026-08-03: "j'aimerai que tu
+// rajoutes la version de Kenjaku au démarrage").
+//
+// Same resolution as the status-line label, a different LABEL: this one is read
+// by a human at every session start, so it names the product ("Kenjaku engine
+// v4.5.0", chosen by the owner) rather than the bare "engine v4.5.0" the retired
+// status line used.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("startupVersionLine — the tag the brain was installed from → the startup segment", () => {
+  assert.equal(
+    startupVersionLine({ source: { repo: "https://x", ref: "v4.5.0" } }),
+    "⚙️ Kenjaku engine v4.5.0",
+  );
+});
+
+test("startupVersionLine — a non-semver ref (branch/commit) is shown verbatim, never dressed up as a release", () => {
+  assert.equal(startupVersionLine({ source: { ref: "main" } }), "⚙️ Kenjaku engine main");
+  assert.equal(startupVersionLine({ source: { ref: "e6bfba0" } }), "⚙️ Kenjaku engine e6bfba0");
+});
+
+// The one decision worth not re-deriving: with no `source.ref`, this brain does
+// NOT know which Kenjaku release it came from, and `engineVersion.rag` is a
+// package number (1.3.0) that has never matched the release (v4.5.0). Printing
+// "Kenjaku engine 1.3.0" would send an owner to report a version that does not
+// exist — so the segment is DROPPED instead. (The status-line label keeps that
+// fallback: it says "engine", claiming nothing about the product's release.)
+// Naming that state out loud belongs to F3 in v4.7.0, which owns "unknown".
+test("startupVersionLine — no ref → NO segment, never the rag package number dressed as a release", () => {
+  assert.equal(startupVersionLine({ engineVersion: { rag: "1.3.0" } }), null);
+  assert.equal(startupVersionLine({ source: { repo: "https://x", ref: "" } , engineVersion: { rag: "1.3.0" } }), null);
+});
+
+// The absence twin of every `?.` above: a brain whose manifest is missing or
+// unreadable must lose the segment, never crash the SessionStart hook that
+// carries the repo and RAG lines with it.
+test("startupVersionLine — missing/invalid manifest → null (fail-silent, never throws)", () => {
+  assert.equal(startupVersionLine(null), null);
+  assert.equal(startupVersionLine(undefined), null);
+  assert.equal(startupVersionLine("nope"), null);
+  assert.equal(startupVersionLine(42), null);
+  assert.equal(startupVersionLine({}), null);
 });

--- a/scripts/lib/engine-version.test.mjs
+++ b/scripts/lib/engine-version.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { formatEngineVersion, startupVersionLine } from "./engine-version.mjs";
+import { formatEngineVersion, startupVersionLine, readStartupVersionLine } from "./engine-version.mjs";
 
 test("formatEngineVersion — semver tag ref → 'engine <tag>'", () => {
   assert.equal(
@@ -85,4 +85,61 @@ test("startupVersionLine — missing/invalid manifest → null (fail-silent, nev
   assert.equal(startupVersionLine("nope"), null);
   assert.equal(startupVersionLine(42), null);
   assert.equal(startupVersionLine({}), null);
+});
+
+// ── The reader, with its I/O injected ──────────────────────────────────────
+// The two callers are top-level scripts no test can import, so the file read +
+// JSON.parse + fail-silent catch would live where nothing can reach them (§6 of
+// the TDD discipline: "not testable here" means "extract a seam").
+test("readStartupVersionLine — reads the brain's manifest and labels what it found", () => {
+  const seen = [];
+  const line = readStartupVersionLine({
+    manifestPath: "/brains/mind-palace/engine-manifest.json",
+    existsSync: (p) => { seen.push(["exists", p]); return true; },
+    readFileSync: (p, enc) => {
+      seen.push(["read", p, enc]);
+      return JSON.stringify({ source: { ref: "v4.5.0" } });
+    },
+  });
+  assert.equal(line, "⚙️ Kenjaku engine v4.5.0");
+  assert.deepEqual(seen, [
+    ["exists", "/brains/mind-palace/engine-manifest.json"],
+    ["read", "/brains/mind-palace/engine-manifest.json", "utf8"],
+  ]);
+});
+
+// Both fail-silent twins, each as the SOLE reason (§9): a brain with no manifest
+// at all, and a manifest that is on disk but unreadable / not JSON. Either one
+// must cost the segment, never the SessionStart hook that carries the repo and
+// RAG lines with it.
+test("readStartupVersionLine — no manifest → null, and the file is never read", () => {
+  let read = 0;
+  assert.equal(
+    readStartupVersionLine({
+      manifestPath: "/brains/fresh-clone/engine-manifest.json",
+      existsSync: () => false,
+      readFileSync: () => { read += 1; return "{}"; },
+    }),
+    null,
+  );
+  assert.equal(read, 0, "a missing manifest must not be read");
+});
+
+test("readStartupVersionLine — unparseable manifest → null, never throws", () => {
+  assert.equal(
+    readStartupVersionLine({
+      manifestPath: "/brains/x/engine-manifest.json",
+      existsSync: () => true,
+      readFileSync: () => "{ this is not json",
+    }),
+    null,
+  );
+  assert.equal(
+    readStartupVersionLine({
+      manifestPath: "/brains/x/engine-manifest.json",
+      existsSync: () => true,
+      readFileSync: () => { throw new Error("EACCES"); },
+    }),
+    null,
+  );
 });

--- a/scripts/lib/engine-version.test.mjs
+++ b/scripts/lib/engine-version.test.mjs
@@ -143,3 +143,12 @@ test("readStartupVersionLine — unparseable manifest → null, never throws", (
     null,
   );
 });
+
+test("a ref made of whitespace is NOT a version — it falls back like an absent one", () => {
+  // "engine    " and "⚙️ Kenjaku engine    " are labels that look like they say
+  // something and say nothing: the exact conflation the null case exists for.
+  const manifest = { source: { ref: "   " }, engineVersion: { rag: "1.3.0" } };
+  assert.equal(startupVersionLine(manifest), null);
+  assert.equal(formatEngineVersion(manifest), "engine 1.3.0");
+  assert.equal(formatEngineVersion({ source: { ref: "\t\n" } }), null);
+});

--- a/scripts/lib/filed-note.mjs
+++ b/scripts/lib/filed-note.mjs
@@ -87,6 +87,25 @@ export function renderFiledNote(spec) {
   ].join("\n");
   const related =
     links.length > 0 ? `\n## Related\n\n${links.map((l) => `- [[${l}]]`).join("\n")}\n` : "";
-  const content = `${frontmatter}\n\n# ${spec.title}\n\n${spec.body}\n${related}`;
+  // The homonymy block sits ABOVE the body, because it is what makes the card
+  // usable to the next resolution: a first name is rarely unique, and a card
+  // that does not say which one only moves the ambiguity.
+  const which = spec.distinguish ? `> **Which one** — ${spec.distinguish}\n\n` : "";
+  const content = `${frontmatter}\n\n# ${spec.title}\n\n${which}${spec.body}\n${related}`;
   return { path, content };
+}
+
+// The first-name segment of a people-card path: `acme/people/romain-durand.md`
+// → `romain`. Cards are named `<firstname>-<lastname>.md` (slugified, so already
+// accent-free and lowercased), which is what makes the shared first name a
+// mechanical fact rather than a judgement call.
+function firstNameSegment(cardPath) {
+  return cardPath.split("/").pop().replace(/\.md$/, "").split("-")[0];
+}
+
+// The existing `people/` cards that already bear the first name a new card is
+// about to claim. Pure: the caller hands it what it found on disk.
+export function homonymCards(path, existing) {
+  const firstName = firstNameSegment(path);
+  return existing.filter((card) => firstNameSegment(card) === firstName);
 }

--- a/scripts/lib/filed-note.mjs
+++ b/scripts/lib/filed-note.mjs
@@ -43,6 +43,34 @@ const FOLDER = {
 // living pages (person/topic) do not.
 const DATED = new Set(["decision", "meeting"]);
 
+// How sure the card's own resolution is, in the words the claim discipline
+// already ships (`sync-sources`, "Mark it in the artifact"). One scale for the
+// whole brain: a second vocabulary here would be a second discipline.
+export const CONFIDENCE = {
+  observed: "✅ observed",
+  probable: "🟡 derived or probable",
+  unverified: "🔴 unverified",
+};
+
+// The rendered reliability line, or a loud refusal. A level outside the scale is
+// NOT rendered leniently: "— undefined · …" is a card whose reliability line
+// looks like it says something and says nothing, which is the very conflation
+// the block exists to end.
+function confidenceLine({ level, basis }) {
+  const marker = CONFIDENCE[level];
+  if (!marker) {
+    throw new Error(
+      `unknown confidence level "${level}": use one of ${Object.keys(CONFIDENCE).join(", ")}`,
+    );
+  }
+  if (!basis || !String(basis).trim()) {
+    throw new Error(
+      `confidence "${level}" needs a basis: say what the resolution rests on (source, date, card)`,
+    );
+  }
+  return `${marker} · ${basis}`;
+}
+
 // The vault-relative path a filed-back note must live at, derived from its type
 // (and title, and — for dated types — its date). Pure: no clock, no fs.
 export function filedNotePath(spec) {
@@ -74,12 +102,19 @@ export function renderFiledNote(spec) {
   const links = spec.links ?? [];
   const path = filedNotePath(spec);
   const universe = activeUniverse(spec);
+  // Rendered (and validated) before the frontmatter, because the level lands in
+  // both: the field is what a later pass can FIND, the line is what a human reads.
+  const sure = spec.confidence ? `> **Confidence** — ${confidenceLine(spec.confidence)}\n\n` : "";
   const frontmatter = [
     "---",
     `type: ${spec.type}`,
     `created: ${spec.today}`,
     `updated: ${spec.today}`,
     `tags: [${spec.tags.join(", ")}]`,
+    // A caveat left in prose is a caveat the next session absorbs as confidence
+    // (the claim discipline's "yesterday's caveat is a debt"). As a field, it is
+    // findable without reading the sentence.
+    ...(spec.confidence ? [`confidence: ${spec.confidence.level}`] : []),
     // Additive scope key so retrieval travels with the file (ADR 0034), appended
     // last to match the import stamper (stamp-universe.mjs). Omitted at the root.
     ...(universe ? [`universe: ${universe}`] : []),
@@ -91,7 +126,7 @@ export function renderFiledNote(spec) {
   // usable to the next resolution: a first name is rarely unique, and a card
   // that does not say which one only moves the ambiguity.
   const which = spec.distinguish ? `> **Which one** — ${spec.distinguish}\n\n` : "";
-  const content = `${frontmatter}\n\n# ${spec.title}\n\n${which}${spec.body}\n${related}`;
+  const content = `${frontmatter}\n\n# ${spec.title}\n\n${which}${sure}${spec.body}\n${related}`;
   return { path, content };
 }
 

--- a/scripts/lib/filed-note.mjs
+++ b/scripts/lib/filed-note.mjs
@@ -56,7 +56,7 @@ export const CONFIDENCE = {
 // NOT rendered leniently: "— undefined · …" is a card whose reliability line
 // looks like it says something and says nothing, which is the very conflation
 // the block exists to end.
-function confidenceLine({ level, basis }) {
+export function confidenceLine({ level, basis }) {
   const marker = CONFIDENCE[level];
   if (!marker) {
     throw new Error(

--- a/scripts/lib/filed-note.test.mjs
+++ b/scripts/lib/filed-note.test.mjs
@@ -63,6 +63,11 @@ test("filedNotePath — an unknown type throws, naming the supported types", () 
     () => filedNotePath({ type: "recipe", title: "Whatever" }),
     /unknown type "recipe".*person.*topic.*decision.*meeting/is,
   );
+  // Whole, separators included: run together, "persontopicdecisionmeeting" is a
+  // list of four types the reader has to guess the boundaries of.
+  assert.throws(() => filedNotePath({ type: "recipe", title: "Whatever" }), {
+    message: 'unknown type "recipe": supported types are person, topic, decision, meeting',
+  });
 });
 
 test("filedNotePath — a dated type without a date throws (fail-loud)", () => {
@@ -370,6 +375,21 @@ test("renderFiledNote — a marker with no basis is refused: an unbacked marker 
       }),
     /confidence "observed" needs a basis/,
     "a level with nothing behind it must not be writable",
+  );
+  // And a basis made of spaces is nothing behind it too — it renders as
+  // "✅ observed · " , a marker whose justification is a blank the eye slides
+  // over, which is the very look the block exists to end.
+  assert.throws(
+    () =>
+      renderFiledNote({
+        type: "person",
+        title: "Jane Doe",
+        tags: ["acme"],
+        body: "…",
+        confidence: { level: "observed", basis: "   " },
+        today: "2026-08-03",
+      }),
+    /confidence "observed" needs a basis/,
   );
 });
 

--- a/scripts/lib/filed-note.test.mjs
+++ b/scripts/lib/filed-note.test.mjs
@@ -277,6 +277,121 @@ test("homonymCards — names EVERY homonym, not just the first, and only the hom
   );
 });
 
+// ── The reliability block: how sure the card's own identity resolution is ─────
+// "Conformant ≠ true." The builder guarantees FORM — right path, complete
+// frontmatter, green lint — and that form is then read as substance: a card
+// resolved from a bare "Jérémy (front Candor)" comes out looking exactly like
+// one resolved from a signed org chart. This plan's own reframe, on the vault's
+// most permanent surface. So the card SAYS what its resolution rests on, in the
+// vocabulary the claim discipline already shipped (✅ observed / 🟡 derived or
+// probable / 🔴 unverified) — never a second scale.
+
+test("renderFiledNote — a probable resolution says so, in the claim discipline's own words", () => {
+  const note = renderFiledNote({
+    type: "person",
+    title: "Jérémy Hinard",
+    tags: ["candor"],
+    body: "Front-end at Candor.",
+    confidence: {
+      level: "probable",
+      basis: 'source said "Jérémy (front Candor)"; the surname comes from the Candor org note.',
+    },
+    today: "2026-08-03",
+  });
+  assert.deepEqual(note, {
+    path: "people/jeremy-hinard.md",
+    content: `---
+type: person
+created: 2026-08-03
+updated: 2026-08-03
+tags: [candor]
+confidence: probable
+---
+
+# Jérémy Hinard
+
+> **Confidence** — 🟡 derived or probable · source said "Jérémy (front Candor)"; the surname comes from the Candor org note.
+
+Front-end at Candor.
+`,
+  });
+});
+
+test("renderFiledNote — a confirmed resolution reads as observed, not as the probable one", () => {
+  // Triangulates the marker: with only the 🟡 example above, the whole scale
+  // could be one hard-coded string and every card would claim the same thing.
+  const note = renderFiledNote({
+    type: "person",
+    title: "Hossam Laanait",
+    tags: ["visma"],
+    body: "CTO Visma France.",
+    confidence: { level: "observed", basis: "his own announcement, 04/06, quoted in the note." },
+    today: "2026-08-03",
+  });
+  assert.match(
+    note.content,
+    /^> \*\*Confidence\*\* — ✅ observed · his own announcement, 04\/06, quoted in the note\.$/m,
+    "an observed resolution must not be rendered in the probable marker",
+  );
+});
+
+test("renderFiledNote — a level outside the scale is refused, never rendered as `undefined`", () => {
+  // Fail-loud (ADR 0009). Rendered leniently, "🤷 undefined" is a card whose
+  // reliability line says nothing while LOOKING like it says something — the
+  // exact conflation this block exists to end.
+  assert.throws(
+    () =>
+      renderFiledNote({
+        type: "person",
+        title: "Jane Doe",
+        tags: ["acme"],
+        body: "…",
+        confidence: { level: "pretty sure", basis: "a hunch" },
+        today: "2026-08-03",
+      }),
+    /confidence level "pretty sure".*observed, probable, unverified/s,
+    "the refusal must name the offending level AND the scale that would be accepted",
+  );
+});
+
+test("renderFiledNote — a marker with no basis is refused: an unbacked marker is decoration", () => {
+  // The marker is a claim ABOUT a claim. Without what it rests on, "✅ observed"
+  // is unfalsifiable — the reader cannot tell a sourced resolution from a
+  // confident one, which is where this whole release started.
+  assert.throws(
+    () =>
+      renderFiledNote({
+        type: "person",
+        title: "Jane Doe",
+        tags: ["acme"],
+        body: "…",
+        confidence: { level: "observed" },
+        today: "2026-08-03",
+      }),
+    /confidence "observed" needs a basis/,
+    "a level with nothing behind it must not be writable",
+  );
+});
+
+test("renderFiledNote — the level is ALSO a frontmatter field, not only prose", () => {
+  // The claim discipline's own §4.6: a caveat left in prose is a caveat the next
+  // session absorbs as confidence. Machine-visible means a FIELD — something
+  // `/lint`, a query or a later pass can find without reading the sentence.
+  const note = renderFiledNote({
+    type: "person",
+    title: "Jane Doe",
+    tags: ["acme"],
+    body: "…",
+    confidence: { level: "unverified", basis: "no source names her team." },
+    today: "2026-08-03",
+  });
+  assert.match(
+    note.content,
+    /^tags: \[acme\]\nconfidence: unverified\n---$/m,
+    "the field belongs in the frontmatter, right after tags",
+  );
+});
+
 test("renderFiledNote — `distinguish` becomes the homonymy block, right under the title", () => {
   const note = renderFiledNote({
     type: "person",

--- a/scripts/lib/filed-note.test.mjs
+++ b/scripts/lib/filed-note.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { slugify, filedNotePath, renderFiledNote } from "./filed-note.mjs";
+import { slugify, filedNotePath, renderFiledNote, homonymCards } from "./filed-note.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // filed-note — the pure, I/O-free core of Track B ("file the good answer back").
@@ -37,15 +37,16 @@ test("filedNotePath — a living page (topic) is <folder>/<slug>.md, no date", (
 });
 
 test("filedNotePath — a person page lives under people/ (folder is not a naive plural)", () => {
-  assert.equal(
-    filedNotePath({ type: "person", title: "Jane Doe" }),
-    "people/jane-doe.md",
-  );
+  assert.equal(filedNotePath({ type: "person", title: "Jane Doe" }), "people/jane-doe.md");
 });
 
 test("filedNotePath — a dated type (decision) is <folder>/<date>-<slug>.md", () => {
   assert.equal(
-    filedNotePath({ type: "decision", title: "Adopt The Hive", date: "2026-07-17" }),
+    filedNotePath({
+      type: "decision",
+      title: "Adopt The Hive",
+      date: "2026-07-17",
+    }),
     "decisions/2026-07-17-adopt-the-hive.md",
   );
 });
@@ -82,13 +83,21 @@ test("filedNotePath — an active universe prefixes the path with <universe>/", 
 
 test("filedNotePath — a dated type under a universe keeps its date, prefixed", () => {
   assert.equal(
-    filedNotePath({ type: "meeting", title: "Q3 Review", date: "2026-07-17", universe: "acme" }),
+    filedNotePath({
+      type: "meeting",
+      title: "Q3 Review",
+      date: "2026-07-17",
+      universe: "acme",
+    }),
     "acme/meetings/2026-07-17-q3-review.md",
   );
 });
 
 test("filedNotePath — the default universe (and no universe) stays at the vault root", () => {
-  assert.equal(filedNotePath({ type: "topic", title: "RAG", universe: "default" }), "topics/rag.md");
+  assert.equal(
+    filedNotePath({ type: "topic", title: "RAG", universe: "default" }),
+    "topics/rag.md",
+  );
   assert.equal(filedNotePath({ type: "topic", title: "RAG" }), "topics/rag.md");
 });
 
@@ -96,7 +105,14 @@ test("filedNotePath — the default universe (and no universe) stays at the vaul
 
 test("renderFiledNote — throws when today is missing (created/updated would be blank)", () => {
   assert.throws(
-    () => renderFiledNote({ type: "topic", title: "X", tags: ["a"], body: "b", links: [] }),
+    () =>
+      renderFiledNote({
+        type: "topic",
+        title: "X",
+        tags: ["a"],
+        body: "b",
+        links: [],
+      }),
     /today.*required/i,
   );
 });
@@ -104,7 +120,14 @@ test("renderFiledNote — throws when today is missing (created/updated would be
 test("renderFiledNote — throws on empty tags (frontmatter conformance would break)", () => {
   assert.throws(
     () =>
-      renderFiledNote({ type: "topic", title: "X", tags: [], body: "b", links: [], today: "2026-07-17" }),
+      renderFiledNote({
+        type: "topic",
+        title: "X",
+        tags: [],
+        body: "b",
+        links: [],
+        today: "2026-07-17",
+      }),
     /at least one tag|tags.*required|non-empty/i,
   );
 });
@@ -211,6 +234,72 @@ The distilled answer.
 
 - [[people/jane-doe]]
 - [[topics/rag]]
+`,
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The homonymy block — a card that does not say WHICH Romain only moves the
+// ambiguity. The field brain carried 3 Romain, 3 Marie, 2 Karim, 2 Caroline and
+// 2 Michael, and the identity discipline's "resolve against the vault before you
+// write" is unusable when the vault's own answer is three cards wide.
+//
+// This is the pure half: which existing cards already bear the first name the
+// new card is about to claim. It knows nothing of the fs — the caller hands it
+// what it found.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("homonymCards — names the existing card that already bears this first name", () => {
+  assert.deepEqual(
+    homonymCards("people/romain-lefevre.md", ["people/romain-durand.md", "people/jane-doe.md"]),
+    ["people/romain-durand.md"],
+  );
+});
+
+test("homonymCards — a card in another universe's subtree is a homonym too", () => {
+  // The resolution rule reads the active universe's people/ AND the root's
+  // cross-cutting cards, so a Romain filed under acme/ is exactly the Romain the
+  // next bare "Romain" could be resolved to. Basename-scoped on purpose.
+  assert.deepEqual(homonymCards("people/romain-lefevre.md", ["acme/people/romain-durand.md"]), [
+    "acme/people/romain-durand.md",
+  ]);
+});
+
+test("homonymCards — names EVERY homonym, not just the first, and only the homonyms", () => {
+  assert.deepEqual(
+    homonymCards("people/romain-lefevre.md", [
+      "people/marie-curie.md",
+      "acme/people/romain-durand.md",
+      "people/romain.md",
+      "people/romainville-sud.md",
+    ]),
+    ["acme/people/romain-durand.md", "people/romain.md"],
+  );
+});
+
+test("renderFiledNote — `distinguish` becomes the homonymy block, right under the title", () => {
+  const note = renderFiledNote({
+    type: "person",
+    title: "Romain Lefèvre",
+    tags: ["acme"],
+    body: "SRE, joined in March.",
+    distinguish: "SRE at Acme — not [[people/romain-durand]] (product), nor Romain the freelance.",
+    today: "2026-08-03",
+  });
+  assert.deepEqual(note, {
+    path: "people/romain-lefevre.md",
+    content: `---
+type: person
+created: 2026-08-03
+updated: 2026-08-03
+tags: [acme]
+---
+
+# Romain Lefèvre
+
+> **Which one** — SRE at Acme — not [[people/romain-durand]] (product), nor Romain the freelance.
+
+SRE, joined in March.
 `,
   });
 });

--- a/scripts/lib/hooks-reconcile.mjs
+++ b/scripts/lib/hooks-reconcile.mjs
@@ -93,7 +93,11 @@ const BROKEN_WIN32_RUN_NODE = /^cmd \/c "[^"]*\\run-node\.cmd"/;
 // Returns the fixed command, or the original unchanged when it isn't the broken shape.
 export function repairWin32NodePrefix(command, projectRoot) {
   if (typeof command !== "string" || !BROKEN_WIN32_RUN_NODE.test(command)) return command;
-  return command.replace(BROKEN_WIN32_RUN_NODE, `${projectRoot}/scripts/run-node.cmd`);
+  // A FUNCTION replacement, never a string: the injected value is the owner's own
+  // folder path, and `$` / `&` are both legal in a Windows folder name — a string
+  // replacement expands `$$`, `$&`, `` $` `` and `$'`, silently writing a hook that
+  // points at a launcher which is not there.
+  return command.replace(BROKEN_WIN32_RUN_NODE, () => `${projectRoot}/scripts/run-node.cmd`);
 }
 
 // Repair every broken engine hook command in a settings.json `hooks` tree. Pure:

--- a/scripts/lib/hooks-reconcile.test.mjs
+++ b/scripts/lib/hooks-reconcile.test.mjs
@@ -235,6 +235,26 @@ test("repairWin32NodePrefix — repairs a single command string (used for status
   );
 });
 
+test("repairWin32NodePrefix — a hook with no command string is handed back, not crashed on", () => {
+  // `settings.json` is hand-edited by owners, so a hook entry whose `command` is
+  // missing (or is not a string at all) is an ordinary shape here. The typeof
+  // guard was written for it and no test ever fed it one: every mutant that
+  // removes the guard survived, and each of them turns this into a TypeError
+  // thrown at session start, on the reconcile path that is meant to REPAIR a
+  // brain.
+  for (const notAString of [undefined, null, 42, { command: "x" }, ["cmd /c"]]) {
+    assert.equal(repairWin32NodePrefix(notAString, "C:/brain"), notAString);
+  }
+});
+
+test("repairWin32NodePrefix — the broken prefix is only repaired at the START of the command", () => {
+  // The anchor is what keeps this off a USER hook: an owner's own command that
+  // merely mentions the engine launcher further along is not the broken shape,
+  // and rewriting inside it would corrupt a command we do not own.
+  const userHook = 'pwsh -c "log" && cmd /c "C:\\brain\\scripts\\run-node.cmd" "x.mjs"';
+  assert.equal(repairWin32NodePrefix(userHook, "C:/brain"), userHook);
+});
+
 test("repairWin32NodePrefix — a `$` in the brain's own path survives the repair verbatim", () => {
   // Same class as the confidence-block defect found by review: the replacement was
   // handed to `replace` as a string, so `$&`, `` $` ``, `$'` and `$$` in it expand.

--- a/scripts/lib/hooks-reconcile.test.mjs
+++ b/scripts/lib/hooks-reconcile.test.mjs
@@ -235,6 +235,23 @@ test("repairWin32NodePrefix — repairs a single command string (used for status
   );
 });
 
+test("repairWin32NodePrefix — a `$` in the brain's own path survives the repair verbatim", () => {
+  // Same class as the confidence-block defect found by review: the replacement was
+  // handed to `replace` as a string, so `$&`, `` $` ``, `$'` and `$$` in it expand.
+  // Here the injected value is the OWNER'S FOLDER PATH — `$` and `&` are both legal
+  // in a Windows folder name — and the damage is silent: the hook command is written
+  // into settings.json pointing at a launcher that is not there, so every session of
+  // that brain starts with a broken hook.
+  assert.equal(
+    repairWin32NodePrefix('cmd /c "C:\\Users\\x\\my$$brain\\scripts\\run-node.cmd" "x.mjs"', "C:/Users/x/my$$brain"),
+    'C:/Users/x/my$$brain/scripts/run-node.cmd "x.mjs"',
+  );
+  assert.equal(
+    repairWin32NodePrefix('cmd /c "C:\\Users\\x\\a$&b\\scripts\\run-node.cmd" "x.mjs"', "C:/Users/x/a$&b"),
+    'C:/Users/x/a$&b/scripts/run-node.cmd "x.mjs"',
+  );
+});
+
 // ── detectHookGap — the pure bootstrap drift gate (mirrors detectSelfHealGap) ──
 // session-status uses it to decide whether to spawn the one-time reconcile on a
 // pre-3.2 brain. A converged brain → not needed → the hook stays a TRUE no-op.

--- a/scripts/lib/hooks-reconcile.test.mjs
+++ b/scripts/lib/hooks-reconcile.test.mjs
@@ -242,7 +242,19 @@ test("repairWin32NodePrefix — a hook with no command string is handed back, no
   // removes the guard survived, and each of them turns this into a TypeError
   // thrown at session start, on the reconcile path that is meant to REPAIR a
   // brain.
-  for (const notAString of [undefined, null, 42, { command: "x" }, ["cmd /c"]]) {
+  // The last fixture is the one that tells the two terms of the guard apart: a
+  // non-string whose string coercion LOOKS like the broken command. With only
+  // harmless non-strings, `typeof command !== "string"` and
+  // `!BROKEN.test(command)` agree on every input, and either can be deleted with
+  // the suite green. A hook whose `command` was hand-written as a JSON array is
+  // exactly that value — and without the guard it reaches `.replace` and throws.
+  for (const notAString of [
+    undefined,
+    null,
+    42,
+    { command: "x" },
+    ['cmd /c "C:\\brain\\scripts\\run-node.cmd" "x.mjs"'],
+  ]) {
     assert.equal(repairWin32NodePrefix(notAString, "C:/brain"), notAString);
   }
 });

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -92,6 +92,39 @@ for (const { name, locale, path } of SKILLS.filter((s) => s.name === "sync-sourc
   }
 }
 
+// ── The constitutions carry it too — same words, deliberately ──────────────
+// The two skills are the operative carriers; the constitution is what a brain
+// reads when no skill is loaded, which is most of the time. It is asserted
+// against the SAME patterns as the skills on purpose: two paraphrases of one
+// discipline are two disciplines (the rule the claim guard already enforces).
+//
+// Reach caveat, unchanged since F18 and NOT a reason to skip this: the skills
+// are in the manifest's `merge` regime and do reach deployed brains, while
+// `CLAUDE.engine.md` is in no regime and reaches new installs only. So the
+// constitution is worth writing and must never be the only carrier — which is
+// why the skill assertions above exist and come first.
+const CONSTITUTIONS = [
+  { locale: "EN", layers: ["CLAUDE.md.template", "CLAUDE.engine.md"] },
+  { locale: "FR", layers: ["templates/fr/CLAUDE.md.template", "templates/fr/CLAUDE.engine.md"] },
+];
+
+for (const { locale, layers } of CONSTITUTIONS) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  const rules = locale === "FR" ? RULES_FR : RULES_EN;
+  const constitution = () => layers.map(read).join("\n");
+  test(`${locale} constitution has an identity-discipline section at all`, () => {
+    assert.match(constitution(), heading, "the discipline must have its own heading");
+  });
+  for (const { why, pattern } of rules) {
+    test(`${locale} constitution carries the identity discipline: ${why}`, () => {
+      const section = docSection(constitution(), heading);
+      for (const one of [pattern].flat()) {
+        assert.match(section, one, `the ${locale} constitution lost the rule — ${why}`);
+      }
+    });
+  }
+}
+
 // ── The rule that MANUFACTURED the defect must be gone, not merely balanced ──
 // "People registry" ordered two things that cannot both hold when a source gives
 // only a first name: `[[people/jane]]` is FORBIDDEN, and create the backlink even

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -55,6 +55,10 @@ const RULES_EN = [
     why: 'a bare first name stays plain text — never a [[people/…]] link, never a surname you supplied ("Jérémy" → "Jérémy Hinard")',
     pattern: /never invent the missing half/i,
   },
+  {
+    why: 'nothing is "new" until the vault has been asked — and the check must be NAMED, not implied (tier 3 of the claim discipline)',
+    pattern: [/before you call anything new/i, /search_vault/],
+  },
 ];
 
 const RULES_FR = [
@@ -66,6 +70,10 @@ const RULES_FR = [
     why: "un prénom seul reste du texte, jamais un lien, jamais un nom de famille fourni par le modèle",
     pattern: /n'invente jamais la moitié manquante/i,
   },
+  {
+    why: "rien n'est « nouveau » tant que le vault n'a pas été interrogé — et la vérification doit être NOMMÉE",
+    pattern: [/avant de qualifier quoi que ce soit de nouveau/i, /search_vault/],
+  },
 ];
 
 for (const { name, locale, path } of SKILLS.filter((s) => s.name === "sync-sources")) {
@@ -76,7 +84,10 @@ for (const { name, locale, path } of SKILLS.filter((s) => s.name === "sync-sourc
   });
   for (const { why, pattern } of rules) {
     test(`${locale} ${name} carries the identity discipline: ${why}`, () => {
-      assert.match(docSection(read(path), heading), pattern, `${path} lost the rule — ${why}`);
+      const section = docSection(read(path), heading);
+      for (const one of [pattern].flat()) {
+        assert.match(section, one, `${path} lost the rule — ${why}`);
+      }
     });
   }
 }
@@ -104,6 +115,32 @@ for (const { locale, path } of SKILLS.filter((s) => s.name === "sync-sources")) 
       section,
       locale === "FR" ? /Discipline d'identité/ : /Identity discipline/,
       "the registry must send the reader to the discipline that says what to do with an unresolved name",
+    );
+  });
+}
+
+// ── The novelty check must sit in the OPERATIVE step, not only in the prose ──
+// The sub-agents never see the vault — they read external sources. "This is new"
+// is asserted in the main context, at the synthesis, which is also the only place
+// holding both the delta and the ability to run a `search_vault`. A rule stated in
+// the discipline section but absent from the reconcile passes is a rule nothing
+// executes: that is how a two-month-old fact was republished as a scoop.
+const SYNTHESIS_EN = /^#+ Step 3 — Synthesis/m;
+const SYNTHESIS_FR = /^#+ Étape 3 — Synthèse/m;
+
+for (const { locale, path } of SKILLS.filter((s) => s.name === "sync-sources")) {
+  test(`${locale} the synthesis step runs the novelty check, and counts its own passes`, () => {
+    const section = docSection(read(path), locale === "FR" ? SYNTHESIS_FR : SYNTHESIS_EN);
+    assert.match(section, /search_vault/, "the reconcile must name the check, not imply it");
+    assert.match(
+      section,
+      locale === "FR" ? /^3\. \*\*/m : /^3\. \*\*/m,
+      "the novelty check must be a numbered pass like the other two, not a footnote",
+    );
+    assert.doesNotMatch(
+      section,
+      locale === "FR" ? /Deux passes/i : /Two passes/i,
+      "the intro still promises two passes while three are listed — the third reads as optional",
     );
   });
 }

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -68,6 +68,19 @@ const RULES_EN = [
     why: "a dangling [[people/…]] link is repaired at the source, never by creating the person it names",
     pattern: [/a link is not a person/i, /never create a `people\/`/i],
   },
+  {
+    // The homonymy block. Rule 1 is unusable when the vault's own answer is
+    // three cards wide: the field brain held 3 Romain, 3 Marie, 2 Karim, 2
+    // Caroline and 2 Michael. A card that does not say which one does not
+    // resolve anything — it moves the ambiguity one hop, into the vault.
+    //
+    // Two sides, and the second is what makes the first usable: the card SAYS
+    // what tells this person apart (the builder refuses the write otherwise),
+    // and at read time a bare first name matching several cards is UNRESOLVED,
+    // never resolved to the nearest one.
+    why: "a person card says WHICH one (the `distinguish` block), and a first name matching several cards stays unresolved",
+    pattern: [/say which one/i, /distinguish/, /unresolved/i],
+  },
 ];
 
 const RULES_FR = [
@@ -86,6 +99,10 @@ const RULES_FR = [
   {
     why: "un lien `[[people/…]]` cassé se répare à la source, jamais en créant la personne qu'il nomme",
     pattern: [/un lien n'est pas une personne/i, /ne crée jamais une fiche `people\/`/i],
+  },
+  {
+    why: "une fiche dit DE QUI il s'agit (le bloc `distinguish`), et un prénom qui correspond à plusieurs fiches reste non résolu",
+    pattern: [/dis de qui il s'agit/i, /distinguish/, /non résolu/i],
   },
 ];
 
@@ -303,6 +320,38 @@ for (const { name, locale, path } of SKILLS) {
       text,
       locale === "FR" ? LINKLESS_FR : LINKLESS_EN,
       "the prompt must state the action (no full name → no link at all), not only the ban",
+    );
+  });
+}
+
+// ── The two doors that WRITE a person card must name the field ──────────────
+// The rule above is stated in the producer's discipline; these two skills are
+// where a `people/` card is actually created, and they both write through the
+// same builder — which now REFUSES a person whose first name the vault already
+// holds until the spec says which one. A skill that documents the builder's exit
+// codes without that one leaves the writer reading a refusal it never mentioned,
+// and the likeliest repair is to drop the card or invent a surname (F7 again).
+//
+// Same shape as `/lint` and `/consolidate` under F6: name the field, then POINT
+// at the producer's section. Two paraphrases of one discipline are two
+// disciplines.
+const WRITE_DOORS = [
+  { name: "file-back", path: "engine-skills/file-back/SKILL.md" },
+  { name: "consolidate", path: "engine-skills/consolidate/SKILL.md" },
+];
+
+for (const { name, path } of WRITE_DOORS) {
+  test(`${name} tells the writer about the homonymy block the builder demands`, () => {
+    const text = read(path);
+    assert.match(
+      text,
+      /distinguish/,
+      "the skill drives the builder — a refusal it never mentions reads as a bug in the tool",
+    );
+    assert.match(
+      text,
+      IDENTITY_ANCHOR_EN,
+      "the reason belongs to the producer's identity SECTION, not to a second wording here",
     );
   });
 }

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -178,6 +178,32 @@ for (const { locale, path } of SKILLS.filter((s) => s.name === "sync-sources")) 
   });
 }
 
+// ── The consumer POINTS, it does not paraphrase ────────────────────────────
+// F7's own lesson applied to the skills themselves: the control belongs where
+// the facts are produced. `prepare-1-1` consumes the `sync-sources` fan-out, and
+// it was already carrying its own wording of the producer's rules ("the vault
+// outranks the delta…", "a bare first name stays a bare first name") — true
+// today, and free to drift tomorrow. Two paraphrases are two disciplines.
+//
+// Anchored at the SECTION, never merely at the file: prepare-1-1 has linked
+// `../sync-sources/SKILL.md` for the fan-out architecture since long before any
+// of this, so a bare file link would go green on prose that predates the fix.
+const IDENTITY_ANCHOR_EN = /sync-sources\/SKILL\.md#identity-discipline/;
+const IDENTITY_ANCHOR_FR = /sync-sources\/SKILL\.md#discipline-didentit/;
+
+for (const { locale, path } of SKILLS.filter((s) => s.name === "prepare-1-1")) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  test(`${locale} prepare-1-1 defers to the producer's identity section instead of restating it`, () => {
+    const text = read(path);
+    assert.match(text, heading, "the consumer must name the discipline it obeys, under its own heading");
+    assert.match(
+      docSection(text, heading),
+      locale === "FR" ? IDENTITY_ANCHOR_FR : IDENTITY_ANCHOR_EN,
+      "the pointer must reach the producer's identity SECTION, so the two cannot drift into two rules",
+    );
+  });
+}
+
 // ── The same trap, in the OPERATIVE text: the sub-agent prompts ─────────────
 // The prose sections are read by a human maintainer; these bullets are handed to
 // the extraction sub-agents verbatim, and they still carried the pair that has no

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -1,8 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 import { docSection } from "./doc-section.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -328,7 +328,39 @@ test("consolidate resolves a person candidate instead of trusting the mention co
 const LINKLESS_EN = /no full name[^.\n]*no link/i;
 const LINKLESS_FR = /pas de nom complet[^.\n]*pas de lien/i;
 
-for (const { name, locale, path } of SKILLS) {
+// Every skill that hands a fenced prompt to a sub-agent is a carrier of this
+// trap, and the list below must be DERIVED from the repo rather than kept by
+// hand: `engine-skills/consolidate` spawned sub-agents from the day it shipped,
+// carried the banned phrasing verbatim, and this guard iterated `SKILLS` — four
+// files that never included it. The rule read green for a release while the
+// other write-door still ordered the invention.
+const PROMPT_CARRIERS = [
+  ...SKILLS,
+  { name: "consolidate", locale: "EN", path: CONSOLIDATE },
+];
+
+const SKILL_ROOTS = [".claude/skills", "templates/fr/.claude/skills", "engine-skills"];
+const SPAWNS_SUBAGENTS = /^\s*prompt="""/m;
+
+const skillFilesUnder = (root) =>
+  readdirSync(join(REPO_ROOT, root), { recursive: true, encoding: "utf8" })
+    .filter((rel) => rel.endsWith("SKILL.md"))
+    .map((rel) => `${root}/${rel.split(sep).join("/")}`);
+
+test("every skill that spawns sub-agents is covered by the prompt-text guard", () => {
+  const carriers = SKILL_ROOTS.flatMap(skillFilesUnder).filter((path) =>
+    SPAWNS_SUBAGENTS.test(read(path)),
+  );
+  assert.ok(carriers.length > 0, "the discovery itself must find something, or this guard proves nothing");
+  const uncovered = carriers.filter((path) => !PROMPT_CARRIERS.some((c) => c.path === path));
+  assert.deepEqual(
+    uncovered,
+    [],
+    "a skill handing a prompt to a sub-agent and unlisted here is exactly how the wording that manufactured the invention survived a release",
+  );
+});
+
+for (const { name, locale, path } of PROMPT_CARRIERS) {
   test(`${locale} ${name}: an unresolved first name yields NO link, and the old ban is gone`, () => {
     const text = read(path);
     assert.doesNotMatch(

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -59,6 +59,15 @@ const RULES_EN = [
     why: 'nothing is "new" until the vault has been asked — and the check must be NAMED, not implied (tier 3 of the claim discipline)',
     pattern: [/before you call anything new/i, /search_vault/],
   },
+  {
+    // F6, F7's companion. `people/stephanie-music.md` was created "to resolve an
+    // incoming link"; that name then occurred exactly once in the whole vault — in
+    // its own title. A dangling link is a defect OF THE LINK, and creating its
+    // target promotes a mis-resolution into the vault's answer to "who exists",
+    // which is what the next resolution then resolves against.
+    why: "a dangling [[people/…]] link is repaired at the source, never by creating the person it names",
+    pattern: [/a link is not a person/i, /never create a `people\/`/i],
+  },
 ];
 
 const RULES_FR = [
@@ -73,6 +82,10 @@ const RULES_FR = [
   {
     why: "rien n'est « nouveau » tant que le vault n'a pas été interrogé — et la vérification doit être NOMMÉE",
     pattern: [/avant de qualifier quoi que ce soit de nouveau/i, /search_vault/],
+  },
+  {
+    why: "un lien `[[people/…]]` cassé se répare à la source, jamais en créant la personne qu'il nomme",
+    pattern: [/un lien n'est pas une personne/i, /ne crée jamais une fiche `people\/`/i],
   },
 ];
 
@@ -203,6 +216,66 @@ for (const { locale, path } of SKILLS.filter((s) => s.name === "prepare-1-1")) {
     );
   });
 }
+
+// ── F6's own carrier: the repair gesture that MANUFACTURED the fabrication ──
+// The discipline above states the rule; `/lint` is where the gesture is actually
+// OFFERED, and it offered exactly the wrong one: "Dangling → fix the target
+// spelling, or CREATE THE MISSING NOTE, or remove the dead link", with no carve-out
+// for a person. Applied to a mis-resolved `[[people/…]]`, that bullet IS how
+// `people/stephanie-music.md` came to exist — a name occurring once in the whole
+// vault, in its own title, that every later resolution would have resolved against.
+//
+// Creating the missing note stays right for a TOPIC the vault meant to hold, so the
+// assertion is not "the gesture is gone" but "the gesture excludes people". And the
+// reason is not restated here: `/lint` POINTS at the producer's section, the same way
+// prepare-1-1 does, because two paraphrases of one discipline are two disciplines.
+// The relative path holds on a deployed brain: both skills are installed siblings
+// under `.claude/skills/`.
+const LINT = "engine-skills/lint/SKILL.md";
+const LINT_FIXES = /^#+ 3\. Propose fixes/m;
+
+test("the lint skill never offers to create a person to satisfy a dangling link", () => {
+  const section = docSection(read(LINT), LINT_FIXES);
+  assert.notEqual(section, "", "the propose-fixes section must still exist");
+  assert.match(
+    section,
+    /never.*\[\[people\//is,
+    "the create-the-missing-note gesture must exclude a person target, or it repeats F6 verbatim",
+  );
+  assert.match(
+    section,
+    IDENTITY_ANCHOR_EN,
+    "the carve-out must send the reader to the producer's identity SECTION, not carry its own wording",
+  );
+});
+
+// ── The OTHER door onto a fabricated person: `/consolidate` ────────────────
+// `/lint` was the door F6 was found at; this is the one it hands off to. The scan
+// proposes "an entity/PERSON [[mentioned]] in captures but with no page yet", ranked
+// by how many captures cite it — and a fabricated `[[people/jeremy-hinard]]` that
+// F7 wrote into three captures reads as signal, not as a defect. Mention count
+// measures how often a link was written, never whether the person exists.
+//
+// This is not a duplicate of the `/lint` carve-out: creating the page IS this
+// skill's purpose, so the rule here is that a PERSON candidate gets resolved before
+// it is written, not that the gesture is refused. Same anchor, for the same reason.
+const CONSOLIDATE = "engine-skills/consolidate/SKILL.md";
+const CONSOLIDATE_BOUND = /^#+ 2\. Bound the batch/m;
+
+test("consolidate resolves a person candidate instead of trusting the mention count", () => {
+  const section = docSection(read(CONSOLIDATE), CONSOLIDATE_BOUND);
+  assert.notEqual(section, "", "the bound-the-batch section must still exist");
+  assert.match(
+    section,
+    /count[^.\n]*not[^.\n]*(evidence|proof)/i,
+    "the skill must say what the count does NOT establish, or a fabricated name reads as signal",
+  );
+  assert.match(
+    section,
+    IDENTITY_ANCHOR_EN,
+    "a person candidate must be sent to the producer's identity SECTION before a page is written",
+  );
+});
 
 // ── The same trap, in the OPERATIVE text: the sub-agent prompts ─────────────
 // The prose sections are read by a human maintainer; these bullets are handed to

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -81,6 +81,22 @@ const RULES_EN = [
     why: "a person card says WHICH one (the `distinguish` block), and a first name matching several cards stays unresolved",
     pattern: [/say which one/i, /distinguish/, /unresolved/i],
   },
+  {
+    // "Conformant ≠ true." The builder hands every card the same clean
+    // frontmatter and the same green lint, so nothing on the page tells a
+    // resolution read off an org chart from one inferred out of a nickname —
+    // and the vault reads both as its own answer to who exists, forever.
+    //
+    // The scale is the claim discipline's, deliberately: v4.5.0 shipped
+    // ✅ observed / 🟡 derived or probable / 🔴 unverified, and a second
+    // vocabulary here would be a second discipline. The pattern pins the middle
+    // marker's exact words for that reason.
+    //
+    // The read half is what makes the block worth writing: a marked card is a
+    // lead, not the vault's answer, so it is re-verified rather than inherited.
+    why: "a person card says HOW SURE its identity is, in the claim discipline's own scale, and a marked card is re-verified rather than inherited",
+    pattern: [/say how sure you are/i, /🟡 derived or probable/, /re-verify/i],
+  },
 ];
 
 const RULES_FR = [
@@ -103,6 +119,10 @@ const RULES_FR = [
   {
     why: "une fiche dit DE QUI il s'agit (le bloc `distinguish`), et un prénom qui correspond à plusieurs fiches reste non résolu",
     pattern: [/dis de qui il s'agit/i, /distinguish/, /non résolu/i],
+  },
+  {
+    why: "une fiche dit À QUEL POINT son identité est sûre, dans l'échelle de la discipline de revendication, et une fiche marquée se revérifie au lieu de s'hériter",
+    pattern: [/dis à quel point c'est sûr/i, /🟡 déduit ou probable/, /revérifie/i],
   },
 ];
 

--- a/scripts/lib/identity-discipline.test.mjs
+++ b/scripts/lib/identity-discipline.test.mjs
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { docSection } from "./doc-section.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// F7 — the brain writes ABOUT people into the vault without ever reading what
+// the vault already says about them.
+//
+// Two field failures, on two machines, one evening apart:
+//   • a source said "Jérémy (front Candor)" — a bare first name — and the note
+//     asserted "Jérémy Hinard", a surname that exists nowhere but in that note;
+//   • a 1-1 prep wrote "Hossam, who would become CTO Visma France (unconfirmed)"
+//     while the vault's own people/hossam-laanait.md said "CTO Visma France
+//     (confirmed 04/06)" — a dated record downgraded into a rumour.
+//
+// The second one is why this is a doc guard and not a note fixer: correcting the
+// note does NOT stop it. The vault carried the right answer to both laptops and
+// the skill read neither, so it fires again at the next briefing, and the next.
+//
+// And the invention was not the model being creative — the skill ORDERED it. Its
+// "People registry" section said, in the same breath, "never a first name alone,
+// [[people/jane]] is forbidden" AND "create the backlinks even if the target page
+// doesn't exist". Handed a bare first name, an agent obeying both has exactly two
+// exits: drop the link, or invent a surname. So the fix repairs a rule the engine
+// ships — which is also why it must land here and never brain-side (patching a
+// skill inside a brain freezes it against every future engine fix, F5).
+//
+// Same carrier and same shape as the claim discipline (F18): the producer
+// `sync-sources`, its consumer `prepare-1-1`, EN and FR, plus both constitutions.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (rel) => readFileSync(join(REPO_ROOT, rel), "utf8");
+
+const HEADING_EN = /^#+ Identity discipline/m;
+const HEADING_FR = /^#+ Discipline d'identité/m;
+
+const SKILLS = [
+  { name: "sync-sources", locale: "EN", path: ".claude/skills/sync-sources/SKILL.md" },
+  { name: "prepare-1-1", locale: "EN", path: ".claude/skills/prepare-1-1/SKILL.md" },
+  { name: "sync-sources", locale: "FR", path: "templates/fr/.claude/skills/sync-sources/SKILL.md" },
+  { name: "prepare-1-1", locale: "FR", path: "templates/fr/.claude/skills/prepare-1-1/SKILL.md" },
+];
+
+// ── The rules, each naming the field failure it prevents ───────────────────
+const RULES_EN = [
+  {
+    why: "resolve against the vault's own people cards BEFORE writing a person into a note",
+    pattern: /Resolve before you write/i,
+  },
+  {
+    why: 'a bare first name stays plain text — never a [[people/…]] link, never a surname you supplied ("Jérémy" → "Jérémy Hinard")',
+    pattern: /never invent the missing half/i,
+  },
+];
+
+const RULES_FR = [
+  {
+    why: "résoudre contre les fiches du vault AVANT d'écrire une personne dans une note",
+    pattern: /Résous avant d'écrire/i,
+  },
+  {
+    why: "un prénom seul reste du texte, jamais un lien, jamais un nom de famille fourni par le modèle",
+    pattern: /n'invente jamais la moitié manquante/i,
+  },
+];
+
+for (const { name, locale, path } of SKILLS.filter((s) => s.name === "sync-sources")) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  const rules = locale === "FR" ? RULES_FR : RULES_EN;
+  test(`${locale} ${name} has an identity-discipline section at all`, () => {
+    assert.match(read(path), heading, `${path} must carry the discipline under its own heading`);
+  });
+  for (const { why, pattern } of rules) {
+    test(`${locale} ${name} carries the identity discipline: ${why}`, () => {
+      assert.match(docSection(read(path), heading), pattern, `${path} lost the rule — ${why}`);
+    });
+  }
+}
+
+// ── The rule that MANUFACTURED the defect must be gone, not merely balanced ──
+// "People registry" ordered two things that cannot both hold when a source gives
+// only a first name: `[[people/jane]]` is FORBIDDEN, and create the backlink even
+// with no target page. The agent obeyed both by inventing the surname. Adding the
+// identity discipline while leaving that section intact would leave the two
+// instructions fighting inside one file, which is how the field defect was born.
+const REGISTRY_EN = /^#+ People registry/m;
+const REGISTRY_FR = /^#+ Référentiel de personnes/m;
+
+for (const { locale, path } of SKILLS.filter((s) => s.name === "sync-sources")) {
+  const registry = locale === "FR" ? REGISTRY_FR : REGISTRY_EN;
+  test(`${locale} the people registry no longer orders a link a bare first name cannot satisfy`, () => {
+    const section = docSection(read(path), registry);
+    assert.notEqual(section, "", "the registry section must still exist");
+    assert.doesNotMatch(
+      section,
+      locale === "FR" ? /interdit/i : /forbidden/i,
+      "an absolute ban on a bare-first-name link is what left inventing a surname as the only exit",
+    );
+    assert.match(
+      section,
+      locale === "FR" ? /Discipline d'identité/ : /Identity discipline/,
+      "the registry must send the reader to the discipline that says what to do with an unresolved name",
+    );
+  });
+}
+
+// ── The same trap, in the OPERATIVE text: the sub-agent prompts ─────────────
+// The prose sections are read by a human maintainer; these bullets are handed to
+// the extraction sub-agents verbatim, and they still carried the pair that has no
+// exit — "create the backlinks even if the target page doesn't exist" NEXT TO
+// "never a first name alone". Read together by an agent holding "Jérémy (front
+// Candor)", the only way to obey both is to produce a surname.
+//
+// The phrasing must therefore say what to DO (no full name → no link at all),
+// never merely what is forbidden. Asserted file-wide on purpose: these bullets sit
+// inside fenced prompt blocks, and a rule that moved into another prompt would
+// still be handed to an agent.
+const LINKLESS_EN = /no full name[^.\n]*no link/i;
+const LINKLESS_FR = /pas de nom complet[^.\n]*pas de lien/i;
+
+for (const { name, locale, path } of SKILLS) {
+  test(`${locale} ${name}: an unresolved first name yields NO link, and the old ban is gone`, () => {
+    const text = read(path);
+    assert.doesNotMatch(
+      text,
+      locale === "FR" ? /jamais de prénom seul/i : /never a first name alone/i,
+      "that phrasing bans the link while the neighbouring bullet still demands one — inventing the surname is the only way out",
+    );
+    assert.match(
+      text,
+      locale === "FR" ? LINKLESS_FR : LINKLESS_EN,
+      "the prompt must state the action (no full name → no link at all), not only the ban",
+    );
+  });
+}

--- a/scripts/lib/note-refresh.mjs
+++ b/scripts/lib/note-refresh.mjs
@@ -53,6 +53,34 @@ export function duplicateFrontmatterKeys(content) {
   return dupes;
 }
 
+const CONFIDENCE_BLOCK = /^> \*\*Confidence\*\* — .*$/m;
+
+/**
+ * Returns `body` with the confidence block written in the builder's own slot: under
+ * the H1, after the homonymy block when there is one, above the prose. Used only
+ * when the page carries no block yet — every card written before this shipped is in
+ * exactly that shape, and moving the field alone would leave a card that says how
+ * sure it is to a `grep` and nothing at all to the human reading it in Obsidian.
+ * Pure.
+ */
+function insertConfidenceBlock(body, line) {
+  const lines = body.split("\n");
+  const h1 = lines.findIndex((l) => /^# /.test(l));
+  if (h1 === -1) return `${line}\n\n${body}`;
+  let at = h1 + 1;
+  // Past the blank line, then past the homonymy block if the card has one: WHICH
+  // one comes before HOW SURE, because it is what makes the card usable to the
+  // next resolution. Inserting higher would rewrite, one refresh at a time, a
+  // layout the builder guarantees on every new card.
+  while (at < lines.length && lines[at].trim() === "") at += 1;
+  if (at < lines.length && /^> \*\*Which one\*\* — /.test(lines[at])) {
+    at += 1;
+    while (at < lines.length && lines[at].trim() === "") at += 1;
+  }
+  lines.splice(at, 0, line, "");
+  return lines.join("\n");
+}
+
 /**
  * Returns the page's content with `updated:` set to `today` (replaced in place, or
  * appended to the frontmatter when the page had none) and `section` appended to the
@@ -99,7 +127,10 @@ export function refreshNote({ content, today, section, confidence }) {
     // source, and a string replacement expands `$&`, `` $` ``, `$'` and `$$` — a
     // basis quoting a rate as "$500" beside a "$&" spliced the OLD block back into
     // the new one, which is the two-different-things state this block exists to end.
-    body = body.replace(/^> \*\*Confidence\*\* — .*$/m, () => `> **Confidence** — ${rendered}`);
+    const line = `> **Confidence** — ${rendered}`;
+    body = CONFIDENCE_BLOCK.test(body)
+      ? body.replace(CONFIDENCE_BLOCK, () => line)
+      : insertConfidenceBlock(body, line);
   }
 
   body = body.replace(/\s*$/, "");

--- a/scripts/lib/note-refresh.mjs
+++ b/scripts/lib/note-refresh.mjs
@@ -95,7 +95,11 @@ export function refreshNote({ content, today, section, confidence }) {
     const key = lines.findIndex((l) => /^confidence:/.test(l));
     if (key === -1) lines.push(`confidence: ${confidence.level}`);
     else lines[key] = `confidence: ${confidence.level}`;
-    body = body.replace(/^> \*\*Confidence\*\* — .*$/m, `> **Confidence** — ${rendered}`);
+    // A FUNCTION replacement, never a string: the basis is free-form prose about a
+    // source, and a string replacement expands `$&`, `` $` ``, `$'` and `$$` — a
+    // basis quoting a rate as "$500" beside a "$&" spliced the OLD block back into
+    // the new one, which is the two-different-things state this block exists to end.
+    body = body.replace(/^> \*\*Confidence\*\* — .*$/m, () => `> **Confidence** — ${rendered}`);
   }
 
   body = body.replace(/\s*$/, "");

--- a/scripts/lib/note-refresh.mjs
+++ b/scripts/lib/note-refresh.mjs
@@ -15,6 +15,12 @@
 
 const FRONTMATTER_RE = /^(---\r?\n)([\s\S]*?)(\r?\n---\r?\n?)([\s\S]*)$/;
 
+// The SAME renderer the builder uses (and the same refusals on a bad level or a
+// missing basis). Two renderers would let a promoted card and a fresh one word
+// their reliability differently, which is the fiction a checker with its own
+// parser measures — F16, on the writing side.
+import { confidenceLine } from "./filed-note.mjs";
+
 /** Splits a note into its frontmatter block and body, or null when it has none. Pure. */
 function splitNote(content) {
   const m = content.match(FRONTMATTER_RE);
@@ -58,7 +64,7 @@ export function duplicateFrontmatterKeys(content) {
  * instead of appended to. Appending to a damaged page would keep it unreadable and
  * hide the damage one refresh longer.
  */
-export function refreshNote({ content, today, section }) {
+export function refreshNote({ content, today, section, confidence }) {
   if (!today) throw new Error("today (YYYY-MM-DD) is required to bump `updated:`");
   const parts = splitNote(content);
   if (!parts) {
@@ -79,7 +85,20 @@ export function refreshNote({ content, today, section }) {
   if (at === -1) lines.push(`updated: ${today}`);
   else lines[at] = `updated: ${today}`;
 
-  const body = parts.body.replace(/\s*$/, "");
+  // A re-verified card is promoted in BOTH places at once. Rewriting the field
+  // and leaving the block (or the reverse) would leave the page asserting two
+  // different things about its own reliability — the conflation this whole
+  // block exists to end, reproduced inside the fix for it.
+  let body = parts.body;
+  if (confidence) {
+    const rendered = confidenceLine(confidence);
+    const key = lines.findIndex((l) => /^confidence:/.test(l));
+    if (key === -1) lines.push(`confidence: ${confidence.level}`);
+    else lines[key] = `confidence: ${confidence.level}`;
+    body = body.replace(/^> \*\*Confidence\*\* — .*$/m, `> **Confidence** — ${rendered}`);
+  }
+
+  body = body.replace(/\s*$/, "");
   const appended = section ? `${body}\n\n${section.replace(/\s*$/, "")}\n` : `${body}\n`;
   return `${parts.open}${lines.join("\n")}${parts.close}${appended}`;
 }

--- a/scripts/lib/note-refresh.mjs
+++ b/scripts/lib/note-refresh.mjs
@@ -65,8 +65,11 @@ const CONFIDENCE_BLOCK = /^> \*\*Confidence\*\* — .*$/m;
  */
 function insertConfidenceBlock(body, line) {
   const lines = body.split("\n");
+  // The title is a heading at the START of a line — a "# " inside a sentence is
+  // prose, and burying the marker under it would hide the very thing it states.
+  // No heading at all is not a special case: the walk simply starts at the top,
+  // which keeps the blank line the body opens with rather than doubling it.
   const h1 = lines.findIndex((l) => /^# /.test(l));
-  if (h1 === -1) return `${line}\n\n${body}`;
   let at = h1 + 1;
   // Past the blank line, then past the homonymy block if the card has one: WHICH
   // one comes before HOW SURE, because it is what makes the card usable to the

--- a/scripts/lib/note-refresh.test.mjs
+++ b/scripts/lib/note-refresh.test.mjs
@@ -294,3 +294,106 @@ Front-end at Candor.
 `,
   );
 });
+
+test("promoting a card that has NO confidence yet appends the field", () => {
+  // Every card written before this shipped is in exactly this shape, so this is
+  // the ordinary promotion, not an edge case: without the append, a re-verified
+  // pre-v4.6.0 card could never record that it was confirmed.
+  const card = `---
+type: person
+created: 2026-06-02
+updated: 2026-07-19
+tags: [candor]
+---
+
+# Jérémy Hinard
+
+Front-end at Candor.
+`;
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "probable", basis: "the Candor org note, 2026-06." },
+  });
+  assert.equal(
+    out,
+    `---
+type: person
+created: 2026-06-02
+updated: 2026-08-03
+tags: [candor]
+confidence: probable
+---
+
+# Jérémy Hinard
+
+Front-end at Candor.
+`,
+  );
+});
+
+test("a frontmatter VALUE mentioning confidence: is not mistaken for the field", () => {
+  // Same shape as the `updated:`-suffix test above, and the same damage: the
+  // rewrite would land on someone else's line and destroy it (F12 was one
+  // hand-edited frontmatter key away from unreadable).
+  const card = `---
+type: person
+created: 2026-06-02
+updated: 2026-07-19
+tags: [candor]
+note: "ask him to raise confidence: unclear so far"
+confidence: probable
+---
+
+# Jérémy Hinard
+
+Front-end at Candor.
+`;
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "observed", basis: "he introduced himself in #candor." },
+  });
+  assert.match(out, /\nnote: "ask him to raise confidence: unclear so far"\n/);
+  assert.match(out, /\nconfidence: observed\n/);
+});
+
+test("an INDENTED mention of the block does not absorb the promotion, even first", () => {
+  // These pages are edited by hand in Obsidian, so the card's own block is not
+  // guaranteed to be the first thing that looks like one. The block is the one
+  // at the START of a line: promoting an indented quotation instead would leave
+  // the real block stale, and the page would then say two different things
+  // about its own reliability — which is what the block exists to end.
+  const card = `---
+type: person
+created: 2026-06-02
+updated: 2026-07-19
+tags: [candor]
+confidence: probable
+---
+
+# Jérémy Hinard
+
+Noted from his manager's card, which still reads
+    > **Confidence** — 🔴 unverified · nothing but a first name, which is why we asked.
+
+> **Confidence** — 🟡 derived or probable · the surname comes from the Candor org note.
+
+Front-end at Candor.
+`;
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "observed", basis: "he introduced himself in #candor." },
+  });
+  assert.match(
+    out,
+    /^> \*\*Confidence\*\* — ✅ observed · he introduced himself in #candor\.$/m,
+    "the card's own block is promoted",
+  );
+  assert.match(
+    out,
+    /^ {4}> \*\*Confidence\*\* — 🔴 unverified · nothing but a first name, which is why we asked\.$/m,
+    "and the quoted one is left exactly as it was",
+  );
+});

--- a/scripts/lib/note-refresh.test.mjs
+++ b/scripts/lib/note-refresh.test.mjs
@@ -332,6 +332,25 @@ Front-end at Candor.
   );
 });
 
+test("a basis carrying `$` sequences lands verbatim, not expanded by the replace", () => {
+  // Found by review. The replacement was handed to `String.prototype.replace` as a
+  // STRING, so `$&`, `` $` ``, `$'` and `$$` in it are replacement patterns: the
+  // basis is free-form prose written by an LLM about a source, and a rate quoted
+  // as "$500" next to a "$&" would splice the OLD block back into the new one.
+  // Silent, and it lands the page in the exact two-different-things state the
+  // comment four lines above the replace swears it prevents.
+  const basis = "he quoted $500/day in #candor, and the thread cites $& and $` verbatim.";
+  const out = refreshNote({
+    content: CARD,
+    today: "2026-08-03",
+    confidence: { level: "observed", basis },
+  });
+
+  assert.match(out, new RegExp(`^> \\*\\*Confidence\\*\\* — ✅ observed · ${basis.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+  assert.equal(out.match(/^> \*\*Confidence\*\*/gm).length, 1, "exactly one block, not a spliced pair");
+  assert.doesNotMatch(out, /derived or probable/, "the old marker must be gone, not re-injected by `$&`");
+});
+
 test("a frontmatter VALUE mentioning confidence: is not mistaken for the field", () => {
   // Same shape as the `updated:`-suffix test above, and the same damage: the
   // rewrite would land on someone else's line and destroy it (F12 was one

--- a/scripts/lib/note-refresh.test.mjs
+++ b/scripts/lib/note-refresh.test.mjs
@@ -386,6 +386,112 @@ Back-end at Candor.
   );
 });
 
+// ── Where the block goes when the page is not the tidy shape ───────────────
+// The mutation pass on the insertion above left twelve survivors, all of them the
+// same admission: only the tidy card was ever fed to it. These four feed the
+// shapes a vault written by hand in Obsidian actually holds.
+
+test("no H1 at all — the block leads the page instead of hunting for a heading", () => {
+  // `# ` must be matched at the START of a line: this body carries "# " inside a
+  // sentence, and treating that as the title would bury the marker mid-prose.
+  const card = `---
+type: person
+created: 2026-06-02
+updated: 2026-07-19
+tags: [candor]
+---
+
+He filed issue # 12 about the Candor rollout.
+`;
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "unverified", basis: "a single mention, no source." },
+  });
+  assert.equal(
+    out,
+    `---
+type: person
+created: 2026-06-02
+updated: 2026-08-03
+tags: [candor]
+confidence: unverified
+---
+
+> **Confidence** — 🔴 unverified · a single mention, no source.
+
+He filed issue # 12 about the Candor rollout.
+`,
+  );
+});
+
+test("a card with a title and no body yet — the block lands, nothing throws", () => {
+  // The insertion walks forward past blank lines, so a page that ENDS right after
+  // its heading is where it can walk off the end. A stub card is ordinary: the
+  // builder writes the page, the prose comes later.
+  const out = refreshNote({
+    content: "---\ntype: person\nupdated: 2026-07-19\ntags: [candor]\n---\n\n# Jérémy Hinard\n",
+    today: "2026-08-03",
+    confidence: { level: "probable", basis: "the Candor org note, 2026-06." },
+  });
+  assert.equal(
+    out,
+    `---
+type: person
+updated: 2026-08-03
+tags: [candor]
+confidence: probable
+---
+
+# Jérémy Hinard
+
+> **Confidence** — 🟡 derived or probable · the Candor org note, 2026-06.
+`,
+  );
+});
+
+test("a line of spaces is a blank line — an editor's trailing whitespace does not split the card", () => {
+  // Obsidian and most editors leave these behind. Treating "   " as content would
+  // wedge the block between the heading and its own blank line.
+  const card = "---\ntype: person\nupdated: 2026-07-19\ntags: [c]\n---\n\n# Jérémy Hinard\n   \nFront-end.\n";
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "probable", basis: "the org note." },
+  });
+  assert.match(
+    out,
+    /# Jérémy Hinard\n {3}\n> \*\*Confidence\*\* — 🟡 derived or probable · the org note\.\n\nFront-end\.\n/,
+  );
+});
+
+test("an INDENTED homonymy line is not the homonymy block, so the marker stays above it", () => {
+  // The twin of the indented-Confidence test: the block is the one at the START of
+  // a line. A quotation of someone else's card must not push this card's marker
+  // below it, or the page reads as if the quote were its own answer to "which one".
+  const card = `---
+type: person
+updated: 2026-07-19
+tags: [c]
+---
+
+# Romain Durand
+
+    > **Which one** — the Romain at Acme, quoted from his card.
+
+Back-end at Candor.
+`;
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "probable", basis: "the Candor org note." },
+  });
+  assert.match(
+    out,
+    /# Romain Durand\n\n> \*\*Confidence\*\* — 🟡 derived or probable · the Candor org note\.\n\n {4}> \*\*Which one\*\*/,
+  );
+});
+
 test("a basis carrying `$` sequences lands verbatim, not expanded by the replace", () => {
   // Found by review. The replacement was handed to `String.prototype.replace` as a
   // STRING, so `$&`, `` $` ``, `$'` and `$$` in it are replacement patterns: the

--- a/scripts/lib/note-refresh.test.mjs
+++ b/scripts/lib/note-refresh.test.mjs
@@ -244,3 +244,53 @@ test("a note with no frontmatter is refused rather than silently given one", () 
     },
   );
 });
+
+// ── Promoting a confidence marker, when the re-verification actually happens ──
+// The identity discipline's rule 6 says a 🟡 or 🔴 card is a lead, re-verified
+// before anything is resolved against it. A marker with no supported way to
+// change is a marker that says 🟡 forever — and one readers learn to ignore,
+// which is the block rotting back into the decoration it exists to replace.
+// Freehand is not an option here: editing a frontmatter key by hand is exactly
+// what put two `updated:` keys on one page and made it unreadable (F12).
+
+const CARD = `---
+type: person
+created: 2026-06-02
+updated: 2026-07-19
+tags: [candor]
+confidence: probable
+---
+
+# Jérémy Hinard
+
+> **Confidence** — 🟡 derived or probable · the surname comes from the Candor org note.
+
+Front-end at Candor.
+`;
+
+test("promoting confidence rewrites the FIELD and the visible block together", () => {
+  // Rewriting one and not the other leaves the page asserting two different
+  // things about itself — this plan's own defect shape, inside the fix for it.
+  const out = refreshNote({
+    content: CARD,
+    today: "2026-08-03",
+    confidence: { level: "observed", basis: "he introduced himself in #candor, 2026-08-03." },
+  });
+  assert.equal(
+    out,
+    `---
+type: person
+created: 2026-06-02
+updated: 2026-08-03
+tags: [candor]
+confidence: observed
+---
+
+# Jérémy Hinard
+
+> **Confidence** — ✅ observed · he introduced himself in #candor, 2026-08-03.
+
+Front-end at Candor.
+`,
+  );
+});

--- a/scripts/lib/note-refresh.test.mjs
+++ b/scripts/lib/note-refresh.test.mjs
@@ -465,6 +465,49 @@ test("a line of spaces is a blank line — an editor's trailing whitespace does 
   );
 });
 
+test("a card that is a homonymy block and nothing else — the marker lands under it, nothing throws", () => {
+  // The twin of the stub-card test, one branch deeper: the walk past the homonymy
+  // block is its own loop, and this is where IT can step off the end. Asserting
+  // the first loop's boundary and not this one is how a guard half-holds.
+  const out = refreshNote({
+    content: "---\ntype: person\nupdated: 2026-07-19\ntags: [c]\n---\n\n# Romain Durand\n\n> **Which one** — back-end at Candor.\n",
+    today: "2026-08-03",
+    confidence: { level: "probable", basis: "the Candor org note." },
+  });
+  assert.equal(
+    out,
+    `---
+type: person
+updated: 2026-08-03
+tags: [c]
+confidence: probable
+---
+
+# Romain Durand
+
+> **Which one** — back-end at Candor.
+
+> **Confidence** — 🟡 derived or probable · the Candor org note.
+`,
+  );
+});
+
+test("editor whitespace under the homonymy block is a blank line there too", () => {
+  // Same reason as under the title: "   " is a blank line to a reader, so the
+  // marker belongs after it, not wedged between the block and its own spacing.
+  const card =
+    "---\ntype: person\nupdated: 2026-07-19\ntags: [c]\n---\n\n# Romain Durand\n\n> **Which one** — back-end at Candor.\n   \nBack-end.\n";
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "probable", basis: "the Candor org note." },
+  });
+  assert.match(
+    out,
+    /> \*\*Which one\*\* — back-end at Candor\.\n {3}\n> \*\*Confidence\*\* — 🟡 derived or probable · the Candor org note\.\n\nBack-end\.\n/,
+  );
+});
+
 test("an INDENTED homonymy line is not the homonymy block, so the marker stays above it", () => {
   // The twin of the indented-Confidence test: the block is the one at the START of
   // a line. A quotation of someone else's card must not push this card's marker

--- a/scripts/lib/note-refresh.test.mjs
+++ b/scripts/lib/note-refresh.test.mjs
@@ -295,10 +295,18 @@ Front-end at Candor.
   );
 });
 
-test("promoting a card that has NO confidence yet appends the field", () => {
+test("promoting a card that has NO confidence yet appends the field AND writes the block", () => {
   // Every card written before this shipped is in exactly this shape, so this is
   // the ordinary promotion, not an edge case: without the append, a re-verified
   // pre-v4.6.0 card could never record that it was confirmed.
+  //
+  // The block is written too — the review raised this as a candidate and it was
+  // left open, so here is the answer. A promotion that moves only the field leaves
+  // a card that says how sure it is to a `grep` and says nothing at all to the
+  // human reading it in Obsidian, while every card the builder writes shows the
+  // marker. The rule this release ships is that the card SAYS how sure it is, so
+  // the two halves move together, in the builder's own slot: under the H1, after
+  // the "Which one" block when there is one, above the body.
   const card = `---
 type: person
 created: 2026-06-02
@@ -327,7 +335,53 @@ confidence: probable
 
 # Jérémy Hinard
 
+> **Confidence** — 🟡 derived or probable · the Candor org note, 2026-06.
+
 Front-end at Candor.
+`,
+  );
+});
+
+test("the promoted block lands under the homonymy block, never above it", () => {
+  // The builder's own order: "Which one" first (it is what makes the card usable
+  // to the next resolution), then how sure that resolution is. A promotion that
+  // inserted itself higher would rewrite, one refresh at a time, a layout the
+  // builder guarantees on every new card.
+  const card = `---
+type: person
+created: 2026-06-02
+updated: 2026-07-19
+tags: [candor]
+---
+
+# Romain Durand
+
+> **Which one** — back-end at Candor, not the Romain at Acme.
+
+Back-end at Candor.
+`;
+  const out = refreshNote({
+    content: card,
+    today: "2026-08-03",
+    confidence: { level: "probable", basis: "the Candor org note, 2026-06." },
+  });
+  assert.equal(
+    out,
+    `---
+type: person
+created: 2026-06-02
+updated: 2026-08-03
+tags: [candor]
+confidence: probable
+---
+
+# Romain Durand
+
+> **Which one** — back-end at Candor, not the Romain at Acme.
+
+> **Confidence** — 🟡 derived or probable · the Candor org note, 2026-06.
+
+Back-end at Candor.
 `,
   );
 });

--- a/scripts/lib/startup-payload-guard.test.mjs
+++ b/scripts/lib/startup-payload-guard.test.mjs
@@ -9,9 +9,9 @@ import { fileURLToPath } from "node:url";
 // .additionalContext` is echoed to a CLI owner VERBATIM, prefixed
 // `SessionStart:startup says:`, before they have typed a word (field-verified
 // 2026-07-28, Claude Code v2.1.220). The field log named three emitters; the audit
-// found four. So the leak does not scale with our care — it scales with the number
-// of hooks we add, and the next one will be written by someone who never read this
-// story.
+// found four, and a fifth then arrived and escaped it (see `EMITS` below). So the
+// leak does not scale with our care — it scales with the number of hooks we add,
+// and the next one will be written by someone who never read this story.
 //
 // Each emitter bounds its own payload, in its own test, because only that test
 // knows what the block is for (housekeeping gets less room than a RESTART REQUIRED
@@ -28,21 +28,36 @@ const SCRIPTS = join(dirname(fileURLToPath(import.meta.url)), "..");
 // and a guard that silently stops matching is worse than no guard.
 const BOUND_MARKER = "volume IS the defect (F5)";
 
+// …which is exactly what this guard then did to itself. It matched the literal
+// `additionalContext:`, so `status-hook-output.mjs` — which ASSIGNS the key
+// (`hookSpecificOutput.additionalContext = …`) because the key must be ABSENT
+// rather than empty when there is no version — was invisible to it: a fifth
+// emitter shipped, the pinned list stayed at four, and every test here went green.
+// The scan is still purely textual (no parse); it just no longer assumes the
+// object-literal shape.
+const EMITS = /additionalContext\s*[:=]/;
+
 function emitters() {
   return [SCRIPTS, join(SCRIPTS, "lib")].flatMap((dir) =>
     readdirSync(dir)
       .filter((name) => name.endsWith(".mjs") && !name.endsWith(".test.mjs"))
       .map((name) => ({ name, path: join(dir, name), test: join(dir, name.replace(/\.mjs$/, ".test.mjs")) }))
-      .filter(({ path }) => readFileSync(path, "utf8").includes("additionalContext:")),
+      .filter(({ path }) => EMITS.test(readFileSync(path, "utf8"))),
   );
 }
 
-test("the F5 audit knows every additionalContext emitter — the field log named three, there are four", () => {
+test("the F5 audit knows every additionalContext emitter — the field log named three, there are five", () => {
   // Pin the list. A new startup hook lands here first, which is the moment to ask
   // whether the owner should be reading its prose at all.
   assert.deepEqual(
     emitters().map(({ name }) => name).sort(),
-    ["actions-log-seed.mjs", "session-self-heal.mjs", "universe-reminder.mjs", "wiki-health-nudge.mjs"],
+    [
+      "actions-log-seed.mjs",
+      "session-self-heal.mjs",
+      "status-hook-output.mjs",
+      "universe-reminder.mjs",
+      "wiki-health-nudge.mjs",
+    ],
   );
 });
 
@@ -63,7 +78,7 @@ test("the scan reads real sources, so an empty result cannot pass for a clean on
   // vacuously forever — the quietest way there is to lose a guard.
   const found = emitters();
 
-  assert.equal(found.length, 4);
+  assert.equal(found.length, 5);
   assert.ok(
     found.every(({ path }) => readFileSync(path, "utf8").includes("hookEventName")),
     "an emitter was matched that does not build a hook output at all",

--- a/scripts/lib/status-hook-output.mjs
+++ b/scripts/lib/status-hook-output.mjs
@@ -17,16 +17,23 @@
 // No version (a brain that cannot say which release it came from) → the key is
 // ABSENT rather than empty: an additionalContext saying "[engine] null" would be
 // relayed to the owner as fact. Silence is the honest rendering here.
+//
+// `leadLine` is the restart nudge, and it outranks the version for a documented
+// reason (ADR 0036): until the owner restarts, nothing they read comes from the
+// engine they now have — the manifest already names the NEW version while the OLD
+// code is still answering. So a pending restart both demotes the version on the
+// CLI and silences its chat relay entirely, since additionalContext would carry
+// that claim to Desktop with no restart line beside it to qualify it.
 // ─────────────────────────────────────────────────────────────────────────────
 
-export function buildStatusHookOutput({ versionLine = null, statusLines = [] } = {}) {
+export function buildStatusHookOutput({ leadLine = null, versionLine = null, statusLines = [] } = {}) {
   const hookSpecificOutput = { hookEventName: "SessionStart" };
-  if (versionLine) {
+  if (versionLine && !leadLine) {
     hookSpecificOutput.additionalContext =
       `[engine] ${versionLine} — state this version once, verbatim, in your first message.`;
   }
   return {
     hookSpecificOutput,
-    systemMessage: [versionLine, ...statusLines].filter(Boolean).join("\n"),
+    systemMessage: [leadLine, versionLine, ...statusLines].filter(Boolean).join("\n"),
   };
 }

--- a/scripts/lib/status-hook-output.mjs
+++ b/scripts/lib/status-hook-output.mjs
@@ -1,0 +1,32 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// status-hook-output.mjs — the pure emission seam of the SessionStart status
+// banner (repo / RAG / key / bootstrap / restart), plus the engine version.
+//
+// TWO CHANNELS, because they reach two different halves of the users (ADR 0036's
+// channel matrix):
+//   • `systemMessage` — rendered directly by the CLI terminal, and DROPPED by the
+//     Code tab of Claude Desktop. Every status line this banner has ever printed
+//     has therefore been CLI-only.
+//   • `hookSpecificOutput.additionalContext` — injected into the agent's context,
+//     so the agent relays it in the chat: the ONLY Desktop-visible channel.
+// The version rides both, because "which version am I running" is a question a
+// Desktop owner asks just as often. The other status lines keep their CLI-only
+// reach on purpose: repo/RAG chatter in every first message is noise, a version
+// stated once is an identity.
+//
+// No version (a brain that cannot say which release it came from) → the key is
+// ABSENT rather than empty: an additionalContext saying "[engine] null" would be
+// relayed to the owner as fact. Silence is the honest rendering here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildStatusHookOutput({ versionLine = null, statusLines = [] } = {}) {
+  const hookSpecificOutput = { hookEventName: "SessionStart" };
+  if (versionLine) {
+    hookSpecificOutput.additionalContext =
+      `[engine] ${versionLine} — state this version once, verbatim, in your first message.`;
+  }
+  return {
+    hookSpecificOutput,
+    systemMessage: [versionLine, ...statusLines].filter(Boolean).join("\n"),
+  };
+}

--- a/scripts/lib/status-hook-output.test.mjs
+++ b/scripts/lib/status-hook-output.test.mjs
@@ -93,6 +93,20 @@ test("a pending restart silences the version's chat relay, not just its rank", (
   );
 });
 
+// The F5 bound, and this emitter shipped without one: the audit that pins every
+// additionalContext emitter filtered on the literal `additionalContext:`, while
+// this file ASSIGNS the key — so it was the fifth emitter and the list stayed at
+// four. The CLI echoes this payload verbatim, prefixed `SessionStart:startup
+// says:`, before the owner types a word; the version itself is a fact about their
+// brain, so only OUR framing around it is bounded here.
+test("the version relay stays one short directive — volume IS the defect (F5)", () => {
+  const versionLine = "⚙️ Kenjaku engine v4.6.0";
+  const ctx = buildStatusHookOutput({ versionLine }).hookSpecificOutput.additionalContext;
+  const framing = ctx.length - versionLine.length;
+
+  assert.ok(framing <= 90, `the version framing grew back to ${framing} chars:\n${ctx}`);
+});
+
 test("called with nothing at all — no banner, no relay, and no crash", () => {
   // The default for `statusLines` is what a caller with nothing to report hands
   // in; a default carrying content would put words in the engine's mouth.

--- a/scripts/lib/status-hook-output.test.mjs
+++ b/scripts/lib/status-hook-output.test.mjs
@@ -60,3 +60,35 @@ test("absent status lines are dropped, not rendered as blanks", () => {
     "⚙️ Kenjaku engine v4.5.0\n📁 Repo up to date.\n🧠 RAG up to date — 436/436 files indexed.",
   );
 });
+
+// The restart nudge KEEPS the lead it was given for a documented reason: until
+// the owner restarts, nothing else they read comes from the engine they now have
+// — and that includes this version, which is read from the manifest an update
+// just rewrote while the OLD code is still running. Version first would state,
+// with authority, a version that is not the one answering.
+test("a pending restart still leads, and the version follows it", () => {
+  assert.equal(
+    buildStatusHookOutput({
+      leadLine: "⚠️ RESTART Claude to finish the engine update",
+      versionLine: "⚙️ Kenjaku engine v4.6.0",
+      statusLines: ["📁 Repo up to date."],
+    }).systemMessage,
+    "⚠️ RESTART Claude to finish the engine update\n⚙️ Kenjaku engine v4.6.0\n📁 Repo up to date.",
+  );
+});
+
+// Same reasoning, one channel further — and this is where it bites, because the
+// CLI's restart line does NOT ride additionalContext: relayed alone in the chat,
+// "you are running v4.6.0" would be a bare false claim on a Desktop session that
+// is still executing v4.5.0. So while a restart is pending, the chat says nothing
+// about the version and the owner keeps the one message that matters.
+test("a pending restart silences the version's chat relay, not just its rank", () => {
+  assert.deepEqual(
+    buildStatusHookOutput({
+      leadLine: "⚠️ RESTART Claude to finish the engine update",
+      versionLine: "⚙️ Kenjaku engine v4.6.0",
+      statusLines: ["📁 Repo up to date."],
+    }).hookSpecificOutput,
+    { hookEventName: "SessionStart" },
+  );
+});

--- a/scripts/lib/status-hook-output.test.mjs
+++ b/scripts/lib/status-hook-output.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildStatusHookOutput } from "./status-hook-output.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The SessionStart status banner's emission, as a pure seam.
+//
+// Why it exists: session-status.mjs is a top-level script no test can import
+// (named debt, 0 % mutation), and it emitted `systemMessage` ONLY — which the
+// Code tab of Claude Desktop drops. So its lines have always been CLI-only.
+// Adding the version there and stopping would have shipped it to half the
+// users while reading, from here, exactly like shipping it to all of them.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("the version leads the banner on the CLI, and reaches Desktop through the chat relay", () => {
+  assert.deepEqual(
+    buildStatusHookOutput({
+      versionLine: "⚙️ Kenjaku engine v4.5.0",
+      statusLines: ["📁 Repo up to date.", "🧠 RAG up to date — 436/436 files indexed."],
+    }),
+    {
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext:
+          "[engine] ⚙️ Kenjaku engine v4.5.0 — state this version once, verbatim, in your first message.",
+      },
+      systemMessage:
+        "⚙️ Kenjaku engine v4.5.0\n📁 Repo up to date.\n🧠 RAG up to date — 436/436 files indexed.",
+    },
+  );
+});
+
+// The absence twin: a brain that cannot say which release it runs (no install
+// ref) must fall silent on BOTH channels rather than relay an empty directive —
+// and the CLI banner must keep its own lines, unchanged, as it always had them.
+test("no version → the banner is exactly what it was before, and Desktop hears nothing", () => {
+  assert.deepEqual(
+    buildStatusHookOutput({
+      versionLine: null,
+      statusLines: ["📁 Repo up to date.", "🧠 RAG up to date — 436/436 files indexed."],
+    }),
+    {
+      hookSpecificOutput: { hookEventName: "SessionStart" },
+      systemMessage: "📁 Repo up to date.\n🧠 RAG up to date — 436/436 files indexed.",
+    },
+  );
+});
+
+// The banner's own long-standing behaviour, moved here with the emission: each
+// status line is optional (no restart pending, no key missing, no bootstrap), and
+// an absent one must leave no blank line behind. Two present, one absent, so a
+// mutant dropping the filter shows up as a real blank rather than as an empty
+// systemMessage nobody would notice.
+test("absent status lines are dropped, not rendered as blanks", () => {
+  assert.equal(
+    buildStatusHookOutput({
+      versionLine: "⚙️ Kenjaku engine v4.5.0",
+      statusLines: [null, "📁 Repo up to date.", undefined, "🧠 RAG up to date — 436/436 files indexed."],
+    }).systemMessage,
+    "⚙️ Kenjaku engine v4.5.0\n📁 Repo up to date.\n🧠 RAG up to date — 436/436 files indexed.",
+  );
+});

--- a/scripts/lib/status-hook-output.test.mjs
+++ b/scripts/lib/status-hook-output.test.mjs
@@ -92,3 +92,20 @@ test("a pending restart silences the version's chat relay, not just its rank", (
     { hookEventName: "SessionStart" },
   );
 });
+
+test("called with nothing at all — no banner, no relay, and no crash", () => {
+  // The default for `statusLines` is what a caller with nothing to report hands
+  // in; a default carrying content would put words in the engine's mouth.
+  assert.deepEqual(buildStatusHookOutput(), {
+    hookSpecificOutput: { hookEventName: "SessionStart" },
+    systemMessage: "",
+  });
+  assert.deepEqual(buildStatusHookOutput({ versionLine: "⚙️ Kenjaku engine v4.6.0" }), {
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext:
+        "[engine] ⚙️ Kenjaku engine v4.6.0 — state this version once, verbatim, in your first message.",
+    },
+    systemMessage: "⚙️ Kenjaku engine v4.6.0",
+  });
+});

--- a/scripts/refresh-note.mjs
+++ b/scripts/refresh-note.mjs
@@ -84,6 +84,10 @@ export function runRefresh(argv, deps = realRefreshDeps) {
       content: deps.readFile(absPath),
       today: deps.today(),
       section: spec.section,
+      // Promoting a re-verified card is a REFRESH, not a rewrite: it goes
+      // through the same by-key writer as `updated:`, so nobody has to hand-edit
+      // frontmatter to record that a 🟡 identity has since been confirmed.
+      confidence: spec.confidence,
     });
   } catch (err) {
     deps.error(`✗ vault/${spec.path}: ${err.message}`);

--- a/scripts/refresh-note.mjs
+++ b/scripts/refresh-note.mjs
@@ -16,7 +16,7 @@
 // it names the damage instead. Exits 0 when written, 1 when refused/error.
 // ─────────────────────────────────────────────────────────────────────────────
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, posix } from "node:path";
 
 import { refreshNote } from "./lib/note-refresh.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
@@ -63,9 +63,15 @@ export function runRefresh(argv, deps = realRefreshDeps) {
   }
 
   const vaultDir = toPosix(join(deps.cwd(), "vault"));
-  const absPath = toPosix(join(vaultDir, spec.path));
+  // NORMALISE, then compare. `join` on POSIX leaves a Windows-style `..\x.md`
+  // untouched, and `toPosix` then hands back `<vault>/../x.md` — a string that
+  // starts with the vault and that `fs` resolves outside it. So the escape passed
+  // the check and the refresh rewrote the target (reproduced before it was fixed).
+  // `posix.normalize` collapses the climb first, on both platforms.
+  const absPath = posix.normalize(toPosix(join(vaultDir, spec.path)));
   // Containment, not politeness: a `..` in the spec would otherwise let a refresh
-  // rewrite any file the brain can reach.
+  // rewrite any file the brain can reach — and the spec arrives on stdin, from an
+  // LLM invocation, carrying free-form text.
   if (!absPath.startsWith(`${vaultDir}/`)) {
     deps.error(`✗ "${spec.path}" is outside the vault — a refresh only ever touches vault/.`);
     return 1;

--- a/scripts/refresh-note.test.mjs
+++ b/scripts/refresh-note.test.mjs
@@ -120,6 +120,39 @@ test("a SIBLING of the vault is refused too — the separator is the whole guard
   }
 });
 
+test("a BACKSLASH escape is refused too — the guard normalises before it compares", () => {
+  // Found by review, and reproduced against a real brain before being fixed here.
+  // `join("/brain/vault", "..\\outside.md")` leaves the backslash literal on POSIX;
+  // `toPosix` then turns it into "/brain/vault/../outside.md", which starts with
+  // "/brain/vault/" and sailed through the containment check — while `fs` resolved
+  // it to the escaped target. Read AND write: the spec arrives on stdin from an LLM
+  // invocation, and this release widened what it carries (a free-form basis).
+  //
+  // Run as a real process on purpose: the injected `exists`/`readFile` fakes key on
+  // literal strings, so they cannot tell a path `fs` would resolve elsewhere from
+  // one it would not — the fake would report the escape as "does not exist" and the
+  // test would pass on the wrong reason.
+  const brain = mkdtempSync(join(tmpdir(), "refresh-escape-"));
+  mkdirSync(join(brain, "vault", "topics"), { recursive: true });
+  writeFileSync(join(brain, "vault", "topics", "crise.md"), PAGE);
+  const outside = join(brain, "outside.md");
+  writeFileSync(outside, PAGE);
+
+  const escaped = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL("./refresh-note.mjs", import.meta.url))],
+    {
+      cwd: brain,
+      input: JSON.stringify({ path: "..\\outside.md", section: "## Escaped\n\nx" }),
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(escaped.status, 1, escaped.stdout);
+  assert.match(escaped.stderr, /is outside the vault — a refresh only ever touches vault\//);
+  assert.equal(readFileSync(outside, "utf8"), PAGE, "the file outside the vault must be untouched");
+});
+
 test("valid JSON that is not a refresh spec is refused, not crashed on", () => {
   // `null`, `"x"` and `[]` all PARSE, so they sail past the try/catch around
   // JSON.parse and reach `spec.path` — where `null` threw a TypeError and printed a

--- a/scripts/refresh-note.test.mjs
+++ b/scripts/refresh-note.test.mjs
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { runRefresh } from "./refresh-note.mjs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runRefresh, realRefreshDeps } from "./refresh-note.mjs";
 
 const PAGE = `---
 type: topic
@@ -175,4 +181,55 @@ Front-end at Candor.
     /^> \*\*Confidence\*\* — ✅ observed · he introduced himself in #candor, 2026-08-03\.$/m,
     "and the visible block with it, or the page contradicts itself",
   );
+});
+
+// ── The real wiring, run the way the brain runs it ─────────────────────────
+// Every test above injects its own deps, so `realRefreshDeps` and the
+// entrypoint guard were observed by nothing: this script could read no stdin,
+// write nowhere and log nothing with the suite still green. One real child
+// process against a throwaway brain closes it — and it is the only test here
+// that proves a refresh REWRITES the page on disk rather than describing it.
+
+test("refresh-note, as a real process — rewrites the page and bumps updated:", () => {
+  const brain = mkdtempSync(join(tmpdir(), "refresh-e2e-"));
+  mkdirSync(join(brain, "vault", "topics"), { recursive: true });
+  const page = join(brain, "vault", "topics", "crise.md");
+  writeFileSync(page, PAGE);
+  const run = (input) =>
+    spawnSync(process.execPath, [fileURLToPath(new URL("./refresh-note.mjs", import.meta.url))], {
+      cwd: brain,
+      input,
+      encoding: "utf8",
+    });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const ok = run(JSON.stringify({ path: "topics/crise.md", section: "## New\n\nAdded." }));
+  assert.equal(ok.status, 0, ok.stderr);
+  assert.equal(ok.stdout.trim(), `✓ Refreshed: vault/topics/crise.md (updated: ${today})`);
+  const after = readFileSync(page, "utf8");
+  assert.match(after, new RegExp(`\\nupdated: ${today}\\n`), "the date is stamped, not described");
+  assert.match(after, /\n## New\n\nAdded\.\n$/);
+  assert.match(after, /created: 2026-06-02/, "creation date untouched");
+
+  // And it never creates: a page that is not there is a refusal, not a write.
+  const missing = run(JSON.stringify({ path: "topics/nope.md", section: "x" }));
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /does not exist — refreshing never creates/);
+  assert.equal(existsSync(join(brain, "vault", "topics", "nope.md")), false);
+});
+
+test("realRefreshDeps — the real ports are what they claim, field by field", () => {
+  const dir = mkdtempSync(join(tmpdir(), "refresh-deps-"));
+  const file = join(dir, "note.md");
+  writeFileSync(file, "Réunion\n");
+  assert.equal(realRefreshDeps.cwd(), process.cwd());
+  assert.equal(realRefreshDeps.today(), new Date().toISOString().slice(0, 10));
+  assert.match(realRefreshDeps.today(), /^\d{4}-\d{2}-\d{2}$/, "a date stamp, not an instant");
+  assert.equal(realRefreshDeps.exists(file), true);
+  assert.equal(realRefreshDeps.exists(join(dir, "nope.md")), false);
+  // The exact string, accents and all: a loose match passes on the wrong encoding.
+  assert.equal(realRefreshDeps.readFile(file), "Réunion\n");
+  // Two levels missing, so a non-recursive mkdir cannot do this one.
+  realRefreshDeps.writeFile(join(dir, "a", "b", "written.md"), "body\n");
+  assert.equal(readFileSync(join(dir, "a", "b", "written.md"), "utf8"), "body\n");
 });

--- a/scripts/refresh-note.test.mjs
+++ b/scripts/refresh-note.test.mjs
@@ -138,3 +138,41 @@ test("invalid JSON on stdin is refused, loudly", () => {
   assert.equal(d.written.length, 0);
   assert.match(d.errs[0], /JSON/i);
 });
+
+test("runRefresh — forwards a confidence promotion to the writer, so it is not a freehand edit", () => {
+  // The rule that a marked card is re-verified needs a gesture that RECORDS the
+  // outcome. Without this the only way to promote a card is hand-editing its
+  // frontmatter — the exact move that put two `updated:` keys on one page.
+  const d = deps({
+    files: {
+      "/brain/vault/people/jeremy-hinard.md": `---
+type: person
+created: 2026-06-02
+updated: 2026-07-19
+tags: [candor]
+confidence: probable
+---
+
+# Jérémy Hinard
+
+> **Confidence** — 🟡 derived or probable · the surname comes from the Candor org note.
+
+Front-end at Candor.
+`,
+    },
+  });
+  d.readInput = () =>
+    JSON.stringify({
+      path: "people/jeremy-hinard.md",
+      confidence: { level: "observed", basis: "he introduced himself in #candor, 2026-08-03." },
+    });
+  assert.equal(runRefresh([], d), 0);
+  assert.deepEqual(d.errs, []);
+  const [, content] = d.written[0];
+  assert.match(content, /\nconfidence: observed\n/, "the field is promoted");
+  assert.match(
+    content,
+    /^> \*\*Confidence\*\* — ✅ observed · he introduced himself in #candor, 2026-08-03\.$/m,
+    "and the visible block with it, or the page contradicts itself",
+  );
+});

--- a/scripts/session-status.mjs
+++ b/scripts/session-status.mjs
@@ -204,8 +204,9 @@ const versionLine = readStartupVersionLine({
 process.stdout.write(
   JSON.stringify(
     buildStatusHookOutput({
+      leadLine: restartLine,
       versionLine,
-      statusLines: [restartLine, bootstrapLine, keyLine, repoLine, ragLine],
+      statusLines: [bootstrapLine, keyLine, repoLine, ragLine],
     }),
   ) + "\n"
 );

--- a/scripts/session-status.mjs
+++ b/scripts/session-status.mjs
@@ -30,6 +30,8 @@ import { bootstrapSessionHooks } from "./lib/hook-bootstrap.mjs";
 import { bootstrapReassuranceMessage } from "./lib/self-heal-message.mjs";
 import { restartNudgeSegment } from "./lib/restart-nudge.mjs";
 import { restartPendingOnDisk } from "./lib/restart-signal.mjs";
+import { readStartupVersionLine } from "./lib/engine-version.mjs";
+import { buildStatusHookOutput } from "./lib/status-hook-output.mjs";
 import { deriveWanted } from "./session-self-heal.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -187,13 +189,23 @@ const restartLine = restartNudgeSegment(
   restartPendingOnDisk({ repo: REPO, deriveWanted, existsSync, readFileSync }),
 );
 
-// ─── Emission via systemMessage: displays directly in the terminal ───────────
-const systemMessage = [restartLine, bootstrapLine, keyLine, repoLine, ragLine]
-  .filter(Boolean)
-  .join("\n");
+// ─── Engine version: which Kenjaku this brain runs, read OFFLINE from the ────
+// manifest (ADR 0017). It had a surface — the status line — which ADR 0036
+// retired, so it silently stopped being shown; the owner asked for it back at
+// startup (2026-08-03). Fail-silent: no manifest / no install ref → no segment.
+const versionLine = readStartupVersionLine({
+  manifestPath: join(REPO, "engine-manifest.json"),
+  existsSync,
+  readFileSync,
+});
+
+// ─── Emission: systemMessage displays in the terminal, additionalContext is ──
+// the only channel that reaches Desktop (the agent relays it in the chat).
 process.stdout.write(
-  JSON.stringify({
-    hookSpecificOutput: { hookEventName: "SessionStart" },
-    systemMessage,
-  }) + "\n"
+  JSON.stringify(
+    buildStatusHookOutput({
+      versionLine,
+      statusLines: [restartLine, bootstrapLine, keyLine, repoLine, ragLine],
+    }),
+  ) + "\n"
 );

--- a/templates/fr/.claude/skills/prepare-1-1/SKILL.md
+++ b/templates/fr/.claude/skills/prepare-1-1/SKILL.md
@@ -142,7 +142,7 @@ preuve de réalisation, **mettre à jour** la date `updated:`. Append-only sur l
 - Ne pas inventer ; signaler une source partielle ou de mauvaise qualité.
 - Pas de section vide — l'omettre (sauf « Revue de KPI » et « Axes récurrents » en cas B, à garder
   comme rappel même vides, puisque ce sont les sections que tu dois t'approprier).
-- Jamais d'URL nue : `[texte](url)`. Backlinks `[[people/prenom-nom]]` (jamais de prénom seul).
+- Jamais d'URL nue : `[texte](url)`. Backlinks `[[people/prenom-nom]]` — pas de nom complet, pas de lien : le nom reste en texte simple.
 
 ## Affiner cette skill (c'est le but d'une skill méta)
 La structure ci-dessus est un **point de départ**. Rends-la tienne : remplace les KPI d'exemple par

--- a/templates/fr/.claude/skills/prepare-1-1/SKILL.md
+++ b/templates/fr/.claude/skills/prepare-1-1/SKILL.md
@@ -63,12 +63,20 @@ Va les lire là-bas. Ce qui fait d'une prep de 1-1 le **pire** endroit où les e
   écrire ? C'est cette skill qui a produit le défaut terrain qui le prouve : elle a annoncé un
   changement de rôle comme « non confirmé » alors que la fiche `people/` du vault l'enregistrait
   **confirmé deux mois plus tôt**.
-- **Le vault prime sur le delta pour tout ce qui touche à une personne.** Lire
-  `vault/people/<nom>.md` avant d'affirmer qui est quelqu'un, quel est son titre, ou ce qu'il·elle te
-  doit. Un prénom seul reste un prénom seul.
 
 Les marqueurs sont obligatoires ici aussi : ✅ observé et cité, 🟡 déduit, 🔴 négatif ou
 comportemental non vérifié, et un 🔴 n'est **jamais** sûr à dire à voix haute dans la réunion.
+
+## Discipline d'identité
+
+**Même dispositif, même raison : [`sync-sources` § Discipline d'identité](../sync-sources/SKILL.md#discipline-didentité)
+porte les règles, cette skill leur obéit.** Résoudre contre le vault avant d'écrire une personne, ne
+jamais inventer la moitié manquante d'un nom, et interroger le vault avant de qualifier quoi que ce
+soit de nouveau. Va les lire là-bas.
+
+Une prep de 1-1 est l'endroit où se tromper coûte le plus cher : chaque personne du fichier est
+**l'une des deux personnes présentes dans la pièce**. Se tromper de nom de famille, de titre ou de
+lien hiérarchique, ce n'est pas un backlink cassé ici : c'est dit en face, ou dit à son manager.
 
 ## Étape 2 — Écriture du briefing
 

--- a/templates/fr/.claude/skills/sync-sources/SKILL.md
+++ b/templates/fr/.claude/skills/sync-sources/SKILL.md
@@ -96,6 +96,14 @@ que tu n'as pas.
    vieux de deux mois, et écrit « Hossam, qui deviendrait CTO Visma France (non confirmé) » alors que
    `people/hossam-laanait.md` disait déjà « CTO Visma France (confirmé 04/06) » : un enregistrement
    daté rétrogradé en rumeur. La réponse du vault prime ; si tu la contredis, dis-le et dis sur quoi.
+4. **Un lien n'est pas une personne.** Ne crée jamais une fiche `people/` dans le seul but de
+   satisfaire un lien `[[people/…]]` entrant. Un lien cassé est un défaut *du lien* : répare-le là où
+   il a été écrit (corrige l'orthographe, pointe la fiche qui existe vraiment, ou supprime-le). Créer
+   la cible, à l'inverse, promeut une mauvaise résolution en réponse du vault à la question *qui
+   existe*, et la résolution suivante se fait alors contre elle. `people/stephanie-music.md` est née
+   exactement comme ça, d'un seul lien mal résolu ; ce nom n'apparaît qu'une fois dans tout le vault :
+   dans son propre titre. Une fiche s'écrit quand quelqu'un confirme la personne, jamais pour faire
+   passer au vert un rapport de liens.
 
 ## Discipline d'affirmation
 

--- a/templates/fr/.claude/skills/sync-sources/SKILL.md
+++ b/templates/fr/.claude/skills/sync-sources/SKILL.md
@@ -66,9 +66,30 @@ contexte principal = synthèse finale (~3-5k tokens d'input)
 ## Référentiel de personnes (backlinks)
 
 Pour des backlinks `[[people/prenom-nom]]` cohérents (pas de liens cassés), les sous-agents
-s'appuient sur les fiches de `vault/people/`. Règle : **kebab-case, sans accents**
-(`[[people/jane-doe]]`). **Jamais de prénom seul** (`[[people/jane]]` est interdit). Créer les
-backlinks même si la page cible n'existe pas (*dangling links* OK) ; ne pas créer les pages cibles.
+s'appuient sur les fiches de `vault/people/`. Forme d'un lien, quand tu as un nom complet :
+**kebab-case, sans accents** (`[[people/jane-doe]]`). Le backlink peut pointer vers une page qui
+n'existe pas encore (*dangling links* OK) ; ne pas créer les pages cibles.
+
+**Quand tu n'as qu'un prénom, tu n'as pas de lien à écrire** : ni raccourci, ni complété. Voir
+« Discipline d'identité » juste en dessous : le nom reste en texte simple. Cette section décrit la
+*forme* d'un lien une fois la personne résolue ; elle ne te demande jamais de produire un nom complet
+que tu n'as pas.
+
+## Discipline d'identité
+
+> **Lis le vault avant d'écrire sur les personnes qui s'y trouvent.** Un briefing a un jour transformé
+> le « Jérémy (front Candor) » de la source en « Jérémy Hinard », un nom de famille qui n'existe nulle
+> part ailleurs que dans cette note. La résolution suivante se fait alors contre la fabrication.
+
+1. **Résous avant d'écrire.** Avant de nommer une personne dans une note, lis ce que le vault en dit
+   déjà : les fiches `people/` (celles de l'univers actif **et** celles, transverses, de la racine) et
+   les notes d'organisation. Le vault prime sur ta mémoire de la session comme sur le raccourci de la
+   source.
+2. **N'invente jamais la moitié manquante d'une identité.** Un prénom sans nom de famille **reste un
+   prénom** : écris-le en texte simple, jamais en `[[people/…]]`, et ne le complète jamais avec un nom
+   que la source ne t'a pas donné. « Jérémy (front Candor) » s'écrit « Jérémy (front Candor) ». Perdre
+   un backlink coûte un clic ; une identité fabriquée est définitive, elle est indexée, et elle devient
+   ce contre quoi la résolution suivante se résout.
 
 ## Discipline d'affirmation
 
@@ -215,7 +236,7 @@ RÈGLES :
 - Un prénom seul reste un prénom seul. Ne jamais le résoudre en identité complète : c'est une
   affirmation sur QUI est quelqu'un, et ça a déjà attribué une démission à la mauvaise personne.
 - Créer les backlinks même si la page cible n'existe pas.
-- Backlinks via vault/people/ (kebab-case sans accents, jamais de prénom seul).
+- Backlinks via vault/people/ (kebab-case, sans accents). Pas de nom complet, pas de lien : le nom reste en texte simple.
 - JAMAIS de shell (python3 -c, node -e, awk, sed, jq, grep, cat…) pour lire/charger/découper le
   contenu : si tu dois relire un fichier (vault ou résultat déporté .../tool-results/...), utilise
   l'outil Read ; le découpage et le résumé se font par raisonnement, pas en ligne de commande.
@@ -271,7 +292,7 @@ AFFIRMATIONS NÉGATIVES :
 
 RÈGLES :
 - Ignorer le conversationnel pur (bonjour/merci/emoji) et les bots/notifications.
-- Backlinks via vault/people/ (jamais de prénom seul).
+- Backlinks via vault/people/ (kebab-case, sans accents). Pas de nom complet, pas de lien : le nom reste en texte simple.
 - JAMAIS de shell (python3 -c, node -e, awk, sed, jq, grep, cat…) pour lire/charger/découper le
   contenu : si tu dois relire un fichier (vault ou résultat déporté .../tool-results/...), utilise
   l'outil Read ; le découpage et le résumé se font par raisonnement, pas en ligne de commande.

--- a/templates/fr/.claude/skills/sync-sources/SKILL.md
+++ b/templates/fr/.claude/skills/sync-sources/SKILL.md
@@ -116,6 +116,21 @@ que tu n'as pas.
    fiches et que rien dans la source ne les départage, ce nom est **non résolu** (la règle 2
    s'applique : texte simple, pas de lien). Ne résous jamais vers la fiche la plus proche, ni vers
    celle que tu viens de lire.
+6. **Dis à quel point c'est sûr.** Conforme ne veut pas dire vrai. Le builder donne à chaque fiche le
+   même frontmatter propre et le même `/lint` au vert : un nom lu sur un organigramme et un nom déduit
+   d'un surnom en ressortent identiques, et le vault lit ensuite les deux comme sa propre réponse à
+   « qui existe ». Une fiche `people/` porte donc un **bloc de confiance** : ce sur quoi cette identité
+   repose, dans l'échelle que la discipline d'affirmation utilise déjà plus bas
+   (✅ observé · 🟡 déduit ou probable · 🔴 non vérifié), jamais une seconde. Le builder l'impose :
+   `scripts/file-back-note.mjs` refuse une nouvelle fiche personne tant que la spec ne contient pas
+   `confidence` : un niveau, et la **base** sur laquelle il repose (la source, sa date, la fiche
+   trouvée). Réponds honnêtement plutôt que de choisir le niveau qui débloque l'écriture :
+   `unverified`, écrit noir sur blanc, ne coûte rien et c'est exactement ce que la passe suivante a
+   besoin de savoir. Et l'autre moitié, à la lecture, est ce qui rend le bloc utile : une fiche
+   marquée 🟡 ou 🔴 est une **piste, pas la réponse du vault** : revérifie-la avant de résoudre quoi
+   que ce soit contre elle, et ne la laisse jamais devenir un acquis au seul motif qu'elle est écrite
+   depuis un moment. C'est le « le bémol d'hier est une dette » de la discipline d'affirmation,
+   appliqué aux fiches du vault lui-même.
 
 ## Discipline d'affirmation
 

--- a/templates/fr/.claude/skills/sync-sources/SKILL.md
+++ b/templates/fr/.claude/skills/sync-sources/SKILL.md
@@ -90,6 +90,12 @@ que tu n'as pas.
    que la source ne t'a pas donné. « Jérémy (front Candor) » s'écrit « Jérémy (front Candor) ». Perdre
    un backlink coûte un clic ; une identité fabriquée est définitive, elle est indexée, et elle devient
    ce contre quoi la résolution suivante se résout.
+3. **Interroge le vault avant de qualifier quoi que ce soit de nouveau.** Un fait n'est *nouveau* que
+   par rapport à ce que le vault contient déjà : lance un `search_vault` dessus avant de le présenter
+   comme une nouveauté, et lis ce qui revient. Un briefing a un jour republié comme un scoop un fait
+   vieux de deux mois, et écrit « Hossam, qui deviendrait CTO Visma France (non confirmé) » alors que
+   `people/hossam-laanait.md` disait déjà « CTO Visma France (confirmé 04/06) » : un enregistrement
+   daté rétrogradé en rumeur. La réponse du vault prime ; si tu la contredis, dis-le et dis sur quoi.
 
 ## Discipline d'affirmation
 
@@ -334,12 +340,18 @@ fort. C'est aussi ici qu'on décide si le delta **amende la réponse en cours** 
 
 **Réconcilier avant d'écrire la moindre ligne** (voir *Discipline d'affirmation* plus haut). Les
 retours forment un corpus à rendre cohérent avec lui-même, **pas** un sac de citations pour étayer
-une synthèse déjà décidée. Deux passes, les deux peu coûteuses :
+une synthèse déjà décidée. Trois passes, toutes peu coûteuses :
 
 1. **Est-ce que quelque chose que j'ai récupéré contredit ce que je m'apprête à affirmer ?** Une
    contradiction dans ton propre matériau l'emporte sur l'affirmation, toujours.
 2. **Chaque ligne 🔴 est soit vérifiée maintenant, soit reformulée en question ouverte.** Un 🔴 qui
    atteint le briefing tel quel, c'est celui que la personne va coller dans un canal.
+3. **Tout ce que je m'apprête à présenter comme nouveau, et chaque personne que je m'apprête à
+   nommer, passe d'abord par un `search_vault`.** Tu es la seule étape à tenir à la fois le delta et
+   le vault : les sous-agents lisent des sources externes et ne le voient jamais. Ce qui revient
+   l'emporte sur le cadrage du delta (voir *Discipline d'identité* plus haut) : c'est ainsi qu'un
+   fait vieux de deux mois cesse d'être republié comme un scoop, et qu'une fiche « (confirmé 04/06) »
+   cesse d'être rétrogradée en « (non confirmé) ».
 
 Un sous-agent qui a signalé ne pas voir les compteurs de réponses t'a dit que son silence n'est
 **pas mesuré** : le porter jusqu'au briefing, au lieu de l'arrondir en « il ne s'est rien passé ».

--- a/templates/fr/.claude/skills/sync-sources/SKILL.md
+++ b/templates/fr/.claude/skills/sync-sources/SKILL.md
@@ -104,6 +104,18 @@ que tu n'as pas.
    exactement comme ça, d'un seul lien mal résolu ; ce nom n'apparaît qu'une fois dans tout le vault :
    dans son propre titre. Une fiche s'écrit quand quelqu'un confirme la personne, jamais pour faire
    passer au vert un rapport de liens.
+5. **Dis de qui il s'agit.** Un prénom est rarement unique : le vault pour lequel cette discipline a
+   été écrite contenait trois Romain, trois Marie, deux Karim, deux Caroline et deux Michael. Une
+   fiche `people/` porte donc un **bloc d'homonymie** : une ligne, sous le titre, qui dit ce qui
+   distingue cette personne de toutes celles que le vault connaît sous ce prénom (son rôle, son
+   organisation, et les autres fiches nommées). Sans lui, la fiche ne résout rien : elle déplace
+   l'ambiguïté d'un cran, à l'intérieur du vault. Le builder l'impose :
+   `scripts/file-back-note.mjs` refuse une nouvelle personne dont le vault porte déjà le prénom tant
+   que la spec ne contient pas `distinguish`, et son refus nomme les homonymes trouvés. L'autre
+   moitié, à la lecture, est ce qui rend le bloc utile : quand un prénom seul correspond à plusieurs
+   fiches et que rien dans la source ne les départage, ce nom est **non résolu** (la règle 2
+   s'applique : texte simple, pas de lien). Ne résous jamais vers la fiche la plus proche, ni vers
+   celle que tu viens de lire.
 
 ## Discipline d'affirmation
 

--- a/templates/fr/CLAUDE.engine.md
+++ b/templates/fr/CLAUDE.engine.md
@@ -263,6 +263,25 @@ Le contexte de la session principale est une **ressource rare et qualitative**. 
 - **Ne jamais reconstruire un permalink à la main** à partir d'un identifiant + timestamp (souvent faux) : reprendre le lien fourni tel quel par l'outil.
 - **Qualifier la fiabilité des sources** : verbatim (transcript, message brut) > synthèse humaine > synthèse IA. Signaler quand on interprète plutôt qu'on restitue.
 
+### Discipline d'identité : lis le vault avant d'écrire sur les personnes qui s'y trouvent
+
+Un nom écrit dans le vault ne s'efface pas comme une supposition de conversation : il devient
+l'enregistrement contre lequel la **prochaine** résolution se résout. Un briefing a transformé le
+« Jérémy (front Candor) » de la source en « Jérémy Hinard », un nom de famille qui n'existe nulle part
+ailleurs que dans cette note, et qui est désormais indexé.
+
+- **Résous avant d'écrire.** Avant de nommer une personne dans une note, lis ce que le vault en dit
+  déjà : les fiches `people/` (celles de l'univers actif **et** celles, transverses, de la racine) et
+  les notes d'organisation. Le vault prime sur ta mémoire de la session comme sur le raccourci de la
+  source.
+- **N'invente jamais la moitié manquante d'une identité.** Un prénom sans nom de famille **reste un
+  prénom** : texte simple, jamais `[[people/…]]`, jamais complété par un nom que la source ne t'a pas
+  donné. Perdre un backlink coûte un clic ; une identité fabriquée est définitive.
+- **Interroge le vault avant de qualifier quoi que ce soit de nouveau.** Un fait n'est *nouveau* que
+  par rapport à ce que le vault contient déjà : lance un `search_vault` dessus avant de le présenter
+  comme une nouveauté. Une fiche disant « CTO Visma France (confirmé 04/06) » a été republiée en
+  « (non confirmé) » faute d'avoir demandé.
+
 ### Discipline d'affirmation — le silence qu'on rapporte, voilà le vrai danger
 
 Une recherche renvoie ce qui est **pertinent**, jamais ce qui est **complet**. Donc quand rien ne

--- a/templates/fr/CLAUDE.engine.md
+++ b/templates/fr/CLAUDE.engine.md
@@ -291,6 +291,15 @@ ailleurs que dans cette note, et qui est désormais indexé.
   refuse une personne dont le vault porte déjà le prénom tant que la spec ne dit pas `distinguish`.
   Et quand un prénom seul correspond à plusieurs fiches sans rien pour les départager,
   il est **non résolu** : texte simple, pas de lien.
+- **Dis à quel point c'est sûr.** Conforme ne veut pas dire vrai : le builder donne à chaque fiche le
+  même frontmatter propre et le même `/lint` au vert, donc un nom lu sur un organigramme et un nom
+  déduit d'un surnom en ressortent identiques. Une fiche `people/` porte donc un bloc de confiance :
+  ce sur quoi l'identité repose, dans l'échelle de la discipline d'affirmation ci-dessous
+  (✅ observé · 🟡 déduit ou probable · 🔴 non vérifié), jamais une seconde. Le builder refuse une
+  nouvelle fiche personne tant que la spec ne contient pas `confidence` (un niveau **et** sa base).
+  Réponds honnêtement plutôt que de choisir le niveau qui débloque l'écriture. Une fiche marquée 🟡 ou
+  🔴 est une piste, pas la réponse du vault : revérifie-la avant de résoudre quoi que ce soit contre
+  elle, et ne la laisse jamais devenir un acquis au seul motif qu'elle est écrite depuis un moment.
 
 ### Discipline d'affirmation — le silence qu'on rapporte, voilà le vrai danger
 

--- a/templates/fr/CLAUDE.engine.md
+++ b/templates/fr/CLAUDE.engine.md
@@ -281,6 +281,10 @@ ailleurs que dans cette note, et qui est désormais indexé.
   par rapport à ce que le vault contient déjà : lance un `search_vault` dessus avant de le présenter
   comme une nouveauté. Une fiche disant « CTO Visma France (confirmé 04/06) » a été republiée en
   « (non confirmé) » faute d'avoir demandé.
+- **Un lien n'est pas une personne.** Ne crée jamais une fiche `people/` dans le seul but de
+  satisfaire un lien `[[people/…]]` entrant : un lien cassé est un défaut du lien, répare-le là où il
+  a été écrit ou supprime-le. Créer la cible fait d'une mauvaise résolution la réponse du vault à la
+  question *qui existe*.
 
 ### Discipline d'affirmation — le silence qu'on rapporte, voilà le vrai danger
 

--- a/templates/fr/CLAUDE.engine.md
+++ b/templates/fr/CLAUDE.engine.md
@@ -285,6 +285,12 @@ ailleurs que dans cette note, et qui est désormais indexé.
   satisfaire un lien `[[people/…]]` entrant : un lien cassé est un défaut du lien, répare-le là où il
   a été écrit ou supprime-le. Créer la cible fait d'une mauvaise résolution la réponse du vault à la
   question *qui existe*.
+- **Dis de qui il s'agit.** Un prénom est rarement unique (un vault réel : trois Romain, trois Marie,
+  deux Karim). Une fiche `people/` porte donc un bloc d'homonymie sous son titre (rôle, organisation,
+  et les autres fiches nommées), sinon elle déplace l'ambiguïté au lieu de la résoudre : le builder
+  refuse une personne dont le vault porte déjà le prénom tant que la spec ne dit pas `distinguish`.
+  Et quand un prénom seul correspond à plusieurs fiches sans rien pour les départager,
+  il est **non résolu** : texte simple, pas de lien.
 
 ### Discipline d'affirmation — le silence qu'on rapporte, voilà le vrai danger
 


### PR DESCRIPTION
## v4.6.0 — The One Where It Asks Which One You Mean

Second of the trilogy that came out of one evening on a real deployed brain. v4.5.0 stopped silence from
passing for good news; this one stops the vault from **poisoning itself**. The brain was writing *about
people* without ever reading what the vault already said about them — so a bare *"Jérémy"* became a
surname that exists nowhere, a fact confirmed two months earlier was republished as news, and a page was
created for a colleague who occurs exactly once in the whole vault: in her own title.

**The user-facing note is the source of truth for what ships:**
[`maintainers/plans/prospective/release-v4.6.0-note.md`](maintainers/plans/prospective/release-v4.6.0-note.md).

### What is in it

- **The defect was an order the engine shipped.** `sync-sources` said, in the same breath, *"never a
  first name alone, `[[people/jane]]` is forbidden"* and *"create the backlinks even if the target page
  doesn't exist"*. An agent obeying both had two exits: drop the link, or invent the surname. It
  invented. The rule now states the action — *no full name, no link* — in the **producer** and in the
  second write-door, `/consolidate`, which handed its own sub-agents the same forbidding pair.
- **Resolve before writing, and ask the vault whether it is even new.** The novelty check is a third
  reconcile pass in the synthesis step, the only place that can run it: the sub-agents read external
  sources and never see the vault.
- **Repairing a link is not asserting a person exists.** `/lint`'s create-the-missing-note remedy keeps
  its topic case and stops at people; `/consolidate` says a mention count is a priority signal, never
  evidence.
- **Homonymy and confidence are deterministic refusals, not advice.** Both doors that create a
  `people/` card write through one script, so `scripts/file-back-note.mjs` refuses a new person whose
  first name the vault already holds until the spec says which one (naming the homonyms it found), and
  refuses one that does not say what its identity rests on. `/refresh-note` promotes a card later,
  rewriting the field and the visible block together through the builder's own renderer.
- **The engine says which version it is**, on both session-start channels — a label that had been
  computed since v3.0.0 (first commit `aaa0f64`) and rendered nowhere since v4.4.0, when the engine
  gave the status line back to its owner.

### Choices worth reviewing

- **Required, not optional, for confidence.** Left optional, an absent marker would come to mean
  *confirmed* — silence rendered as certainty, which is this trilogy's own defect shape.
- **One vocabulary.** ✅ observed / 🟡 derived or probable / 🔴 unverified is v4.5.0's scale, reused
  verbatim and pinned by the guard: a second scale here would be a second discipline.
- **Prose is never the only carrier.** Every rule that could be shipped as a check was: this release
  met the "a rule nothing executes" failure twice before adopting that stance.
- **Reach, checked rather than assumed.** `scripts/**` and `engine-skills/**` are in `replace`,
  `sync-sources` in `merge`, so the fleet gets every carrier on `/update-engine`; the constitution is
  in no regime and reaches new installs, which is why the skill carriers were written first.

### Verification

- **CI** on this branch: Node 22/24/26 × macOS + Windows, plus the Windows installer end-to-end.
- **Mutation pass on the eight production files this release changed**, per file rather than averaged.
  Its finding is worth the reviewer's minute: `scripts/lib/doc-section.mjs` — the slicer that decides
  what every doc guard reads — had **no test of its own**, and both "return the whole document" mutants
  survived. That silently turns every sliced guard back into the flat search it was extracted to
  replace. Fixed, 14/14 dead.
- Suites green at every commit; the marketing surface re-read per §10, with its verdict recorded in the
  plan (including the boring half: the boards were re-read and deliberately not re-rendered).
- **An independent review of this branch found six defects, and all six are fixed here**, each in TDD
  with the red verified first. Two of them were **guards that had stopped watching**, which is the more
  useful half: the identity guard iterated a hand-written list of four files that never included
  `/consolidate` — so the release's headline rule read green while the other write-door still ordered
  the invention — and the F5 startup-payload audit filtered on a literal `additionalContext:`, so an
  emitter that *assigns* the key was its invisible fifth. Both now derive what they watch from the repo.
  The other four: a vault-containment check a backslash path walked straight out of (reproduced against
  a real brain, and its class swept — one sibling fixed, one shown unreachable), a `$` sequence in
  free-form prose that spliced the old confidence block into the new one, and a missing blank line that
  made a section-wide rule render as one bullet's tail in EN only.
