### PR TITLE
chore(deps): pin adm-zip and fast-uri where they are actually used

### DIFF
--- a/local-mirror/package-lock.json
+++ b/local-mirror/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "local-mirror",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@notionhq/client": "^5.22.0",
@@ -999,9 +999,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/local-mirror/package.json
+++ b/local-mirror/package.json
@@ -21,7 +21,8 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "fast-uri": "^3.1.5"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.0",

--- a/rag/package-lock.json
+++ b/rag/package-lock.json
@@ -1154,12 +1154,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1852,9 +1852,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/rag/package.json
+++ b/rag/package.json
@@ -25,7 +25,9 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0",
+    "fast-uri": "^3.1.5"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",


### PR DESCRIPTION
## What this replaces

Two drive-by PRs, **#48** (fast-uri) and **#52** (adm-zip), both point at real advisories. Neither closes them. That is measured, not argued: each PR was applied to a throwaway copy of the package it touches and `npm audit` was re-run on its own lockfile.

- **#52 (adm-zip)** — `adm-zip` is required by `onnxruntime-node` at `^0.5.16`, which cannot accept the fixed `0.6.0`. The PR declares `0.6.0` as a **direct dependency of `rag`**, so npm hoists an unused copy to the root and nests `0.5.18` under the one consumer that actually unzips anything. Its own lockfile says so. The audit still reports `high`, now pointing at `node_modules/onnxruntime-node/node_modules/adm-zip`. **Zero security gain, one unused dependency.**
- **#48 (fast-uri)** — `fast-uri` is required by `ajv`. The PR moves `3.1.2` → `3.1.3`, which **does** fix the CVE it names. Two further advisories have since widened the vulnerable range to `3.0.0 - 3.1.4`, so the package stays flagged after the merge. **`3.1.5`** is what clears it, and it satisfies `ajv`'s range.

## What this does instead

Pins both through **`overrides`** — the mechanism this repo already uses for `js-yaml` — in **both** packages: `rag` carries `fast-uri` too, through its own `ajv`. Neither package is imported by our code (checked across `rag/src`, `local-mirror/src` and `scripts`), so neither belongs in `dependencies`.

| Package | Before | After |
|---|---|---|
| `rag` | 12 vulnerabilities (7 high) | **9** (4 high) |
| `local-mirror` | 6 vulnerabilities (3 high) | **5** (2 high) |

## What CI has to judge

The `adm-zip` pin forces a version **outside** `onnxruntime-node`'s declared range. Its `postinstall` unzips the prebuilt binaries through `new AdmZip` / `getEntry` / `extractEntryTo`, which that pin has to keep working. `npm ci` runs it on six cells, so the matrix is the verdict here, not this description.

## Not addressed on purpose

The rest of the audit (`sharp`/libvips with no fix available, `js-yaml`, `protobufjs`, the hono chain) is untouched. It deserves its own pass rather than being folded into a two-line pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
