### PR TITLE
v4.7.0 — The One Where It Knows You Haven't Restarted Yet

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -56,6 +56,18 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{NODE}} \"{{PROJECT_ROOT}}/scripts/prompt-restart-nudge.mjs\"",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/README.md
+++ b/README.md
@@ -262,7 +262,11 @@ and **git**. The installer checks each one and tells you cleanly if something's 
   notes** (your `.env`, `CLAUDE.md`, settings and custom skills are sacred too). No terminal, no
   re-install. **Since v4.1.0 its ready-made skills come along too**: the ones you never edited are
   brought up to date, and any skill you've tailored is left exactly as you wrote it, with the new
-  version parked beside it for you to take or ignore.
+  version parked beside it for you to take or ignore. **Since v4.7.0 it also tells you when the engine
+  answering you is no longer the one on disk** — a session loads its wiring once, at start, so an update
+  that lands mid-session (typically pulled from your remote when you open your brain on a **second
+  machine**) used to be answered by the old code, silently, for the rest of the session. Now it says so,
+  in the terminal and in Desktop, until you close and reopen.
   *(mental model + hands-on steps: [SETUP §10](SETUP.md#10-keeping-your-engine-up-to-date-update-engine))*
 - **🧬 Already have a brain from *before* v3.0.0? Bring your notes over.** Install a fresh brain, then
   say *"importe mes anciennes notes depuis `<path>`"* — it shows a **safe plan**, confirms, copies your
@@ -364,6 +368,13 @@ tested and fail-loud**. The through-line — **fail loudly rather than pretend**
   session: the brain **reconciles on its own** (re-indexes the delta, auto-saves, auto-commits) — nothing
   to replay by hand. An **idempotent reconciler** converges it to its desired state, the pattern behind
   Kubernetes / GitOps / Terraform. *(ADR 0026)*
+- **And when notes are still waiting, it says *what kind* of waiting.** *"A few notes pending, they'll
+  catch up next session"* covered five different situations with one sentence — some that do resolve
+  themselves, one that never will. Your brain now tells them apart: notes it **refused** (a header it
+  can't read — those need a fix), a **daily quota** reached (that one genuinely does resume on its own),
+  a run **still going** as you read, notes that simply **arrived** after the last look — and a catch-up
+  that has already **tried and failed**. The "just arrived" case is now caught up **on the spot**,
+  instead of being promised for next time.
 - **Keeps its *knowledge* healthy, not just its infra.** A SessionStart nudge and the `/lint`,
   `/consolidate` and `/file-back` skills watch the wiki for decay — dangling `[[links]]`, orphan notes,
   stale entity pages, raw captures never filed — and **propose** fixes you confirm (never a silent

--- a/SETUP.md
+++ b/SETUP.md
@@ -594,7 +594,7 @@ tailored: it only writes files that `engine-manifest.json` declares Engine-owned
 
 ### Which version am I on?
 
-Your brain **says so at the start of every session**: a `⚙️ Kenjaku engine v4.6.0` segment in the
+Your brain **says so at the start of every session**: a `⚙️ Kenjaku engine v4.7.0` segment in the
 opening banner, on the command line as well as in the Code tab of Claude Desktop. It reads the tag your
 engine was installed or last updated from (`source.ref` in `engine-manifest.json`), so it follows your
 updates instead of freezing at install day. Two silences are deliberate: when the manifest carries no

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -2,10 +2,10 @@
   "manifestVersion": 1,
   "canonicalRepo": "https://github.com/tpierrain/kenjaku.git",
   "engineVersion": {
-    "rag": "1.3.0",
+    "rag": "1.4.0",
     "local-mirror": "0.3.0",
     "constitutionTemplate": "1.2.0",
-    "scripts": "1.11.0"
+    "scripts": "1.12.0"
   },
   "indexSchemaVersion": 2,
   "regimes": {

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -41,6 +41,7 @@
       "scripts/consolidate-scan.mjs",
       "scripts/refresh-note.mjs",
       "scripts/vault-write-guard.mjs",
+      "scripts/prompt-restart-nudge.mjs",
       "scripts/verify-index.mjs",
       "scripts/lib/**",
       ".claude/settings.json.template",

--- a/engine-skills/univers/SKILL.md
+++ b/engine-skills/univers/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: univers
+description: "Alias of /switch, French spelling. Universes: switch, list, create, rename, describe, delete. Reached by typing /univers (or /universe) — routing is literal, so nothing else here triggers it."
+version: 1.0.0
+---
+
+# /univers — an alias of `/switch`
+
+The command that owns universes is named after the verb (`/switch`), and this is the noun a
+French-speaking owner reaches for first — the spelling actually typed in the field. There is
+nothing else here.
+
+**Do this:** invoke the **`switch`** skill and follow it, passing along whatever arguments were
+given to `/univers` (e.g. `/univers acme` means `/switch acme`). Do not re-derive its behaviour
+from this file — `switch` is the only place the rules live.

--- a/engine-skills/universe/SKILL.md
+++ b/engine-skills/universe/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: universe
+description: "Alias of /switch. Universes: switch, list, create, rename, describe, delete. Reached by typing /universe (or /univers) — routing is literal, so nothing else here triggers it."
+version: 1.0.0
+---
+
+# /universe — an alias of `/switch`
+
+The command that owns universes is named after the verb (`/switch`), and this is the noun most
+people reach for first. There is nothing else here.
+
+**Do this:** invoke the **`switch`** skill and follow it, passing along whatever arguments were
+given to `/universe` (e.g. `/universe acme` means `/switch acme`). Do not re-derive its behaviour
+from this file — `switch` is the only place the rules live.

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -14,8 +14,8 @@
 
 | Package | Mutation score | As of | Detail |
 |---|---|---|---|
-| **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only. Not re-measured package-wide since; the [v4.4.0 targeted run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) over the 10 files that release changed reads **93.93 %**, with its two new files at **100 %**. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) over its 6 changed files reads **94.67 %**, with the file it creates at **100 %** |
-| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new). The [v4.6.0 run](#v460--the-vaults-identity-release-scripts-only--2026-08-03) measured the 7 files that release changed: **all seven end at 96 % or above, two at 100 %**, every remaining survivor a pre-listed equivalent. It then ran a **second pass after the review fixes** (those fixes changed production code, so the first numbers no longer covered it): 4 files re-measured, 3 of them at **96.88–100 %**, plus `lib/hooks-reconcile.mjs` — a file this release only grazes — at **78.69 %**, whose 24 remaining survivors are pre-existing and named rather than implied |
+| **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only. Not re-measured package-wide since; the [v4.4.0 targeted run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) over the 10 files that release changed reads **93.93 %**, with its two new files at **100 %**. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) over its 6 changed files reads **94.67 %**, with the file it creates at **100 %**. The [v4.7.0 run](#v470--the-short-visibility-release-rag--scripts--2026-08-05) over the 2 files that release changed reads **94.44 %** first pass, **100 % on both** after the survivors were closed |
+| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new). The [v4.6.0 run](#v460--the-vaults-identity-release-scripts-only--2026-08-03) measured the 7 files that release changed: **all seven end at 96 % or above, two at 100 %**, every remaining survivor a pre-listed equivalent. It then ran a **second pass after the review fixes** (those fixes changed production code, so the first numbers no longer covered it): 4 files re-measured, 3 of them at **96.88–100 %**, plus `lib/hooks-reconcile.mjs` — a file this release only grazes — at **78.69 %**, whose 24 remaining survivors are pre-existing and named rather than implied. The [v4.7.0 run](#v470--the-short-visibility-release-rag--scripts--2026-08-05) measured the 4 files that release wrote: **83.33 % → 97.56 %**, two of them at **100 %**, the two survivors left both pre-listed equivalents — and the low first-pass number was a **design** defect (a fail-soft written twice, so neither half was observable), not thin tests |
 | **local-mirror** | **90.44 %** | 2026-07-28 (v4.2.0) | [re-audit](#full-local-mirror-re-audit--2026-07-28-v420) — +336 mutants since the 95.63 % below (auto-refresh growth); this release's own survivors were found and killed before tagging. The two files v4.3.0 touched were re-measured [after the review fixes](#v430-after-the-review-fixes--2026-07-28): `markdown.ts` **100 %**, `local-mirror.ts` **96.86 %**. **v4.4.0 touches no `src/**` file here — the number carries over, deliberately not re-measured** |
 
 Pinned to the release that ships the hardened tests: **v3.4.2** (local-mirror pinned at 78.69 % there —
@@ -138,6 +138,57 @@ survivors there are **documented equivalent mutants** (unkillable without touchi
 "effective 100 %" on non-equivalents. The lowest never-hardened tiers, the natural next "B5" targets,
 are rag's **embedders** (~82 %) and `search-degradation` / `reindex-scheduler` / `index-freshness`, plus
 local-mirror's `fs-state-store` and `content-hash`.
+
+---
+
+## v4.7.0 — the short visibility release (`rag` + `scripts`) — 2026-08-05
+
+**Scope decided on the diff** (`main...release/v4.7.0`), the targeted run §5ter prescribes before a tag.
+`local-mirror/src` is untouched by this branch (measured, not assumed) — its number carries over. Both
+halves were run in the disposable worktree `kenjaku-mut-v470`, then **re-measured off the fixes**, because
+a hardened-but-unmeasured file has an unknown score.
+
+| Half | First run | After the pass | |
+|---|---|---|---|
+| `rag/src/lib` — `index-shortfall.ts`, `status-report.ts` | **94.44 %** | **100 % / 100 %** | 9 survivors, all in code written the same day; 0 left |
+| `scripts` — `lib/frozen-wiring.mjs`, `lib/restart-nudge.mjs`, `lib/restart-signal.mjs`, `prompt-restart-nudge.mjs` | **83.33 %** | **97.56 %** | 14 survivors → 2, both accepted equivalents |
+
+**The `rag` half** (logs `reports/v470-rag-changed.log`, then `…-recheck.log`) found two familiar
+families — an absent case nothing fed (a shortfall whose failures ARE the whole gap, so nothing was
+pending) and a truncation nothing exercised (three refusals against a bound of two). The ninth survivor
+was **simplified away rather than excused**: `!== null && !== undefined` reads as two reasons while only
+ever meaning *"a number was recorded"*, and nothing could tell the halves apart → `typeof asked ===
+"number"`. `rag/src/index.ts` is out of the tool's scope (not under `src/lib/`) — the same class as the
+top-level scripts, already named debt.
+
+**The `scripts` half** (logs `reports/v470-scripts-changed.log`) found one **design** defect, and it is
+the reason the file sat at 58.33 %:
+
+- **`lib/restart-signal.mjs` 58.33 % → 95.45 %.** The fail-soft was written **twice per signal** — an
+  initializer *and* a `catch` — so each half silently covered for the other and **neither could be shown
+  to work** (4 survivors on that redundancy alone). Stated once now, in a named `noSignalIfItBlowsUp`,
+  where a test can hold it. Two cases were then missing outright: a brain whose `.mcp.json` registers
+  exactly what the engine delivered (the converged case that proves both probes are really read), and
+  one that registers something else (the gap a forgotten `utf8` would have turned into silence). The
+  fake now reads the way node's `fs` reads — unknown encoding throws, absent file throws — so a read
+  that passes by luck fails in the test instead.
+- **`lib/frozen-wiring.mjs` 92.86 % → 100 %.** `pulledPaths` had only ever been fed **CRLF**, so a split
+  that knows only CRLF passed: on Unix it would have returned the whole stdout as one path, matching no
+  prefix, and the machine that is behind would have gone silent everywhere **but** Windows — the mirror
+  image of this repo's usual Windows bug. LF-only case added, with a blank-but-not-empty line.
+- **`lib/restart-nudge.mjs` 93.33 % → 100 %.** The directive's reason clause (*"a session loads its
+  hooks, skills and servers only at start"*) and its *"open your reply"* instruction could both be
+  deleted with every assertion still green. Both are load-bearing: a restart asked with no reason reads
+  as a glitch, and one appended after the answer gets buried on a channel whose point is that it repeats.
+
+**The two survivors left, both pre-listed equivalents** (§5ter's don't-chase list):
+
+- `prompt-restart-nudge.mjs:55` — the `isEntrypoint(import.meta.url, …)` boot guard (94.12 %). The
+  three-mutant family 10+ scripts carry; already **named debt with an owner** (the shared
+  `runAsEntrypoint`, deferred to v4.8.0).
+- `restart-signal.mjs:51` — `catch { return false; }` → `catch {}`. The value is normalised downstream
+  by `isRestartPending`'s `Boolean(…)`, so `undefined` and `false` are indistinguishable at the only
+  boundary that exists. Killing it would take a consumer written for the test.
 
 ---
 

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -1147,8 +1147,23 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > that break an alias silently: the folder (the CLI routes on it), the declared `name:`, the target
 > still existing, and the description's cost in the always-loaded layer (F19).
 >
-> **Next: 13.4 — the release tail.** Start with the bookkeeping the scope cut created (three code
-> comments still send a reader to v4.7.0 for work that now lands in v4.8.0), then the usual shape.
+> **13.4 — the release tail, in progress.** Done so far, both pushed and green locally:
+> - [x] **The bookkeeping the scope cut created** _(`421121f`)_ — the three comments that still sent
+>       a reader to v4.7.0 for F3's unknown-version state and the `unknown` health check now name
+>       **v4.8.0**. The assertions themselves were not touched.
+> - [x] **The version vector** _(`b529369`)_ — `rag` 1.3.0 → **1.4.0**, `scripts` 1.11.0 → **1.12.0**,
+>       `rag/package.json` + lockfile in step. `local-mirror` (0.3.0) and `constitutionTemplate`
+>       (1.2.0) left alone: nothing in them changed, checked rather than assumed.
+>       `indexSchemaVersion` stays **2** — no reindex, which is what the note will promise.
+> - [ ] **§10, the marketing-surface re-read** — not started.
+> - [ ] **Mutation on what this release changed** — not started. Production files touched:
+>       `scripts/lib/frozen-wiring.mjs`, `scripts/lib/restart-nudge.mjs`,
+>       `scripts/lib/restart-signal.mjs`, `scripts/prompt-restart-nudge.mjs`,
+>       `scripts/session-status.mjs`, `scripts/session-self-heal.mjs`, `scripts/update-engine.mjs`,
+>       `rag/src/lib/index-shortfall.ts`, `rag/src/lib/status-report.ts`, `rag/src/index.ts`.
+>       Recipe and the batching lesson: Step 11's mutation section (worktree, NOT the scratchpad;
+>       one or two files per run; `rag/node_modules` symlinked and verified first).
+> - [ ] **Release note + PR body + tag** — the owner is asked BEFORE the public tail, as at v4.6.0.
 >
 > Nothing is half-written on disk. `main` is at the PR #56 merge (`b414766`), and **`release/v4.7.0`
 > exists and is pushed** off that commit. Work the remaining boxes below in order.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -1087,15 +1087,42 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > ⚠️ **No finding codes in any artifact** (the owner, 2026-08-03): "F20, F21, Fx" are filing labels for
 > this plan only. The note, the PR body and the release name the behaviour instead.
 >
-> ### ⏭️ THE RESUME POINT — the branch is OPEN; the live work is **13.2, F20's detection**
+> ### ⏭️ THE RESUME POINT — F20 IS DONE; the live work is **13.2's second half, F21**
+>
+> **✅ F20 IS COMPLETE** _(2026-08-05 · `82f49cd`, `ee1c373`)_. Both halves shipped, and the two calls
+> the entry left open are taken below; do not re-open them.
+> - **Detection** — `scripts/lib/frozen-wiring.mjs` names what a session freezes at start (hooks,
+>   skills, settings, the constitution, both MCP servers, the version vector) out of the pull's own
+>   file list, which `session-status.mjs` already computed and threw away to keep a count. A match
+>   arms `.cache/restart-needed`, so the nudge that already exists leads the banner. The flag's path
+>   and body now have ONE owner (`restart-signal.mjs`), since three surfaces arm it.
+> - **Delivery** — a `UserPromptSubmit` hook, `scripts/prompt-restart-nudge.mjs`, injects the
+>   directive on **every prompt** while the flag is armed. It **injects, never blocks** (the event
+>   can refuse a prompt outright; a wrong verdict must cost a sentence, not a locked-out owner), and
+>   it is the first deterministic **Desktop** cue for a stale engine. Carried by the manifest,
+>   reconciled onto brains that have no `UserPromptSubmit` key at all — i.e. every brain there is.
+> - **✅ Settled: the nudge does NOT name the privacy case.** A banner that already printed the
+>   profile is not un-leaked by a restart, so naming it buys the owner nothing actionable and dates
+>   the copy to one release. The generic wording (ADR 0036) is what ships.
+> - **✅ Settled: a brain with no remote stays silent, by construction** — no pull, no file list, no
+>   arming. Pinned by a test rather than left to the reader.
+> - **What the pass turned up, worth not re-learning:** the F5 emitter audit
+>   (`startup-payload-guard.test.mjs`) went red on the new hook **before its bound existed** — the net
+>   works. It is the **sixth** emitter and the first that is NOT a startup hook, so the channel it
+>   guards is now "every prompt", not "one session start". Its bound lives with the emitter, per that
+>   guard's own convention.
+>
+> **Next: F21**, whose entry is in `### P3`. Same root (session start is a race between what arrives
+> and what reads it); F20 was the code half, F21 is the notes half.
 >
 > Nothing is half-written on disk. `main` is at the PR #56 merge (`b414766`), and **`release/v4.7.0`
 > exists and is pushed** off that commit. Work the remaining boxes below in order.
 >
 > - [x] **13.1 — merge PR #56 into `main`**, then branch `release/v4.7.0` off it. **✅ DONE 2026-08-05**
 >       (merge `b414766`, CI was 7/7 on `b88ca51`; branch pushed and tracking).
-> - [ ] **13.2 — F20 + F21 together** (one root, two changes). Start with F20's detection, since F21's
->       "notes that simply arrived after the scan" is the same window.
+> - [ ] **13.2 — F20 + F21 together** (one root, two changes).
+>   - [x] **F20 — DONE** _(2026-08-05 · `82f49cd`, `ee1c373`)_, both halves; see the resume point above.
+>   - [ ] **F21** — the shortfall line that promises a resume it cannot know is coming.
 > - [ ] **13.3 — F22**, option A: two thin alias skills, `universe` and `univers`.
 > - [ ] **13.4 — the release tail** (§10 marketing re-read, mutation on what changed, version vector,
 >       note + PR body, tag) — same shape as v4.5.0 and v4.6.0, whose tails are Steps 11 and 12.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -1087,7 +1087,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > ⚠️ **No finding codes in any artifact** (the owner, 2026-08-03): "F20, F21, Fx" are filing labels for
 > this plan only. The note, the PR body and the release name the behaviour instead.
 >
-> ### ⏭️ THE RESUME POINT — F20 IS DONE; the live work is **13.2's second half, F21**
+> ### ⏭️ THE RESUME POINT — 13.2 IS DONE (F20 + F21); the live work is **13.3, F22**
 >
 > **✅ F20 IS COMPLETE** _(2026-08-05 · `82f49cd`, `ee1c373`)_. Both halves shipped, and the two calls
 > the entry left open are taken below; do not re-open them.
@@ -1112,8 +1112,33 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   guards is now "every prompt", not "one session start". Its bound lives with the emitter, per that
 >   guard's own convention.
 >
-> **Next: F21**, whose entry is in `### P3`. Same root (session start is a race between what arrives
-> and what reads it); F20 was the code half, F21 is the notes half.
+> **✅ F21 IS COMPLETE** _(2026-08-05 · `25057b0`)_. Both halves shipped, and the second one is what
+> the owner actually asked for.
+> - **Say which** — `rag/src/lib/index-shortfall.ts` reads the run state the SessionStart banner
+>   already reads (the same `last-run` record, not a second opinion) and separates **five** states
+>   that were rendered as one sentence: notes the indexer **refused** (never resolves itself), a
+>   **quota wall** (does — and it keeps the resume promise, the one case it was written for), a run
+>   **still in flight**, notes that simply **arrived** after the scan, and a gap a catch-up has
+>   already **failed to close**.
+> - **Then act** — the arrival case now schedules a catch-up through the `ReindexScheduler` that was
+>   sitting idle, armed for an event that had already happened. Both surfaces do it: the startup path
+>   (after the watcher exists, since it owns the scheduler) and `vault_stats` (the question IS the
+>   moment — the line says "catching up now", so the ask has to happen there or the sentence would be
+>   the old promise in newer words). Bounded by progress, in memory, per server process.
+> - **The fifth state was found by an existing test, not by design.** `C.13` asserted the old
+>   sentence for a run whose status is `running`; under the new model that would have read "they
+>   arrived after the last scan" about work being done as the owner reads it. A run in flight is the
+>   one wait nobody has to be told about.
+> - **Three existing expectations were repointed, deliberately** (`3.1b`, `4.2`, `C.13`): they
+>   encoded the promise this finding is about. The cap case gained a test of its own so the fix
+>   cannot swap one wrong cause for another.
+> - **Not changed, and why:** the SessionStart banner (`scripts/lib/rag-status.mjs`) still says
+>   "auto catch-up in the background" for an unexplained shortfall — a sentence F21 makes **true**
+>   for the first time. It cannot know about the process-local bound (it runs before the server), so
+>   a permanently stalled gap is named by F15's crosscheck instead, which already exists for exactly
+>   that.
+>
+> **Next: 13.3 — F22**, option A: two thin alias skills, `universe` and `univers`.
 >
 > Nothing is half-written on disk. `main` is at the PR #56 merge (`b414766`), and **`release/v4.7.0`
 > exists and is pushed** off that commit. Work the remaining boxes below in order.
@@ -1122,7 +1147,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >       (merge `b414766`, CI was 7/7 on `b88ca51`; branch pushed and tracking).
 > - [ ] **13.2 — F20 + F21 together** (one root, two changes).
 >   - [x] **F20 — DONE** _(2026-08-05 · `82f49cd`, `ee1c373`)_, both halves; see the resume point above.
->   - [ ] **F21** — the shortfall line that promises a resume it cannot know is coming.
+>   - [x] **F21 — DONE** _(2026-08-05 · `25057b0`)_, both halves; see the resume point above.
 > - [ ] **13.3 — F22**, option A: two thin alias skills, `universe` and `univers`.
 > - [ ] **13.4 — the release tail** (§10 marketing re-read, mutation on what changed, version vector,
 >       note + PR body, tag) — same shape as v4.5.0 and v4.6.0, whose tails are Steps 11 and 12.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -1087,10 +1087,12 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > ⚠️ **No finding codes in any artifact** (the owner, 2026-08-03): "F20, F21, Fx" are filing labels for
 > this plan only. The note, the PR body and the release name the behaviour instead.
 >
-> ### ⏭️ THE RESUME POINT — the three findings are DONE and pushed; the live work is **13.4, the
-> release tail**, whose next command is the `scripts` mutation batch (spelled out below, worktree
-> already prepared). Branch `release/v4.7.0`, CI green through `55128d9`'s predecessors, nothing
-> half-written in the main checkout.
+> ### ⏭️ THE RESUME POINT — everything that does not need the owner is DONE and pushed. **The only
+> box left is the PUBLIC half: the release note, the PR body and the tag** — and §10 says the owner is
+> asked **before** it, as at v4.6.0. Drafts are written and waiting for that read
+> (`maintainers/plans/prospective/release-v4.7.0-note.draft.md` and `…-pr-body.draft.md`); nothing is
+> published, no PR is open, no tag exists. Branch `release/v4.7.0`, pushed through `794a52b`, working
+> tree clean, mutation worktree removed.
 >
 > **✅ F20 IS COMPLETE** _(2026-08-05 · `82f49cd`, `ee1c373`)_. Both halves shipped, and the two calls
 > the entry left open are taken below; do not re-open them.
@@ -1167,29 +1169,40 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >       **`index-shortfall.ts` 100 %**, **`status-report.ts` 100 %**, 0 survivors.
 >       `rag/src/index.ts` is out of the tool's scope (not under `src/lib/`) — same class as the
 >       top-level scripts, already named debt. **Do not re-run this half.**
-> - [ ] **⏭️ THE NEXT COMMAND — mutation, the `scripts` half.** The worktree is ALREADY prepared
->       and verified: `/Users/tpierrain/Dev/kenjaku-mut-v470` (detached at `55128d9`),
->       `rag/node_modules` symlinked, `scripts/vault-write-guard.test.mjs` checked there at
->       **9 pass / 0 skipped** (it must not skip, or the mutants face a suite that cannot judge
->       them). From that worktree, run:
->       ```
->       node /Users/tpierrain/Dev/kenjaku/maintainers/mutation/node_modules/@stryker-mutator/core/bin/stryker.js \
->         run maintainers/mutation/stryker.scripts.batch.config.mjs \
->         --mutate "scripts/lib/frozen-wiring.mjs,scripts/lib/restart-nudge.mjs,scripts/lib/restart-signal.mjs,scripts/prompt-restart-nudge.mjs"
->       ```
->       Those four are what this release wrote. `session-status.mjs` / `session-self-heal.mjs` /
->       `update-engine.mjs` were also touched but are the **known top-level tier** (no test can
->       import them) — record, do not chase. ⚠️ It mutates **in place**: never run it in the main
->       checkout, and reset the worktree between batches per Step 11's recipe.
->       **When done: `git worktree remove /Users/tpierrain/Dev/kenjaku-mut-v470`.**
-> - [ ] **§10, the marketing-surface re-read** — started, nothing written yet. What the reading so
->       far suggests, to be confirmed rather than trusted: nothing became FALSE (question 1); the
->       candidate for question 2 is that `README.md:94-96` (*"freshness catches up behind the
->       scenes"*) and the *Zero-chore* row were **partly unearned** — the arrival case never caught
->       up — and this release is what makes them true, the same shape as v4.5.0's rehydrate repair.
->       The `board-reliability` **"34 ADRs"** drift is pre-existing and deliberately left.
-> - [ ] **Release note + PR body + tag** — the owner is asked BEFORE the public tail, as at v4.6.0.
->       No PR is open for `release/v4.7.0` yet.
+> - [x] **Mutation, the `scripts` half — DONE, 83.33 % → 97.56 %** _(2026-08-05 · `7239caf`, logs
+>       `…/v470-scripts-changed.log` then `…/v470-scripts-recheck.log`)_. Fourteen survivors, and the
+>       low number was **a design defect, not thin tests**: in `restart-signal.mjs` (58.33 %) the
+>       fail-soft is written **twice per signal** — an initializer *and* a `catch` — so each half
+>       silently covered for the other and **neither could be shown to work**. Stated once now
+>       (`noSignalIfItBlowsUp`). Two cases were missing outright (a `.mcp.json` registering exactly
+>       what the engine delivered — the converged case that proves both probes are read — and one
+>       registering something else), and the fake now reads the way node's `fs` reads, so a read that
+>       passes by luck fails in the test. `frozen-wiring` had only ever been fed **CRLF**: on Unix the
+>       whole stdout would have come back as one path and the machine that is behind would have gone
+>       silent everywhere **but** Windows. `restart-nudge`'s reason clause and its *"open your reply"*
+>       instruction were both deletable with the suite green. Both at **100 %** now; `restart-signal`
+>       **95.45 %**. Two survivors left, both **pre-listed equivalents** (§5ter): the `isEntrypoint`
+>       boot guard (already named debt → `runAsEntrypoint`, v4.8.0) and a `catch { return false; }`
+>       that `isRestartPending`'s `Boolean(…)` normalises. Numbers pinned in
+>       `maintainers/mutation/RESULTS.md` (§ v4.7.0, **both halves**). **Do not re-run this half**;
+>       the worktree `kenjaku-mut-v470` has been removed.
+> - [x] **§10, the marketing-surface re-read — DONE** _(2026-08-05 · `794a52b`)_. **Question 1:
+>       nothing became FALSE.** The only stale thing found is an illustration, not a promise —
+>       `SETUP.md` §10 showed the version segment as `v4.6.0` (bumped). **Question 2: two, both
+>       shipped in the copy.** (a) The **stale engine**: the self-upgrade bullet now says the brain
+>       tells you when the engine answering you is no longer the one on disk — the second-machine
+>       pull case, terminal *and* Desktop. (b) **"Always catches up"** was partly unearned, the same
+>       shape as v4.5.0's rehydrate repair: §C now names the **five** kinds of pending, says which one
+>       resolves itself, and says the arrival case is caught up **on the spot**. **Boards: re-read
+>       through their alt texts, NOT re-rendered** — `board-flow`'s "catch up in the background" is
+>       about external sources rather than the index and still holds; `board-reliability`'s **"34
+>       ADRs"** (37 today) is the pre-existing under-claim, deliberately left as decided at v4.6.0.
+>       No finding codes on the surface, as agreed.
+> - [ ] **⏭️ Release note + PR body + tag — THE ONLY BOX LEFT, and it needs the owner.** Drafts are
+>       written and committed, deliberately NOT published: `release-v4.7.0-note.draft.md` and
+>       `release-v4.7.0-pr-body.draft.md`, next to this plan. **Read them with the owner first**, then
+>       open the PR, wait for 7/7, merge, tag, publish — the v4.6.0 sequence. No PR is open for
+>       `release/v4.7.0`, and no tag exists.
 >
 > Nothing is half-written on disk. `main` is at the PR #56 merge (`b414766`), and **`release/v4.7.0`
 > exists and is pushed** off that commit. Work the remaining boxes below in order.
@@ -1202,7 +1215,9 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > - [x] **13.3 — F22 — DONE** _(2026-08-05 · `c229cab`)_, option A; see the resume point above.
 > - [ ] **13.4 — the release tail** (§10 marketing re-read, mutation on what changed, version vector,
 >       note + PR body, tag) — same shape as v4.5.0 and v4.6.0, whose tails are Steps 11 and 12.
->   - [ ] **Bookkeeping the cut created, do it on the release branch, not on `main`:** three code
+>       **Everything except the public half is done** _(2026-08-05)_; see the boxes above.
+>   - [x] **DONE** _(2026-08-05 · `421121f`, verified in the files)_ — **bookkeeping the cut created,
+>         done on the release branch, not on `main`:** three code
 >         comments still send a reader to v4.7.0 for work that now lands in **v4.8.0** —
 >         `scripts/lib/engine-version.mjs:19` and `scripts/lib/engine-version.test.mjs:73` (the
 >         `unknown` version state, F3) and `scripts/lib/health-probe.test.mjs:219`. A comment naming

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -1043,8 +1043,9 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > ### ✅ THE SCOPE, DECIDED BY THE OWNER (2026-08-05). Do not re-open it, do not widen it.
 >
 > **In — four items, and nothing else:**
-> - [ ] **PR #56, the dependency pins** — ours, replacing two drive-by PRs from a fork. Merge it first so
->       `release/v4.7.0` branches off a clean `main`. Detail below; do not re-derive it.
+> - [x] **PR #56, the dependency pins** — ours, replacing two drive-by PRs from a fork. **✅ MERGED
+>       2026-08-05** (`b414766` on `main`); `release/v4.7.0` is branched off it and pushed. Detail below;
+>       do not re-derive it.
 > - [ ] **F20** (`### P3`) — a machine that is behind runs the old engine all session and never says so,
 >       so **F1's privacy fix silently does not apply there**. The pull is already first; the gap is that
 >       the restart nudge is blind to an engine that arrived **by pull**. Its entry carries the
@@ -1086,12 +1087,13 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > ⚠️ **No finding codes in any artifact** (the owner, 2026-08-03): "F20, F21, Fx" are filing labels for
 > this plan only. The note, the PR body and the release name the behaviour instead.
 >
-> ### ⏭️ THE RESUME POINT — the scope call is DONE; the next act is to merge PR #56, then open the branch
+> ### ⏭️ THE RESUME POINT — the branch is OPEN; the live work is **13.2, F20's detection**
 >
-> Nothing is half-written on disk. `main` is at the v4.6.0 merge (`c0b2b16`, tag `v4.6.0` published) plus
-> the plan commits. Work the four boxes below in order.
+> Nothing is half-written on disk. `main` is at the PR #56 merge (`b414766`), and **`release/v4.7.0`
+> exists and is pushed** off that commit. Work the remaining boxes below in order.
 >
-> - [ ] **13.1 — merge PR #56 into `main`**, then branch `release/v4.7.0` off it.
+> - [x] **13.1 — merge PR #56 into `main`**, then branch `release/v4.7.0` off it. **✅ DONE 2026-08-05**
+>       (merge `b414766`, CI was 7/7 on `b88ca51`; branch pushed and tracking).
 > - [ ] **13.2 — F20 + F21 together** (one root, two changes). Start with F20's detection, since F21's
 >       "notes that simply arrived after the scan" is the same window.
 > - [ ] **13.3 — F22**, option A: two thin alias skills, `universe` and `univers`.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -1087,7 +1087,10 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > ⚠️ **No finding codes in any artifact** (the owner, 2026-08-03): "F20, F21, Fx" are filing labels for
 > this plan only. The note, the PR body and the release name the behaviour instead.
 >
-> ### ⏭️ THE RESUME POINT — the three findings are DONE; the live work is **13.4, the release tail**
+> ### ⏭️ THE RESUME POINT — the three findings are DONE and pushed; the live work is **13.4, the
+> release tail**, whose next command is the `scripts` mutation batch (spelled out below, worktree
+> already prepared). Branch `release/v4.7.0`, CI green through `55128d9`'s predecessors, nothing
+> half-written in the main checkout.
 >
 > **✅ F20 IS COMPLETE** _(2026-08-05 · `82f49cd`, `ee1c373`)_. Both halves shipped, and the two calls
 > the entry left open are taken below; do not re-open them.
@@ -1155,15 +1158,38 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >       `rag/package.json` + lockfile in step. `local-mirror` (0.3.0) and `constitutionTemplate`
 >       (1.2.0) left alone: nothing in them changed, checked rather than assumed.
 >       `indexSchemaVersion` stays **2** — no reindex, which is what the note will promise.
-> - [ ] **§10, the marketing-surface re-read** — not started.
-> - [ ] **Mutation on what this release changed** — not started. Production files touched:
->       `scripts/lib/frozen-wiring.mjs`, `scripts/lib/restart-nudge.mjs`,
->       `scripts/lib/restart-signal.mjs`, `scripts/prompt-restart-nudge.mjs`,
->       `scripts/session-status.mjs`, `scripts/session-self-heal.mjs`, `scripts/update-engine.mjs`,
->       `rag/src/lib/index-shortfall.ts`, `rag/src/lib/status-report.ts`, `rag/src/index.ts`.
->       Recipe and the batching lesson: Step 11's mutation section (worktree, NOT the scratchpad;
->       one or two files per run; `rag/node_modules` symlinked and verified first).
+> - [x] **Mutation, the `rag` half — DONE and CLOSED at 100 %** _(2026-08-05 · `55128d9`, logs
+>       `…/v470-rag-changed.log` then `…/v470-rag-recheck.log`)_. First pass **94.44 %**, nine
+>       survivors, all in code written the same day; two familiar families (an absent case nothing
+>       fed — a shortfall whose failures ARE the whole gap — and a truncation nothing exercised:
+>       three refusals against a bound of two). The ninth was **simplified away rather than
+>       excused** (`!== null && !== undefined` → `typeof asked === "number"`). Re-measured:
+>       **`index-shortfall.ts` 100 %**, **`status-report.ts` 100 %**, 0 survivors.
+>       `rag/src/index.ts` is out of the tool's scope (not under `src/lib/`) — same class as the
+>       top-level scripts, already named debt. **Do not re-run this half.**
+> - [ ] **⏭️ THE NEXT COMMAND — mutation, the `scripts` half.** The worktree is ALREADY prepared
+>       and verified: `/Users/tpierrain/Dev/kenjaku-mut-v470` (detached at `55128d9`),
+>       `rag/node_modules` symlinked, `scripts/vault-write-guard.test.mjs` checked there at
+>       **9 pass / 0 skipped** (it must not skip, or the mutants face a suite that cannot judge
+>       them). From that worktree, run:
+>       ```
+>       node /Users/tpierrain/Dev/kenjaku/maintainers/mutation/node_modules/@stryker-mutator/core/bin/stryker.js \
+>         run maintainers/mutation/stryker.scripts.batch.config.mjs \
+>         --mutate "scripts/lib/frozen-wiring.mjs,scripts/lib/restart-nudge.mjs,scripts/lib/restart-signal.mjs,scripts/prompt-restart-nudge.mjs"
+>       ```
+>       Those four are what this release wrote. `session-status.mjs` / `session-self-heal.mjs` /
+>       `update-engine.mjs` were also touched but are the **known top-level tier** (no test can
+>       import them) — record, do not chase. ⚠️ It mutates **in place**: never run it in the main
+>       checkout, and reset the worktree between batches per Step 11's recipe.
+>       **When done: `git worktree remove /Users/tpierrain/Dev/kenjaku-mut-v470`.**
+> - [ ] **§10, the marketing-surface re-read** — started, nothing written yet. What the reading so
+>       far suggests, to be confirmed rather than trusted: nothing became FALSE (question 1); the
+>       candidate for question 2 is that `README.md:94-96` (*"freshness catches up behind the
+>       scenes"*) and the *Zero-chore* row were **partly unearned** — the arrival case never caught
+>       up — and this release is what makes them true, the same shape as v4.5.0's rehydrate repair.
+>       The `board-reliability` **"34 ADRs"** drift is pre-existing and deliberately left.
 > - [ ] **Release note + PR body + tag** — the owner is asked BEFORE the public tail, as at v4.6.0.
+>       No PR is open for `release/v4.7.0` yet.
 >
 > Nothing is half-written on disk. `main` is at the PR #56 merge (`b414766`), and **`release/v4.7.0`
 > exists and is pushed** off that commit. Work the remaining boxes below in order.

--- a/maintainers/plans/prospective/field-findings-2026-08-02-action.md
+++ b/maintainers/plans/prospective/field-findings-2026-08-02-action.md
@@ -1087,7 +1087,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > ⚠️ **No finding codes in any artifact** (the owner, 2026-08-03): "F20, F21, Fx" are filing labels for
 > this plan only. The note, the PR body and the release name the behaviour instead.
 >
-> ### ⏭️ THE RESUME POINT — 13.2 IS DONE (F20 + F21); the live work is **13.3, F22**
+> ### ⏭️ THE RESUME POINT — the three findings are DONE; the live work is **13.4, the release tail**
 >
 > **✅ F20 IS COMPLETE** _(2026-08-05 · `82f49cd`, `ee1c373`)_. Both halves shipped, and the two calls
 > the entry left open are taken below; do not re-open them.
@@ -1138,7 +1138,17 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 >   a permanently stalled gap is named by F15's crosscheck instead, which already exists for exactly
 >   that.
 >
-> **Next: 13.3 — F22**, option A: two thin alias skills, `universe` and `univers`.
+> **✅ F22 IS COMPLETE** _(2026-08-05 · `c229cab`)_. Option A as decided: `engine-skills/universe/`
+> and `engine-skills/univers/`, both locales getting both. They **point** at `switch` and explain
+> nothing — the reconciler never removes a skill, so a second copy of the rules would outlive any
+> repair. Delivery checked, not assumed: `engine-skills/**` is `replace`, `installStagedSkills`
+> install-if-absents any new directory, and both doors run it (the installer for a fresh brain,
+> the reconcile for the fleet). Guarded by `scripts/lib/skill-aliases.test.mjs` on the four things
+> that break an alias silently: the folder (the CLI routes on it), the declared `name:`, the target
+> still existing, and the description's cost in the always-loaded layer (F19).
+>
+> **Next: 13.4 — the release tail.** Start with the bookkeeping the scope cut created (three code
+> comments still send a reader to v4.7.0 for work that now lands in v4.8.0), then the usual shape.
 >
 > Nothing is half-written on disk. `main` is at the PR #56 merge (`b414766`), and **`release/v4.7.0`
 > exists and is pushed** off that commit. Work the remaining boxes below in order.
@@ -1148,7 +1158,7 @@ and the "I found nothing" that came out as "nothing exists" (F18). Do not re-ope
 > - [ ] **13.2 — F20 + F21 together** (one root, two changes).
 >   - [x] **F20 — DONE** _(2026-08-05 · `82f49cd`, `ee1c373`)_, both halves; see the resume point above.
 >   - [x] **F21 — DONE** _(2026-08-05 · `25057b0`)_, both halves; see the resume point above.
-> - [ ] **13.3 — F22**, option A: two thin alias skills, `universe` and `univers`.
+> - [x] **13.3 — F22 — DONE** _(2026-08-05 · `c229cab`)_, option A; see the resume point above.
 > - [ ] **13.4 — the release tail** (§10 marketing re-read, mutation on what changed, version vector,
 >       note + PR body, tag) — same shape as v4.5.0 and v4.6.0, whose tails are Steps 11 and 12.
 >   - [ ] **Bookkeeping the cut created, do it on the release branch, not on `main`:** three code

--- a/maintainers/plans/prospective/release-v4.7.0-note.draft.md
+++ b/maintainers/plans/prospective/release-v4.7.0-note.draft.md
@@ -3,7 +3,7 @@
      commit actually being tagged — it is written in the past tense and is not true yet, (3) this
      comment and the `.draft` in the filename go away, and the file moves to `plans/archived/`. -->
 
-# v4.7.0 — The One Where It Admits It's Behind
+# v4.7.0 — The One Where It Knows You Haven't Restarted Yet
 
 **Your brain stops answering as if it were up to date when it isn't.** When newer code has landed but the
 conversation you are in still runs the old one, it says so. When notes are waiting to be indexed, it says

--- a/maintainers/plans/prospective/release-v4.7.0-note.draft.md
+++ b/maintainers/plans/prospective/release-v4.7.0-note.draft.md
@@ -1,0 +1,97 @@
+<!-- DRAFT, written 2026-08-05 while the owner was away. NOT published, no tag, no PR.
+     Before it ships: (1) the owner reads it, (2) the CI claim at the bottom is checked against the
+     commit actually being tagged — it is written in the past tense and is not true yet, (3) this
+     comment and the `.draft` in the filename go away, and the file moves to `plans/archived/`. -->
+
+# v4.7.0 — The One Where It Admits It's Behind
+
+**Your brain stops answering as if it were up to date when it isn't.** When newer code has landed but the
+conversation you are in still runs the old one, it says so. When notes are waiting to be indexed, it says
+*which kind* of waiting — and the ordinary kind is now caught up on the spot instead of being promised for
+next time.
+
+### What you get
+
+- 🛑 **It tells you when it is running yesterday's engine.** A conversation loads its wiring once, when it
+  opens. So if an update lands while you are working — typically when you open your brain on a **second
+  machine** and it pulls the version you installed on the first — everything you asked afterwards was
+  answered by the *old* code, silently, for the whole session. Your brain now says so, and keeps saying so
+  until you close and reopen. It works in the terminal **and** in the Desktop app, which had no such cue at
+  all.
+- ⏳ **"A few notes pending" now says what kind of pending.** One sentence used to cover five very different
+  situations — and it always promised the same happy ending. Now they are told apart: notes your brain
+  **refused** (a header it cannot read: those need a fix and will never resolve themselves), a **daily
+  quota** reached (that one really does resume on its own), an indexing run **still going** as you read,
+  notes that simply **arrived** after the last look, and a catch-up that has already **tried and failed**.
+- ⚡ **And the ordinary case is fixed right away.** Notes that just arrived used to be promised a catch-up
+  "next session" while nothing was actually scheduled. They are now indexed **on the spot** — when your
+  brain starts, and again the moment you ask about the state of your index.
+- 🌌 **`/universe` and `/univers` now work.** The command that switches between your spheres is called
+  `/switch`, so typing the noun — in English or in French — answered *"unknown command"*. Both now take you
+  straight there.
+
+### What you have to do
+
+Ask for **`/update-engine`** once, then restart your session if it says so.
+
+**This release does not re-read your notes** — nothing to wait for, nothing in your vault is modified.
+
+---
+
+### Under the hood
+
+- **Both defects are the same one, on two clocks.** A session start is a race between what arrives and what
+  reads it. The engine's own code, and your notes, can both land *after* the moment that decided what to
+  say about them — and in both cases what got printed was the reassuring version. The fix is the same shape
+  twice: read the state that actually exists at the moment of speaking, and separate the cases the old
+  sentence had merged.
+- **The stale-engine detection reuses evidence that was already computed and thrown away.** Your brain
+  pulls at session start and counted the files it received, only to discard the list. That list is exactly
+  the evidence needed: it now names which of those files a session freezes at start — hooks, skills,
+  settings, the constitution, both local servers, the version stamp — and arms the existing restart nudge
+  when any of them moved. A pull that brought only notes stays silent, because notes need no restart. A
+  brain with no remote pulls nothing and is silent by construction, which is pinned by a test rather than
+  left to the reader.
+- **The nudge injects, it never blocks.** It rides the one channel that reaches Desktop and repeats on
+  every message. That channel *can* refuse a message outright; it deliberately does not. A wrong verdict
+  must cost you one sentence, never lock you out of your own brain.
+- **It does not mention privacy, on purpose.** A session that already printed something it should not have
+  is not un-printed by a restart, so naming that case would buy you nothing you can act on. The wording
+  stays the general one.
+- **The shortfall model reads the same record the banner reads**, not a second opinion — one source, five
+  outcomes. The fifth state was found by an *existing* test rather than by design: it asserted the old
+  sentence for a run that was still going, which under the new model would have said "they arrived after
+  the last scan" about work being done as you read it. A run in flight is the one wait nobody needs to be
+  told about.
+- **The catch-up is asked for where the promise is made.** Both at startup and at the moment you ask about
+  the index — because that line now says "catching up now", and a sentence like that has to be true where
+  it is printed, or it is the old promise in newer words.
+- **The two new commands explain nothing.** They point at `/switch` and stop there. An engine update never
+  removes a skill from your brain, so a second copy of the rules would outlive any later correction — one
+  page of rules, two doors onto it.
+- **Dependencies: two known advisories closed, ours rather than a drive-by.** Two outside pull requests
+  proposed pinning a vulnerable transitive dependency each; both were applied to a throwaway copy and
+  re-audited, and **neither actually closed its advisory** — they missed that the search engine pulls the
+  same package through a second path. Ours pins both, in both packages: 12 → 9 and 6 → 5 reported
+  vulnerabilities. The rest of the audit (a native image library with no fix available, among others) is
+  named rather than quietly left, and is its own pass.
+
+### Measured, not asserted
+
+The four files this release wrote in the harness went through a mutation pass — code deliberately broken to
+check the tests notice. The first run scored **83.33 %**, and the reason was worth the trip: the
+"if anything goes wrong, stay quiet" fallback was written **twice** in the same function, so each copy
+silently covered for the other and **neither could be shown to work**. Stated once, it became testable.
+Two whole cases were missing besides. After the fixes: **97.56 %**, two of the four files at 100 %, and the
+two surviving mutants are the documented kind that no honest test can kill.
+
+The search-engine side scored **94.44 %** first pass and **100 %** after its nine survivors were closed —
+one of them by deleting a condition that read as two reasons while only ever meaning one thing.
+
+A published release is frozen, so these numbers stay true for this tag forever. Full detail:
+[`maintainers/mutation/RESULTS.md`](maintainers/mutation/RESULTS.md).
+
+### CI
+
+The full matrix — Node 22, 24 and 26 on macOS and Windows, plus the Windows install end-to-end — green on
+the commit being tagged, checked against that commit rather than against the colour of a page.

--- a/maintainers/plans/prospective/release-v4.7.0-pr-body.draft.md
+++ b/maintainers/plans/prospective/release-v4.7.0-pr-body.draft.md
@@ -1,7 +1,7 @@
 <!-- DRAFT, written 2026-08-05 while the owner was away. NOT published, no PR is open.
      Before it ships: the owner reads it, and the CI line is checked against the head commit. -->
 
-## v4.7.0 — The One Where It Admits It's Behind
+## v4.7.0 — The One Where It Knows You Haven't Restarted Yet
 
 The short leg of the trilogy, and the only one whose scope was cut rather than grown: it ships **what one
 morning's field session raised**, plus the dependency pins we wrote ourselves. Everything else moves to

--- a/maintainers/plans/prospective/release-v4.7.0-pr-body.draft.md
+++ b/maintainers/plans/prospective/release-v4.7.0-pr-body.draft.md
@@ -1,0 +1,77 @@
+<!-- DRAFT, written 2026-08-05 while the owner was away. NOT published, no PR is open.
+     Before it ships: the owner reads it, and the CI line is checked against the head commit. -->
+
+## v4.7.0 — The One Where It Admits It's Behind
+
+The short leg of the trilogy, and the only one whose scope was cut rather than grown: it ships **what one
+morning's field session raised**, plus the dependency pins we wrote ourselves. Everything else moves to
+v4.8.0 with its analysis intact.
+
+Two of the three findings are the **same root on two clocks**: a session start is a race between what
+arrives and what reads it, and in both races the reassuring sentence won. Newer engine code lands after the
+session froze its wiring → the whole conversation is answered by the old code, silently. Notes land after
+the scan that counted them → *"pending, they'll catch up next session"*, while nothing was scheduled and
+the watcher sat idle.
+
+**The user-facing note is the source of truth for what ships:**
+[`release-v4.7.0-note.draft.md`](release-v4.7.0-note.draft.md).
+
+### What is in it
+
+- **A machine that is behind now says so** — detected from the startup pull's **own file list**, which the
+  session already computed and threw away to keep a count. `lib/frozen-wiring.mjs` names which of those
+  paths a session freezes at start (hooks, skills, settings, the constitution, both MCP servers, the
+  version vector); a match arms the flag the existing nudge already reads. A pull that brought only notes
+  arms nothing; a brain with no remote is silent by construction, pinned by a test.
+- **The nudge reaches Desktop, and repeats** — a `UserPromptSubmit` hook injecting the directive on every
+  prompt while the flag is armed. It **injects, never blocks**: that event can refuse a prompt outright,
+  and a wrong verdict must cost a sentence, not a locked-out owner. It is the first deterministic Desktop
+  cue for a stale engine.
+- **The shortfall model** (`rag/src/lib/index-shortfall.ts`) reads the run record the banner already reads
+  — one source, not a second opinion — and separates **five** states that were rendered as one sentence:
+  refused notes, a quota wall, a run in flight, notes that arrived after the scan, and a catch-up that has
+  already failed.
+- **And it acts on the one it can fix**: the arrival case schedules a catch-up through the
+  `ReindexScheduler` that was sitting idle, armed for an event that had already happened. Both surfaces do
+  it — startup (which owns the scheduler) and `vault_stats` (where the sentence "catching up now" is
+  printed, so the ask has to happen there or it is the old promise in newer words). Bounded by progress,
+  in memory, per server process.
+- **`/universe` and `/univers`** — two thin aliases at the root, both locales getting both. They **point**
+  at `switch` and explain nothing: the reconciler never removes a skill, so a second copy of the rules
+  would outlive any repair. Guarded on the four things that break an alias silently (the folder the CLI
+  routes on, the declared `name:`, the target still existing, and the description's cost in the
+  always-loaded layer).
+- **PR #56, already merged into `main`** — the dependency pins, ours, replacing two drive-by PRs from a
+  fork (#48, #52). Both were applied to a throwaway copy and re-audited: **neither closed its advisory**,
+  because `rag` pulls `fast-uri` through its own `ajv` too. Ours pins both through `overrides` in both
+  packages: `rag` 12 → 9, `local-mirror` 6 → 5. The rest of the audit is named in the PR body rather than
+  quietly left.
+
+### Choices worth reviewing
+
+- **The nudge does not name the privacy case.** A banner that already printed a profile is not un-leaked by
+  a restart, so naming it buys nothing actionable and dates the copy to one release.
+- **The SessionStart banner was deliberately left alone.** It still says "auto catch-up in the background"
+  for an unexplained shortfall — a sentence this release makes **true** for the first time. It cannot know
+  about the process-local bound (it runs before the server), so a permanently stalled gap is named by the
+  vault↔index crosscheck that already exists for exactly that.
+- **Three existing expectations were repointed, deliberately** (`3.1b`, `4.2`, `C.13`): they encoded the
+  promise this finding is about. The cap case gained a test of its own so the fix cannot swap one wrong
+  cause for another.
+- **Option A for the aliases, not a rename of `/switch`.** On a deployed brain a rename **is** an alias
+  plus a stale duplicate, since the reconciler installs skills by directory name and never removes one.
+
+### Verification
+
+- **Mutation, both halves, per file rather than averaged.** `rag`: **94.44 % → 100 %** on the two files
+  changed. `scripts`: **83.33 % → 97.56 %** on the four written. The `scripts` number is the one worth a
+  reviewer's minute — it was a **design** defect, not thin tests: `lib/restart-signal.mjs` wrote its
+  fail-soft **twice per signal** (an initializer *and* a `catch`), so each half silently covered for the
+  other and neither could be shown to work. Stated once, it became testable. `lib/frozen-wiring.mjs` had
+  only ever been fed CRLF, so a splitter that knew only CRLF passed — on Unix the whole stdout would have
+  come back as one path and the machine that is behind would have gone silent everywhere *but* Windows.
+  Detail: [`maintainers/mutation/RESULTS.md`](../../mutation/RESULTS.md) § v4.7.0.
+- **§10, the marketing re-read: nothing became false.** Two things became **true** and are now sold — the
+  stale-engine cue, and "always catches up", which was partly unearned until this release (the arrival case
+  never caught up). Boards re-read through their alt texts, **not** re-rendered.
+- **CI**: the full matrix — Node 22/24/26 × macOS + Windows, plus the Windows installer end-to-end.

--- a/rag/package-lock.json
+++ b/rag/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "second-brain-rag",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "second-brain-rag",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@google/genai": "^1.0.0",

--- a/rag/package.json
+++ b/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "second-brain-rag",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/rag/src/index.ts
+++ b/rag/src/index.ts
@@ -39,6 +39,7 @@ import { scanVault } from "./lib/document-scanner.js";
 import { UsageTracker } from "./lib/usage-tracker.js";
 import { ReindexLock } from "./lib/reindex-lock.js";
 import { buildStatusReport, incompleteIndexWarning, formatWatcherLiveness } from "./lib/status-report.js";
+import { CatchUpBound, describeShortfall, type Shortfall } from "./lib/index-shortfall.js";
 import { ReindexScheduler } from "./lib/reindex-scheduler.js";
 import { startVaultWatcher } from "./lib/vault-watcher.js";
 import {
@@ -70,6 +71,17 @@ const server = new McpServer({
 // (which sets them at startup) and `vault_stats` (which reads the scheduler's in-memory state).
 let liveScheduler: ReindexScheduler | null = null;
 let watcherActive = false;
+
+// F21: the engine's own catch-up, and the memory that keeps it from looping. A shortfall the
+// run state cannot explain is notes that landed after the scan — the ordinary multi-machine
+// case, where the pull delivers them at the very instant the startup reindex reads the vault.
+// Nothing was waiting for them: the scheduler sits idle, armed for an event that has already
+// happened. So we ask, once, and only ask again if the previous ask actually closed part of it.
+const catchUpBound = new CatchUpBound();
+
+function catchUpIfNotesArrived(shortfall: Shortfall | null): void {
+  if (catchUpBound.request(shortfall)) liveScheduler?.notify();
+}
 
 server.tool(
   "search_vault",
@@ -230,8 +242,21 @@ server.tool(
       // quota in local mode (in-process / OpenAI-compatible endpoint).
       providerId: createEmbedder().identity.providerId,
       progress,
+      lastCatchUpRemaining: catchUpBound.lastCatchUpRemaining(),
       now: new Date().toISOString(),
     });
+
+    // The question the owner asks IS the moment to close the gap: they are looking at the
+    // number. The line above says "catching up now" for exactly this cause, so the ask has to
+    // happen here, or that sentence would be the old promise wearing newer words.
+    catchUpIfNotesArrived(
+      describeShortfall({
+        docCount: stats.docCount,
+        scannedCount: scanned.length,
+        progress,
+        lastCatchUpRemaining: catchUpBound.lastCatchUpRemaining(),
+      }),
+    );
 
     const watcherLine = formatWatcherLiveness({
       active: watcherActive,
@@ -369,13 +394,17 @@ async function main() {
         `[vault-rag] Auto-reindex done: ${result.indexed} indexed, ${result.skipped} unchanged` +
           (result.errors.length > 0 ? `, ${result.errors.length} errors` : "")
       );
-      // Surface incompleteness: if the index is not complete after the run
-      // (quota wall, errors), say so explicitly — auto-resumes on the next
-      // session, nothing to do by hand.
-      const warning = incompleteIndexWarning({
+      // Surface incompleteness, and say WHICH of the causes it is (F21): a refusal never
+      // resolves itself, a quota wall does, and notes that landed during this very run are
+      // closed by asking again — which is what `catchUpIfNotesArrived` does, a few lines
+      // below, once the watcher that owns the scheduler exists.
+      const shortfallInput = {
         docCount: getStats().docCount,
         scannedCount: result.scanned,
-      });
+        progress: new FileProgressStorage().load(),
+        lastCatchUpRemaining: catchUpBound.lastCatchUpRemaining(),
+      };
+      const warning = incompleteIndexWarning(shortfallInput);
       if (warning) console.error(`[vault-rag] ${warning}`);
 
       // The background path that fires after an import: tell the user the new
@@ -387,6 +416,11 @@ async function main() {
       // serializes in-process runs; each run rewrites last-run.md → observable like
       // the others (F.5).
       startFileWatcher();
+
+      // AFTER the watcher, because it is what owns the scheduler: this is the exact window
+      // the field report walked into — the session's `git pull` lands notes while this run is
+      // already reading the vault, so they are neither failed nor queued, just unseen.
+      catchUpIfNotesArrived(describeShortfall(shortfallInput));
     })
     .catch((err) =>
       console.error("[vault-rag] Auto-reindex failed (non-blocking):", err)

--- a/rag/src/lib/index-shortfall.test.ts
+++ b/rag/src/lib/index-shortfall.test.ts
@@ -1,0 +1,149 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { describeShortfall, CatchUpBound } from "./index-shortfall.js";
+import type { RunProgress } from "./progress-report.js";
+
+/** The engine's own record of a finished run, with only what a shortfall verdict reads varied. */
+const run = (over: Partial<RunProgress> = {}): RunProgress => ({
+  status: "done",
+  startedAt: "2026-08-05T06:00:00Z",
+  finishedAt: "2026-08-05T06:02:00Z",
+  totalChunks: 100,
+  doneChunks: 100,
+  scanned: 441,
+  indexed: 12,
+  skipped: 427,
+  removed: 0,
+  errors: [],
+  hitCap: false,
+  ...over,
+});
+
+// F21 (field, 2026-08-05): `vault_stats` answered "19 pending — auto-resume on the next
+// session" while the watcher was idle, the embedder was local (so there is no quota to wait
+// for) and nothing had failed. The sentence was made from two numbers and nothing else, so it
+// promised a recovery it could not know was coming. The run state the engine already writes
+// says which of the three it is; this is the one place that reads it.
+test("a complete index has no shortfall to describe", () => {
+  assert.equal(describeShortfall({ docCount: 42, scannedCount: 42 }), null);
+});
+
+// A run that recorded refusals: the note is scanned, never indexed, and the next run will
+// reject the same bytes the same way. This is F11/F12's cause, on the surface F11/F12 never
+// reached — and it is the one the resume promise gets exactly backwards.
+test("notes the indexer REFUSED are a failure, and the run named which", () => {
+  assert.deepEqual(
+    describeShortfall({ docCount: 439, scannedCount: 441, progress: run({ errors: ["a.md: bad frontmatter", "b.md: unreadable"] }) }),
+    { remaining: 2, cause: "failures", failures: ["a.md: bad frontmatter", "b.md: unreadable"], queued: 0 },
+  );
+});
+
+// The one case the original sentence was written for, and where it is TRUE: a run cut off by
+// the daily cap resumes by itself, because the wall comes down at midnight. Note this run
+// also has no errors — the two terms are separated on purpose (§9), so neither can be
+// dropped while the suite stays green.
+test("a run stopped by the quota wall is a wait, and waiting is the right answer", () => {
+  assert.deepEqual(describeShortfall({ docCount: 400, scannedCount: 441, progress: run({ hitCap: true }) }), {
+    remaining: 41,
+    cause: "cap",
+    failures: [],
+    queued: 41,
+  });
+});
+
+// THE field case. Nothing failed, no wall was hit, and the notes are still missing: they
+// landed after the scan that produced this run — the multi-machine window where the session's
+// `git pull` delivers notes while the server is already indexing. Nothing is waiting for
+// anything, so nothing will happen at the next session either; the machinery that could close
+// it is idle, waiting for an event that has already happened.
+test("notes that simply ARRIVED after the scan are neither a failure nor a wait", () => {
+  assert.deepEqual(describeShortfall({ docCount: 439, scannedCount: 458, progress: run() }), {
+    remaining: 19,
+    cause: "arrived",
+    failures: [],
+    queued: 19,
+  });
+});
+
+// No run state at all — a freshly rehydrated machine, or a brain whose cache was cleared.
+// Absent is not "nothing failed": it is "nothing is recorded", and the honest reading is the
+// same as the field case, because that is the state where asking now costs one run.
+test("no run recorded → the shortfall is read as arrived, not as a wait", () => {
+  assert.equal(describeShortfall({ docCount: 439, scannedCount: 458 })?.cause, "arrived");
+});
+
+// The bound, and the reason it is not optional: "arrived" is the only cause that makes the
+// engine ACT, so without a stop condition a note that is scanned but lands in no bucket at
+// all (F10's shape — neither indexed, nor unchanged, nor reported) would have the server
+// catching up forever. One catch-up that closes nothing is the runtime evidence that this is
+// not a late arrival, whatever the run state says.
+test("a catch-up that closed nothing is stalled, not something to ask for again", () => {
+  assert.equal(
+    describeShortfall({ docCount: 439, scannedCount: 458, progress: run(), lastCatchUpRemaining: 19 })?.cause,
+    "stalled",
+  );
+});
+
+test("a catch-up that closed part of the gap keeps going — progress is what buys the next one", () => {
+  // The boundary: 19 → 18 is progress, 19 → 19 is not. Nothing else tells `>=` from `>`, and
+  // the wrong one here either loops forever or gives up while notes are still landing.
+  assert.equal(
+    describeShortfall({ docCount: 440, scannedCount: 458, progress: run(), lastCatchUpRemaining: 19 })?.cause,
+    "arrived",
+  );
+});
+
+// Found by an existing status-report test rather than by design: a run that is STILL RUNNING
+// is a genuine wait, and the only one the engine must not act on — the work is already being
+// done in this process. Read from the run's own status, not from its numbers.
+test("a run in progress is a wait: the catch-up is already happening", () => {
+  assert.equal(
+    describeShortfall({ docCount: 120, scannedCount: 211, progress: run({ status: "running" }) })?.cause,
+    "running",
+  );
+});
+
+// ─── The half the owner actually asked for: stop describing, ACT ─────────────
+// "ça devrait reprendre en auto dès lors qu'il constate qu'il est en retard, non ?" — yes,
+// and the machinery is right there: the scheduler is idle, waiting for an event that has
+// already happened. This is the memory that keeps asking bounded.
+
+test("CatchUpBound — a shortfall of notes that arrived is worth asking for", () => {
+  const bound = new CatchUpBound();
+
+  assert.equal(bound.lastCatchUpRemaining(), null, "nothing has been asked yet");
+  assert.equal(bound.request(describeShortfall({ docCount: 439, scannedCount: 458, progress: run() })), true);
+  assert.equal(bound.lastCatchUpRemaining(), 19, "the ask is remembered, so the next read can judge it");
+});
+
+test("CatchUpBound — a refusal, a wall, a run in flight and a complete index are never asked for", () => {
+  const bound = new CatchUpBound();
+
+  assert.deepEqual(
+    [
+      bound.request(describeShortfall({ docCount: 439, scannedCount: 441, progress: run({ errors: ["a.md: bad"] }) })),
+      bound.request(describeShortfall({ docCount: 400, scannedCount: 441, progress: run({ hitCap: true }) })),
+      bound.request(describeShortfall({ docCount: 120, scannedCount: 211, progress: run({ status: "running" }) })),
+      bound.request(describeShortfall({ docCount: 42, scannedCount: 42 })),
+    ],
+    [false, false, false, false],
+  );
+  assert.equal(bound.lastCatchUpRemaining(), null, "a refused ask leaves no trace to judge later");
+});
+
+test("CatchUpBound — the second ask, on a gap that did not move, is refused (the loop is closed)", () => {
+  // The two halves composed, which is the only way to see the bound actually bind: ask once,
+  // let the catch-up change nothing, and read again exactly as the server does.
+  const bound = new CatchUpBound();
+  const read = () =>
+    describeShortfall({
+      docCount: 439,
+      scannedCount: 458,
+      progress: run(),
+      lastCatchUpRemaining: bound.lastCatchUpRemaining(),
+    });
+
+  assert.equal(bound.request(read()), true);
+  assert.equal(read()?.cause, "stalled");
+  assert.equal(bound.request(read()), false);
+});

--- a/rag/src/lib/index-shortfall.ts
+++ b/rag/src/lib/index-shortfall.ts
@@ -57,8 +57,10 @@ function causeOf(remaining: number, failures: number, input: ShortfallInput): Sh
   if (failures > 0) return "failures";
   if (input.progress?.status === "running") return "running";
   if (input.progress?.hitCap) return "cap";
+  // One term, not two: `!== null && !== undefined` reads as a pair of reasons while only
+  // ever meaning "a number was recorded", and nothing can tell the halves apart.
   const asked = input.lastCatchUpRemaining;
-  if (asked !== null && asked !== undefined && remaining >= asked) return "stalled";
+  if (typeof asked === "number" && remaining >= asked) return "stalled";
   return "arrived";
 }
 

--- a/rag/src/lib/index-shortfall.ts
+++ b/rag/src/lib/index-shortfall.ts
@@ -1,0 +1,88 @@
+import type { RunProgress } from "./progress-report.js";
+
+export interface ShortfallInput {
+  docCount: number;
+  scannedCount: number;
+  /** The last catch-up run's persisted state — the engine's own record of what happened. */
+  progress?: RunProgress | null;
+  /**
+   * The shortfall as it stood when this process last ASKED for a catch-up, if it ever did.
+   * The bound on acting: a catch-up that closed nothing is evidence the notes are not late,
+   * whatever the run state says — so the engine stops asking instead of looping.
+   */
+  lastCatchUpRemaining?: number | null;
+}
+
+/**
+ * Why the index holds fewer notes than the vault. These are not five wordings of one
+ * state: a refusal never resolves itself, a wall resolves on its own, a note that simply
+ * arrived late is closed by asking NOW, a shortfall that survived a catch-up is none of the
+ * three (the engine has already tried and must stop rather than loop), and a run still in
+ * flight is the one wait nobody has to be told about — it is being closed as they read.
+ */
+export type ShortfallCause = "failures" | "cap" | "arrived" | "stalled" | "running";
+
+export interface Shortfall {
+  /** How many scanned notes the index does not hold. */
+  remaining: number;
+  cause: ShortfallCause;
+  /** The failures the run recorded, verbatim — empty unless the cause is `failures`. */
+  failures: string[];
+  /** The part of the shortfall that is NOT explained by those failures. */
+  queued: number;
+}
+
+/**
+ * What a shortfall between the vault and the index IS — or null when there is none.
+ */
+export function describeShortfall(input: ShortfallInput): Shortfall | null {
+  const remaining = input.scannedCount - input.docCount;
+  if (remaining <= 0) return null;
+
+  const failures = input.progress?.errors ?? [];
+  return {
+    remaining,
+    cause: causeOf(remaining, failures.length, input),
+    failures,
+    queued: Math.max(0, remaining - failures.length),
+  };
+}
+
+/**
+ * Ordered by what can be done about it, most-actionable first. A refusal outranks a wall:
+ * the wall lifts by itself, the refused note never does, and a shortfall carrying both must
+ * not read as a wait.
+ */
+function causeOf(remaining: number, failures: number, input: ShortfallInput): ShortfallCause {
+  if (failures > 0) return "failures";
+  if (input.progress?.status === "running") return "running";
+  if (input.progress?.hitCap) return "cap";
+  const asked = input.lastCatchUpRemaining;
+  if (asked !== null && asked !== undefined && remaining >= asked) return "stalled";
+  return "arrived";
+}
+
+/**
+ * The memory that keeps the engine's own catch-up bounded (F21). Asking for one is the
+ * right answer to notes that landed after the scan; asking a second time when the first
+ * closed nothing is a loop, so the shortfall of the last ask is remembered and handed back
+ * to `describeShortfall`, which then reads the state as `stalled` rather than `arrived`.
+ *
+ * Per server process, in memory, deliberately: the window it guards is one process's, and a
+ * bound persisted to disk would outlive the run it describes.
+ */
+export class CatchUpBound {
+  private lastRemaining: number | null = null;
+
+  /** The shortfall this process last asked a catch-up to close — null if it never has. */
+  lastCatchUpRemaining(): number | null {
+    return this.lastRemaining;
+  }
+
+  /** Records the ask and answers whether a catch-up should be requested. */
+  request(shortfall: Shortfall | null): boolean {
+    if (shortfall?.cause !== "arrived") return false;
+    this.lastRemaining = shortfall.remaining;
+    return true;
+  }
+}

--- a/rag/src/lib/status-report.test.ts
+++ b/rag/src/lib/status-report.test.ts
@@ -86,7 +86,10 @@ test("3.1a — complete index, gemini/default provider → exact 2-line report",
   );
 });
 
-test("3.1b — incomplete index → exact Y/X indexed + Z pending + auto-resume line", () => {
+// F21 repointed the expectation of this test and of `4.2` below, deliberately: with NO run
+// recorded, "auto-resume on the next session" was a promise made from two numbers. Absent is
+// not "nothing failed" — it is "nothing is recorded", and asking now costs one run.
+test("3.1b — incomplete index → exact Y/X indexed + Z pending + the cause it can actually support", () => {
   const report = buildStatusReport({
     docCount: 30,
     scannedCount: 42,
@@ -98,7 +101,7 @@ test("3.1b — incomplete index → exact Y/X indexed + Z pending + auto-resume 
 
   assert.equal(
     report,
-    "Index incomplete: 30/42 files indexed, 12 pending — auto-resume on the next session.\n" +
+    "Index incomplete: 30/42 files indexed, 12 pending — they arrived after the last scan; catching up now.\n" +
       "Quota: 0/950 used today, 950 remaining (reserve 50 for search).",
   );
 });
@@ -173,9 +176,22 @@ test("3.1d — no lock → no mention of reindex in progress", () => {
 
 // ─── incompleteIndexWarning (leaf) ───
 
-test("4.2 — incompleteIndexWarning: incomplete index → exact resume message", () => {
+test("4.2 — incompleteIndexWarning: incomplete index → the cause, not a resume it cannot know", () => {
   assert.equal(
     incompleteIndexWarning({ docCount: 30, scannedCount: 42 }),
+    "Index incomplete: 30/42 files indexed, 12 pending — they arrived after the last scan; catching up now.",
+  );
+});
+
+test("4.2 — incompleteIndexWarning: a wall IS a wait, and keeps the resume promise it earns", () => {
+  // The one case the original sentence was written for. It has to keep saying it, or F21's
+  // fix would have swapped one wrong cause for another.
+  assert.equal(
+    incompleteIndexWarning({
+      docCount: 30,
+      scannedCount: 42,
+      progress: finishedRun({ hitCap: true, scanned: 42 }),
+    }),
     "Index incomplete: 30/42 files indexed, 12 pending — auto-resume on the next session.",
   );
 });
@@ -215,7 +231,9 @@ test("C.13 — progress running with `now` → exact 3-line report (now, not sta
   // elapsed time → "~0/min, ETA unknown".
   assert.equal(
     report,
-    "Index incomplete: 120/211 files indexed, 91 pending — auto-resume on the next session.\n" +
+    // F21: the run is `status: "running"`, so the shortfall is being closed as it is read —
+    // the one wait nobody has to be told to wait for.
+    "Index incomplete: 120/211 files indexed, 91 pending — a catch-up is running right now.\n" +
       "Quota: 200/950 used today, 750 remaining (reserve 50 for search).\n" +
       "Catch-up in progress: 120/660 chunks (18 %), ~120/min, ETA ~5 min, 0 error(s).",
   );
@@ -319,5 +337,67 @@ test("3.1g — any other provider → exact generic \"Embeddings via <id>\" fall
     report,
     "Index up to date: 7/7 files indexed.\n" +
       "Embeddings via mistral-embed: no Gemini quota tracked.",
+  );
+});
+
+// ─── F21: the shortfall line stops promising a resume it cannot know is coming ───
+// It was made from two numbers and nothing else, so `vault_stats` answered "19 pending —
+// auto-resume on the next session" with the watcher idle, a local embedder (no quota to wait
+// for) and nothing failed. The cause model is `describeShortfall`, read from the run state
+// the engine already writes — the SAME state the SessionStart banner reads (F11/F12), not a
+// second opinion.
+const finishedRun = (over: Partial<RunProgress> = {}): RunProgress => ({
+  status: "done",
+  startedAt: "2026-08-05T06:00:00Z",
+  finishedAt: "2026-08-05T06:02:00Z",
+  totalChunks: 100,
+  doneChunks: 100,
+  scanned: 458,
+  indexed: 12,
+  skipped: 427,
+  removed: 0,
+  errors: [],
+  hitCap: false,
+  ...over,
+});
+
+test("F21 — notes the indexer refused are named, and the line says it will NOT fix itself", () => {
+  assert.equal(
+    incompleteIndexWarning({
+      docCount: 439,
+      scannedCount: 441,
+      progress: finishedRun({ errors: ["a.md: bad frontmatter"] }),
+    }),
+    "Index incomplete: 439/441 files indexed, 1 failed, 1 pending — a.md: bad frontmatter. " +
+      "This will NOT resolve on its own: repair the note (or ask me to), then reindex.",
+  );
+});
+
+test("F21 — notes that arrived after the scan are caught up NOW, not promised to a next session", () => {
+  assert.equal(
+    incompleteIndexWarning({ docCount: 439, scannedCount: 458, progress: finishedRun() }),
+    "Index incomplete: 439/458 files indexed, 19 pending — they arrived after the last scan; catching up now.",
+  );
+});
+
+test("F21 — a run still in flight is the one wait that needs no explaining", () => {
+  assert.equal(
+    incompleteIndexWarning({ docCount: 120, scannedCount: 211, progress: finishedRun({ status: "running" }) }),
+    "Index incomplete: 120/211 files indexed, 91 pending — a catch-up is running right now.",
+  );
+});
+
+test("F21 — a catch-up that closed nothing stops promising, and names the tool that can look", () => {
+  // The bound, on the surface: the engine has already asked once and the gap did not move, so
+  // repeating "catching up now" would be the same false promise in a newer coat.
+  assert.equal(
+    incompleteIndexWarning({
+      docCount: 439,
+      scannedCount: 458,
+      progress: finishedRun(),
+      lastCatchUpRemaining: 19,
+    }),
+    "Index incomplete: 439/458 files indexed, 19 pending — a catch-up just ran and closed none of them. " +
+      "This will NOT resolve on its own: run `node scripts/verify-index.mjs` to see which notes disagree.",
   );
 });

--- a/rag/src/lib/status-report.test.ts
+++ b/rag/src/lib/status-report.test.ts
@@ -401,3 +401,31 @@ test("F21 — a catch-up that closed nothing stops promising, and names the tool
       "This will NOT resolve on its own: run `node scripts/verify-index.mjs` to see which notes disagree.",
   );
 });
+
+test("F21 — when the failures ARE the whole shortfall, nothing is described as pending", () => {
+  // The boundary the `, N pending` suffix turns on: two missing notes, two refusals, so
+  // there is no queue at all. Without it, a reader is told to wait for zero notes.
+  assert.equal(
+    incompleteIndexWarning({
+      docCount: 439,
+      scannedCount: 441,
+      progress: finishedRun({ errors: ["a.md: bad frontmatter", "b.md: unreadable"] }),
+    }),
+    "Index incomplete: 439/441 files indexed, 2 failed — a.md: bad frontmatter; b.md: unreadable. " +
+      "This will NOT resolve on its own: repair the note (or ask me to), then reindex.",
+  );
+});
+
+test("F21 — a long list of refusals is truncated, and says how many it is not showing", () => {
+  // Three failures against a bound of two: the only fixture that tells the truncation from
+  // the whole list, the separator from nothing, and `+N other(s)` from silence.
+  assert.equal(
+    incompleteIndexWarning({
+      docCount: 438,
+      scannedCount: 441,
+      progress: finishedRun({ errors: ["a.md: bad", "b.md: worse", "c.md: worst"] }),
+    }),
+    "Index incomplete: 438/441 files indexed, 3 failed — a.md: bad; b.md: worse (+1 other(s)). " +
+      "This will NOT resolve on its own: repair the note (or ask me to), then reindex.",
+  );
+});

--- a/rag/src/lib/status-report.ts
+++ b/rag/src/lib/status-report.ts
@@ -1,6 +1,7 @@
 import type { LockState } from "./reindex-lock.js";
 import { formatProgressReport, RESUME_HINT, type RunProgress } from "./progress-report.js";
 import type { SchedulerState } from "./reindex-scheduler.js";
+import { describeShortfall, type ShortfallInput } from "./index-shortfall.js";
 
 /**
  * Liveness line for the live-stream watcher (real-time in-memory state of the
@@ -38,6 +39,12 @@ export interface StatusReportInput {
   providerId?: string;
   /** State of the last catch-up run (or the in-progress one), if any. */
   progress?: RunProgress | null;
+  /**
+   * The shortfall the server last asked a catch-up to close (F21). Passed so the LINE and
+   * the ACTION read the same state: without it the report would keep saying "catching up
+   * now" about a gap the engine has already given up on.
+   */
+  lastCatchUpRemaining?: number | null;
   /** Current ISO instant (required for the ETA of a `running` run). */
   now?: string;
 }
@@ -62,13 +69,42 @@ function progressLine(input: StatusReportInput): string | null {
  * docs remain to be indexed, `null` if the index is complete (nothing to
  * surface). Single source of the "index incomplete" phrasing.
  */
-export function incompleteIndexWarning(input: {
-  docCount: number;
-  scannedCount: number;
-}): string | null {
-  const remaining = input.scannedCount - input.docCount;
-  if (remaining <= 0) return null;
-  return `Index incomplete: ${input.docCount}/${input.scannedCount} files indexed, ${remaining} pending — ${RESUME_HINT}.`;
+export function incompleteIndexWarning(input: ShortfallInput): string | null {
+  const shortfall = describeShortfall(input);
+  if (!shortfall) return null;
+
+  const head = `Index incomplete: ${input.docCount}/${input.scannedCount} files indexed`;
+  if (shortfall.cause === "failures") {
+    const waiting = shortfall.queued > 0 ? `, ${shortfall.queued} pending` : "";
+    return (
+      `${head}, ${shortfall.failures.length} failed${waiting} — ${describeFailures(shortfall.failures)}. ` +
+      `This will NOT resolve on its own: repair the note (or ask me to), then reindex.`
+    );
+  }
+  if (shortfall.cause === "arrived") {
+    return `${head}, ${shortfall.remaining} pending — they arrived after the last scan; catching up now.`;
+  }
+  if (shortfall.cause === "running") {
+    return `${head}, ${shortfall.remaining} pending — a catch-up is running right now.`;
+  }
+  if (shortfall.cause === "stalled") {
+    return (
+      `${head}, ${shortfall.remaining} pending — a catch-up just ran and closed none of them. ` +
+      "This will NOT resolve on its own: run `node scripts/verify-index.mjs` to see which notes disagree."
+    );
+  }
+  // A wall: the one case the resume promise was written for, and the only one where it holds.
+  return `${head}, ${shortfall.remaining} pending — ${RESUME_HINT}.`;
+}
+
+/**
+ * The failures worth naming, truncated (2 max + a count of the rest) — same bound, and the
+ * same reason, as the SessionStart banner's: a wall of stack-like strings is skipped as noise.
+ */
+function describeFailures(errors: string[], max = 2): string {
+  const shown = errors.slice(0, max).join("; ");
+  const rest = errors.length - max;
+  return rest > 0 ? `${shown} (+${rest} other(s))` : shown;
 }
 
 function indexLine(input: StatusReportInput): string {

--- a/scripts/lib/engine-manifest-integrity.test.mjs
+++ b/scripts/lib/engine-manifest-integrity.test.mjs
@@ -115,8 +115,10 @@ test("engine-manifest — every hook script arrives WHOLE (replace/regenerate), 
 test("engine-manifest — the hook sweep reads every event, so an empty scan cannot pass for a clean one", () => {
   const events = Object.keys(templateHooks());
 
-  assert.ok(events.includes("PreToolUse") && events.includes("PostToolUse") && events.includes("SessionStart"),
-    `the template lost a hook event the guard above relies on: ${events.join(", ")}`);
+  assert.ok(
+    ["PreToolUse", "PostToolUse", "SessionStart", "UserPromptSubmit"].every((e) => events.includes(e)),
+    `the template lost a hook event the guard above relies on: ${events.join(", ")}`,
+  );
 });
 
 // The same reverse guard, for the OTHER way a brain runs an engine script: a skill

--- a/scripts/lib/engine-version.mjs
+++ b/scripts/lib/engine-version.mjs
@@ -16,7 +16,8 @@
 //     ref: `engineVersion.rag` (1.3.0) has never been a Kenjaku release number
 //     (v4.5.0), and an owner reading "Kenjaku engine 1.3.0" would report a version
 //     that does not exist. No ref → no segment. Naming that state out loud
-//     ("version unknown") belongs to F3, in v4.7.0.
+//     ("version unknown") belongs to F3, deferred to v4.8.0 (v4.7.0 was cut down to
+//     one morning's field session, 2026-08-05).
 //
 // Fallbacks (never invent a version):
 //   • `source.ref` present (any string — semver tag OR a branch/commit) → show it

--- a/scripts/lib/engine-version.test.mjs
+++ b/scripts/lib/engine-version.test.mjs
@@ -70,7 +70,7 @@ test("startupVersionLine — a non-semver ref (branch/commit) is shown verbatim,
 // "Kenjaku engine 1.3.0" would send an owner to report a version that does not
 // exist — so the segment is DROPPED instead. (The status-line label keeps that
 // fallback: it says "engine", claiming nothing about the product's release.)
-// Naming that state out loud belongs to F3 in v4.7.0, which owns "unknown".
+// Naming that state out loud belongs to F3, which owns "unknown" — deferred to v4.8.0.
 test("startupVersionLine — no ref → NO segment, never the rag package number dressed as a release", () => {
   assert.equal(startupVersionLine({ engineVersion: { rag: "1.3.0" } }), null);
   assert.equal(startupVersionLine({ source: { repo: "https://x", ref: "" } , engineVersion: { rag: "1.3.0" } }), null);

--- a/scripts/lib/frozen-wiring.mjs
+++ b/scripts/lib/frozen-wiring.mjs
@@ -1,0 +1,39 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// frozen-wiring.mjs — which of a set of paths a Claude session FREEZES when it
+// starts (F20). Pure decider; the caller supplies the paths (session-status.mjs
+// hands it the pull's own `git diff --name-only ORIG_HEAD HEAD`).
+//
+// Why a list of its own rather than the manifest's regimes: the question here is
+// not "does an upgrade own this file" but "did THIS session already load it". A
+// skill the owner wrote themselves is in no regime and is frozen all the same;
+// `engine-manifest.json` is in no regime either, and it is the version vector
+// every other surface quotes. The two sets overlap, they are not the same set.
+//
+// Paths are POSIX-shaped on every OS: git reports them that way, including on
+// Windows. Nothing here joins or resolves — comparing is the whole job.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Everything under these lives in the session's frozen picture: the hooks it wired,
+// the skills and settings it read, the staged skills a reconcile installs from, and
+// the two MCP servers it spawned.
+const FROZEN_PREFIXES = [
+  "scripts/",
+  ".claude/",
+  "engine-skills/",
+  "rag/",
+  "local-mirror/",
+  "CLAUDE.", // CLAUDE.md, CLAUDE.engine.md, CLAUDE.md.template — the constitution it loaded
+];
+
+// Two single files with no folder to stand for them.
+const FROZEN_FILES = new Set(["engine-manifest.json", ".mcp.json.template"]);
+
+/** The paths in a `git diff --name-only` stdout. Splits on either line ending, drops blanks. */
+export function pulledPaths(diffOut) {
+  return diffOut.split(/\r?\n/).filter((line) => line.trim().length > 0);
+}
+
+/** The subset of `paths` this session froze at start — empty when a pull brought only notes. */
+export function frozenWiringIn(paths) {
+  return paths.filter((p) => FROZEN_FILES.has(p) || FROZEN_PREFIXES.some((prefix) => p.startsWith(prefix)));
+}

--- a/scripts/lib/frozen-wiring.test.mjs
+++ b/scripts/lib/frozen-wiring.test.mjs
@@ -1,0 +1,82 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { frozenWiringIn, pulledPaths } from "./frozen-wiring.mjs";
+
+// F20 (field, 2026-08-05): a brain updated on machine A, then opened on machine B, ran the
+// PRE-update engine for the whole session and never said so — the startup `git pull` had
+// just landed the new code, and every hook / skill / MCP server was already frozen on the
+// old one. The pull's own file list is the exact evidence, and session-status.mjs already
+// computes it (`git diff --name-only ORIG_HEAD HEAD`) only to count it and throw it away.
+test("frozenWiringIn — a pulled session hook is named (the code this session already froze)", () => {
+  assert.deepEqual(frozenWiringIn(["scripts/session-universe.mjs"]), ["scripts/session-universe.mjs"]);
+});
+
+// The discriminator, and the one that decides whether this is shippable at all: the ordinary
+// multi-machine pull brings NOTES, and notes need no restart (the RAG watches the vault and
+// reindexes). A nudge that fired on every sync would be a phantom restart at every session —
+// the repo's own rule (restart-signal.mjs): it costs a pointless one and teaches people to
+// ignore the real one.
+test("frozenWiringIn — pulled notes are not wiring, and do not drag a sibling script out with them", () => {
+  assert.deepEqual(
+    frozenWiringIn(["vault/people/hossam.md", "scripts/lib/rag-status.mjs", "vault/inbox/2026-08-05.md"]),
+    ["scripts/lib/rag-status.mjs"],
+  );
+});
+
+// The other four doors a session reads once and never again: the constitution it loaded, the
+// skills + settings under `.claude/`, the staged `engine-skills/` the reconciler installs from,
+// and the MCP servers it spawned. `engine-manifest.json` rides along because it is the version
+// vector every other surface quotes — a session that pulled it is already ANSWERING with a
+// number its running code does not match.
+test("frozenWiringIn — the constitution, the skills, the staged engine skills, the servers and the manifest", () => {
+  assert.deepEqual(
+    frozenWiringIn([
+      "CLAUDE.md",
+      "CLAUDE.engine.md",
+      ".claude/skills/switch/SKILL.md",
+      ".claude/settings.json.template",
+      "engine-skills/consolidate/SKILL.md",
+      "rag/src/index.ts",
+      "local-mirror/src/server.ts",
+      "engine-manifest.json",
+      ".mcp.json.template",
+    ]),
+    [
+      "CLAUDE.md",
+      "CLAUDE.engine.md",
+      ".claude/skills/switch/SKILL.md",
+      ".claude/settings.json.template",
+      "engine-skills/consolidate/SKILL.md",
+      "rag/src/index.ts",
+      "local-mirror/src/server.ts",
+      "engine-manifest.json",
+      ".mcp.json.template",
+    ],
+  );
+});
+
+// A prefix, not a substring: a vault note filed under a folder that happens to be called
+// `scripts` is a note. Told apart from `includes` only by a path where the token sits in the
+// middle, which is exactly the shape an owner's own filing produces.
+test("frozenWiringIn — the token must START the path, and a lookalike filename is not the file", () => {
+  assert.deepEqual(
+    frozenWiringIn([
+      "vault/topics/scripts/shell-tricks.md",
+      "maintainers/engine-manifest.json",
+      "vault/CLAUDE.md",
+    ]),
+    [],
+  );
+});
+
+// The list arrives as the raw stdout of `git diff --name-only`, which session-status.mjs
+// used to split inline and immediately reduce to a count. Parsed here so both the count and
+// the wiring verdict are read from one tested place. CRLF is fed on purpose: this repo has
+// been bitten three times by a Windows checkout, and a trailing `\r` would turn every path
+// into one nothing matches — a machine that is behind would then stay silent on Windows only.
+test("pulledPaths — the raw diff becomes paths, blank lines and CRLF included", () => {
+  assert.deepEqual(
+    pulledPaths("scripts/session-status.mjs\r\nvault/inbox/note.md\r\n\r\n"),
+    ["scripts/session-status.mjs", "vault/inbox/note.md"],
+  );
+});

--- a/scripts/lib/frozen-wiring.test.mjs
+++ b/scripts/lib/frozen-wiring.test.mjs
@@ -81,6 +81,18 @@ test("pulledPaths — the raw diff becomes paths, blank lines and CRLF included"
   );
 });
 
+// The other ending, and the majority one: git on macOS/Linux emits bare LF. Fed as its own
+// case because a split that only knows CRLF still passes the test above — it would return
+// the whole stdout as ONE path, which matches no prefix, and the machine that is behind goes
+// silent on every Unix. The whitespace-only line is the second half of the same guard: a
+// blank that is not empty must not survive as a path either.
+test("pulledPaths — LF-only stdout, and a line that is blank without being empty", () => {
+  assert.deepEqual(
+    pulledPaths("scripts/session-status.mjs\n   \nvault/inbox/note.md\n"),
+    ["scripts/session-status.mjs", "vault/inbox/note.md"],
+  );
+});
+
 // A brain with no remote pulls nothing, and a brain that is already up to date pulls
 // nothing either — session-status hands an empty list in both cases. It is the majority
 // of all sessions, so it is the one that must cost nothing and say nothing.

--- a/scripts/lib/frozen-wiring.test.mjs
+++ b/scripts/lib/frozen-wiring.test.mjs
@@ -80,3 +80,10 @@ test("pulledPaths — the raw diff becomes paths, blank lines and CRLF included"
     ["scripts/session-status.mjs", "vault/inbox/note.md"],
   );
 });
+
+// A brain with no remote pulls nothing, and a brain that is already up to date pulls
+// nothing either — session-status hands an empty list in both cases. It is the majority
+// of all sessions, so it is the one that must cost nothing and say nothing.
+test("frozenWiringIn — nothing pulled, nothing to say", () => {
+  assert.deepEqual(frozenWiringIn([]), []);
+});

--- a/scripts/lib/health-probe.test.mjs
+++ b/scripts/lib/health-probe.test.mjs
@@ -216,8 +216,9 @@ test("formatHealthBanner — an unknown check name still gets a gesture, not an 
 //
 // ⚠️ This test PINS a known defect, it does not bless it: the `unknown` check is listed
 // under "found a problem", i.e. "we could not tell" is rendered as "it is broken" — the
-// finding already recorded for v4.7.0 (field-findings-2026-08-02-action.md, F14's second
-// field run). When that ships, this expectation changes on purpose.
+// finding already recorded in field-findings-2026-08-02-action.md (F14's second field run),
+// and deferred to v4.8.0 by the 2026-08-05 scope call. When it ships, this expectation
+// changes on purpose.
 test("formatHealthBanner — a module's healthy checks are not reported as causes", () => {
   const banner = formatHealthBanner([
     {

--- a/scripts/lib/hooks-reconcile.test.mjs
+++ b/scripts/lib/hooks-reconcile.test.mjs
@@ -306,3 +306,33 @@ test("detectHookGap — a converged brain → not needed (steady-state no-op)", 
   };
   assert.equal(detectHookGap({ brainHooks: converged, templateHooks }).needed, false);
 });
+
+// The same door, one release later, for the OTHER whole event a deployed brain has never
+// heard of: `UserPromptSubmit`. It is F20's only Desktop-visible channel, so a brain that
+// never receives the entry gets the fix on paper and nothing on screen — and EVERY brain
+// installed before v4.7.0 is in that state. Read from the real template, like its sibling.
+test("reconcileHooks — a brain with no UserPromptSubmit at all is given the restart nudge", () => {
+  const { hooks, hooksAdded } = reconcileHooks({
+    brainHooks: v310BrainHooks(),
+    templateHooks: realTemplateHooks(),
+    projectRoot: "/brains/foo",
+  });
+
+  assert.deepEqual(
+    hooks.UserPromptSubmit,
+    [
+      {
+        matcher: "",
+        hooks: [
+          {
+            type: "command",
+            command: '/usr/local/bin/node "/brains/foo/scripts/prompt-restart-nudge.mjs"',
+            timeout: 10000,
+          },
+        ],
+      },
+    ],
+    "the event must be CREATED, matcher and timeout intact, with the brain's own node + dir substituted",
+  );
+  assert.ok(hooksAdded.includes("scripts/prompt-restart-nudge.mjs"), "the newly-wired nudge must be named in hooksAdded");
+});

--- a/scripts/lib/restart-nudge.mjs
+++ b/scripts/lib/restart-nudge.mjs
@@ -42,3 +42,22 @@ export function isRestartPending({ flagExists, gapNeeded }) {
 export function restartNudgeSegment(pending) {
   return pending ? "⚠️ RESTART Claude to finish the engine update" : null;
 }
+
+// The SAME nudge, on the channel that reaches Desktop and repeats: injected as
+// `additionalContext` by a `UserPromptSubmit` hook, so it is re-stated on every prompt until
+// the owner actually restarts (ADR 0036's matrix — `systemMessage` and `statusLine` are both
+// CLI-only). It INJECTS, it never blocks: a wrong verdict must cost one sentence, never lock
+// someone out of their own brain. Returns null when nothing is pending — the normal case, and
+// the one that must add exactly nothing to a prompt.
+//
+// Wording deliberately reuses the update-engine skill's: a FULL close + reopen, then back to
+// THIS conversation — never a new one, which is the distinct initial-rooting rule.
+export function restartPromptDirective(pending) {
+  if (!pending) return null;
+  return (
+    "🛑 This conversation is running the OLD engine: newer code is on disk, and a session " +
+    "loads its hooks, skills and servers only at start. Open your reply by telling the " +
+    "owner, calmly and in their own language: fully CLOSE Claude and REOPEN it, then come " +
+    "back to THIS same conversation — do not open a new conversation. Then answer them."
+  );
+}

--- a/scripts/lib/restart-nudge.test.mjs
+++ b/scripts/lib/restart-nudge.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { restartNudgeSegment, isRestartPending, RESTART_FLAG_REL } from "./restart-nudge.mjs";
+import { restartNudgeSegment, restartPromptDirective, isRestartPending, RESTART_FLAG_REL } from "./restart-nudge.mjs";
 
 // F-B7d (A2, hardened after Thomas's rig QA): a pre-3.3 brain's FIRST /update-engine runs
 // the OLD orchestrator → silent report → the user doesn't restart → the new skill/MCP stay
@@ -45,3 +45,32 @@ test("restartNudgeSegment — not pending → no segment (null), so the status l
 test("RESTART_FLAG_REL — a stable, gitignored .cache-relative path", () => {
   assert.match(RESTART_FLAG_REL, /^\.cache\//);
 });
+
+// ─── F20: the channel that reaches Desktop, and repeats until it is acted on ──
+// `systemMessage` is CLI-only and is printed once, at the top of a session that may run for
+// hours; on Desktop it is dropped outright, and a pending restart even SILENCES the version
+// relay (status-hook-output.mjs). So the only deterministic Desktop cue for "you are running
+// the old engine" was a chat rule inside the update-engine skill — which fires when the update
+// ran HERE, precisely the case F20 is not about. `UserPromptSubmit` can inject on every prompt.
+// Inject, never block (exit 2): a false positive must cost a sentence, never lock an owner out
+// of their own brain.
+test("restartPromptDirective — pending → the agent is told to raise the restart, in the owner's language", () => {
+  const directive = restartPromptDirective(true);
+
+  assert.match(directive, /old engine/i);
+  assert.match(directive, /close .*reopen/i);
+  assert.match(directive, /same conversation/i, "a full restart resumes THIS conversation");
+  // Not merely absent — FORBIDDEN, the way the update-engine skill forbids it: "open a new
+  // conversation" is the distinct initial-rooting rule, and an agent that reaches for it here
+  // sends the owner away from the thread they were working in.
+  assert.match(directive, /do not .{0,30}new conversation/i);
+  assert.match(directive, /their own language|owner's language/i);
+});
+
+test("restartPromptDirective — nothing pending → nothing injected, on every prompt of every session", () => {
+  assert.equal(restartPromptDirective(false), null);
+});
+
+// Its LENGTH is bounded where it is emitted (`scripts/prompt-restart-nudge.test.mjs`),
+// per the F5 audit's convention: the bound belongs to the file that puts the text in the
+// owner's channel, so the guard that hunts unbounded emitters can find it.

--- a/scripts/lib/restart-nudge.test.mjs
+++ b/scripts/lib/restart-nudge.test.mjs
@@ -65,6 +65,12 @@ test("restartPromptDirective — pending → the agent is told to raise the rest
   // sends the owner away from the thread they were working in.
   assert.match(directive, /do not .{0,30}new conversation/i);
   assert.match(directive, /their own language|owner's language/i);
+  // The WHY, and the place to put it. Both are load-bearing copy, not decoration: an owner
+  // told to restart with no reason reads it as a glitch and ignores the next one, and a
+  // directive that does not say "open your reply with it" gets buried under the answer to
+  // whatever they actually asked — on a channel whose whole point is that it repeats.
+  assert.match(directive, /only at start/i, "the reason a restart is what fixes it");
+  assert.match(directive, /open your reply/i, "led with, not appended after the answer");
 });
 
 test("restartPromptDirective — nothing pending → nothing injected, on every prompt of every session", () => {

--- a/scripts/lib/restart-signal.mjs
+++ b/scripts/lib/restart-signal.mjs
@@ -23,31 +23,34 @@ const FLAG_BODY = "restart needed to finish the engine update\n";
  * `deriveWanted` is injected (it belongs to the self-heal), as are the two fs reads.
  */
 export function restartPendingOnDisk({ repo, deriveWanted, existsSync, readFileSync }) {
-  let gapNeeded = false;
-  try {
+  const gapNeeded = noSignalIfItBlowsUp(() => {
     const { wantedSkillDirs, wantedServerIds } = deriveWanted(repo);
     const mcpPath = join(repo, ".mcp.json");
     const registered = existsSync(mcpPath)
       ? new Set(Object.keys(JSON.parse(readFileSync(mcpPath, "utf8")).mcpServers ?? {}))
       : new Set();
-    gapNeeded = detectSelfHealGap({
+    return detectSelfHealGap({
       wantedSkillDirs,
       wantedServerIds,
       skillDirExists: (dir) => existsSync(join(repo, dir)),
       mcpServerRegistered: (id) => registered.has(id),
     }).needed;
-  } catch {
-    gapNeeded = false;
-  }
+  });
 
-  let flagExists = false;
-  try {
-    flagExists = existsSync(join(repo, RESTART_FLAG_REL));
-  } catch {
-    flagExists = false;
-  }
+  const flagExists = noSignalIfItBlowsUp(() => existsSync(join(repo, RESTART_FLAG_REL)));
 
   return isRestartPending({ flagExists, gapNeeded });
+}
+
+// The fail-soft above, with ONE owner. Written twice (an initializer AND a catch per signal)
+// it was unobservable both times: each half silently covered for the other, so neither could
+// be shown to work. Here the fallback is stated once and a test can hold it.
+function noSignalIfItBlowsUp(read) {
+  try {
+    return read();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/scripts/lib/restart-signal.mjs
+++ b/scripts/lib/restart-signal.mjs
@@ -5,9 +5,13 @@
 // delivered this one). The policy itself stays in restart-nudge.mjs; here we only
 // read the disk, with the reads injected so the glue is testable.
 // ─────────────────────────────────────────────────────────────────────────────
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { isRestartPending, RESTART_FLAG_REL } from "./restart-nudge.mjs";
 import { detectSelfHealGap } from "./self-heal-detect.mjs";
+
+// What the flag file says. Read by nobody — its existence IS the signal — but a human
+// who opens it deserves a sentence, and the three writers must not each invent one.
+const FLAG_BODY = "restart needed to finish the engine update\n";
 
 /**
  * True when the brain's on-disk engine state is AHEAD of what this session loaded,
@@ -44,4 +48,22 @@ export function restartPendingOnDisk({ repo, deriveWanted, existsSync, readFileS
   }
 
   return isRestartPending({ flagExists, gapNeeded });
+}
+
+/**
+ * Arm the "a restart is pending" flag under the brain's gitignored `.cache/`. Returns
+ * whether it was actually written. FAIL-SOFT — a write that blows up yields `false` and
+ * never breaks the hook it runs on: the nudge is a convenience, never a blocker.
+ *
+ * The fs writes are injected so the arming is assertable without a real disk.
+ */
+export function armRestartPending({ repo, mkdirSync, writeFileSync }) {
+  try {
+    const flagPath = join(repo, RESTART_FLAG_REL);
+    mkdirSync(dirname(flagPath), { recursive: true });
+    writeFileSync(flagPath, FLAG_BODY);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/scripts/lib/restart-signal.test.mjs
+++ b/scripts/lib/restart-signal.test.mjs
@@ -13,7 +13,14 @@ function deps({ files = [], servers = [], wanted = { wantedSkillDirs: [], wanted
     repo: "/brain",
     deriveWanted: () => wanted,
     existsSync: (p) => present.has(p),
-    readFileSync: () => JSON.stringify({ mcpServers: Object.fromEntries(servers.map((s) => [s, {}])) }),
+    // Reads the way node's `fs` reads, on both counts: an encoding it does not know is an
+    // ERROR (not a silently-returned Buffer), and an absent file throws. A call that forgot
+    // `utf8`, or read a path nothing wrote, therefore fails here instead of passing by luck.
+    readFileSync: (p, encoding) => {
+      if (encoding !== "utf8") throw new Error(`Unknown encoding: ${encoding}`);
+      if (!present.has(p)) throw new Error(`ENOENT: no such file, open '${p}'`);
+      return JSON.stringify({ mcpServers: Object.fromEntries(servers.map((s) => [s, {}])) });
+    },
   };
 }
 
@@ -38,6 +45,32 @@ test("an engine-delivered skill sitting on disk, uninstalled, means it too", () 
   const d = deps({
     wanted: { wantedSkillDirs: [".claude/skills/switch"], wantedServerIds: [] },
   });
+  assert.equal(restartPendingOnDisk(d), true);
+});
+
+// The converged brain of the test above, but with something to converge: the engine wants a
+// skill and a server, and BOTH are already there. It is the case that says the two probes are
+// really read — an "is it installed?" that answers nothing at all would report a gap here, and
+// nudge a restart at every session start on a brain that has nothing to finish.
+test("what the engine wants is installed and registered — still no restart", () => {
+  const d = deps({
+    files: [join("/brain", ".mcp.json"), join("/brain", ".claude/skills/switch")],
+    servers: ["vault-rag"],
+    wanted: { wantedSkillDirs: [".claude/skills/switch"], wantedServerIds: ["vault-rag"] },
+  });
+
+  assert.equal(restartPendingOnDisk(d), false);
+});
+
+// The other half of the same read: `.mcp.json` is there and parses, and what it registers is
+// NOT what the engine delivered. The server exists on disk, this session never spawned it.
+test("an engine-delivered MCP server that .mcp.json does not register means a restart too", () => {
+  const d = deps({
+    files: [join("/brain", ".mcp.json")],
+    servers: ["vault-rag"],
+    wanted: { wantedSkillDirs: [], wantedServerIds: ["local-mirror"] },
+  });
+
   assert.equal(restartPendingOnDisk(d), true);
 });
 

--- a/scripts/lib/restart-signal.test.mjs
+++ b/scripts/lib/restart-signal.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { join } from "node:path";
-import { restartPendingOnDisk } from "./restart-signal.mjs";
+import { restartPendingOnDisk, armRestartPending } from "./restart-signal.mjs";
 import { RESTART_FLAG_REL } from "./restart-nudge.mjs";
 
 // The two on-disk reads the signal is made of, faked: which files exist, and what
@@ -53,4 +53,38 @@ test("a read that blows up asks for NO restart — it never invents a nudge", ()
     readFileSync: () => "",
   };
   assert.equal(restartPendingOnDisk(d), false);
+});
+
+// ─── F20: the third writer of the flag, and the reason it moved here ─────────
+// The flag is written by an update that ran on THIS machine (update-engine, self-heal),
+// and `.cache/` is gitignored, so machine A's flag never travels. A machine that gets the
+// same engine by `git pull` therefore had no writer at all — it ran the old code all
+// session and said nothing. session-status arms it from the pull's own file list, through
+// this function, so the three writers cannot drift on where the flag lives or what it says.
+test("armRestartPending — writes the flag under the brain's .cache, parents included", () => {
+  const dirs = [];
+  const writes = [];
+  const armed = armRestartPending({
+    repo: "/brain",
+    mkdirSync: (dir, opts) => dirs.push([dir, opts]),
+    writeFileSync: (p, body) => writes.push([p, body]),
+  });
+
+  assert.equal(armed, true);
+  assert.deepEqual(dirs, [[join("/brain", ".cache"), { recursive: true }]]);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0][0], join("/brain", RESTART_FLAG_REL));
+  assert.match(writes[0][1], /restart/i);
+});
+
+test("armRestartPending — a write that blows up is swallowed, and says so (a hook never dies over a nudge)", () => {
+  const armed = armRestartPending({
+    repo: "/brain",
+    mkdirSync: () => {},
+    writeFileSync: () => {
+      throw new Error("EROFS: read-only file system");
+    },
+  });
+
+  assert.equal(armed, false);
 });

--- a/scripts/lib/skill-aliases.test.mjs
+++ b/scripts/lib/skill-aliases.test.mjs
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F22 (field, 2026-08-05): the owner typed `/univers`, twice, and got `Unknown command`
+// then `Args from unknown skill: shodo`, before typing `/switch` himself. `/switch` is
+// named after the VERB while it owns the NOUN — it also creates, lists, renames and
+// describes a universe — and someone thinking about the thing does not guess the action.
+// No hook can catch it: an unknown slash command fails in the CLI, before any model turn.
+// So the only mechanism is THE COMMAND EXISTING, in both the English and the French guess.
+//
+// A pure scan over the sources (rung 1 of the determinism ladder, ADR 0009): an alias is a
+// skill DIRECTORY, so what has to hold is spelling, thinness, and a target that is there.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ALIASES = ["universe", "univers"];
+const TARGET = "switch";
+
+const aliasFile = (name) => join(REPO, "engine-skills", name, "SKILL.md");
+const frontmatter = (body) => body.split(/^---$/m)[1] ?? "";
+
+test("both spellings of the noun exist as commands — the English guess and the French one", () => {
+  assert.deepEqual(
+    ALIASES.filter((name) => !existsSync(aliasFile(name))),
+    [],
+    "an alias that does not exist as a directory is not a command: the CLI routes on the folder name",
+  );
+});
+
+// The name in the frontmatter and the name of the folder are two different things, and only
+// one of them is what the owner types. A mismatch is the exact defect being fixed, one layer
+// deeper: the command would exist and still not be the one that was reached for.
+test("each alias declares the name it is typed as", () => {
+  assert.deepEqual(
+    ALIASES.filter((name) => !new RegExp(`^name:\\s*${name}\\s*$`, "m").test(frontmatter(readFileSync(aliasFile(name), "utf8")))),
+    [],
+  );
+});
+
+// An alias that re-explains the command is a second copy of the rules, free to drift — and
+// the reconciler never removes a skill, so the drifted copy would outlive any repair.
+test("each alias POINTS at the one skill that holds the rules, and holds none of its own", () => {
+  for (const name of ALIASES) {
+    const body = readFileSync(aliasFile(name), "utf8");
+
+    assert.match(body, new RegExp(`\`?${TARGET}\`?`), `${name} must name the skill it defers to`);
+    assert.ok(
+      body.length <= 900,
+      `${name} grew to ${body.length} chars: an alias that explains anything is a second source of truth`,
+    );
+  }
+});
+
+// F19 — the frontmatter description of every skill is loaded on EVERY session, whether or not
+// the skill is ever used. It is the whole price of an alias, so it is the thing to bound.
+test("each alias costs only a short description in the always-loaded layer", () => {
+  for (const name of ALIASES) {
+    const description = /^description:\s*"([^"]*)"/m.exec(frontmatter(readFileSync(aliasFile(name), "utf8")))?.[1];
+
+    assert.ok(description, `${name} must carry a quoted description — it is what routes the guess`);
+    assert.ok(description.length <= 220, `${name}'s description is ${description.length} chars, too long for a stub`);
+  }
+});
+
+// The target itself. An alias to a skill that has been renamed or removed is a command that
+// exists, answers, and does nothing — worse than the unknown-command error it replaced.
+test("the skill both aliases defer to is really there", () => {
+  assert.ok(existsSync(join(REPO, ".claude", "skills", TARGET, "SKILL.md")));
+});

--- a/scripts/lib/startup-payload-guard.test.mjs
+++ b/scripts/lib/startup-payload-guard.test.mjs
@@ -46,13 +46,16 @@ function emitters() {
   );
 }
 
-test("the F5 audit knows every additionalContext emitter — the field log named three, there are five", () => {
-  // Pin the list. A new startup hook lands here first, which is the moment to ask
-  // whether the owner should be reading its prose at all.
+test("the F5 audit knows every additionalContext emitter — the field log named three, there are six", () => {
+  // Pin the list. A new hook lands here first, which is the moment to ask whether the
+  // owner should be reading its prose at all. The sixth (F20) is the first that is NOT a
+  // startup hook: it rides `UserPromptSubmit`, i.e. EVERY prompt rather than one session
+  // start — so the question this guard asks gets harder as the channel widens, not easier.
   assert.deepEqual(
     emitters().map(({ name }) => name).sort(),
     [
       "actions-log-seed.mjs",
+      "prompt-restart-nudge.mjs",
       "session-self-heal.mjs",
       "status-hook-output.mjs",
       "universe-reminder.mjs",
@@ -61,7 +64,7 @@ test("the F5 audit knows every additionalContext emitter — the field log named
   );
 });
 
-test("every startup hook that writes into the channel the owner reads bounds what it writes", () => {
+test("every hook that writes into the channel the owner reads bounds what it writes", () => {
   const unbounded = emitters()
     .filter(({ test: sibling }) => !existsSync(sibling) || !readFileSync(sibling, "utf8").includes(BOUND_MARKER))
     .map(({ name }) => name);
@@ -78,7 +81,7 @@ test("the scan reads real sources, so an empty result cannot pass for a clean on
   // vacuously forever — the quietest way there is to lose a guard.
   const found = emitters();
 
-  assert.equal(found.length, 5);
+  assert.equal(found.length, 6);
   assert.ok(
     found.every(({ path }) => readFileSync(path, "utf8").includes("hookEventName")),
     "an emitter was matched that does not build a hook output at all",

--- a/scripts/prompt-restart-nudge.mjs
+++ b/scripts/prompt-restart-nudge.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// prompt-restart-nudge.mjs — the UserPromptSubmit hook that keeps saying "this
+// conversation is running the OLD engine" until the owner restarts (F20).
+//
+// Why this event, and not one more line in the SessionStart banner: that banner
+// prints once, at the top of a session that may run for hours, and on Desktop it
+// is dropped entirely (ADR 0036's channel matrix — `systemMessage` and
+// `statusLine` are both CLI-only). `UserPromptSubmit` is the only deterministic
+// channel Desktop receives, and it repeats on every prompt, so the nudge cannot
+// scroll away.
+//
+// It INJECTS and never blocks. The event can refuse a prompt outright (exit 2);
+// that lever is deliberately not used, because a wrong verdict would lock an owner
+// out of their own brain, while a wrong sentence costs them one sentence.
+//
+// The words live in lib/restart-nudge.mjs, the disk verdict in lib/restart-signal.mjs.
+// This file is only the contract with the harness.
+// ─────────────────────────────────────────────────────────────────────────────
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { restartPromptDirective } from "./lib/restart-nudge.mjs";
+import { restartPendingOnDisk } from "./lib/restart-signal.mjs";
+import { isEntrypoint } from "./lib/entrypoint.mjs";
+import { deriveWanted } from "./session-self-heal.mjs";
+
+export const realNudgeDeps = {
+  // The brain root is derived from THIS module's location (one level up from
+  // scripts/), never from the hook's cwd — same rule as auto-commit.mjs.
+  brainDir: () => resolve(dirname(fileURLToPath(import.meta.url)), ".."),
+  pending: (repo) => restartPendingOnDisk({ repo, deriveWanted, existsSync, readFileSync }),
+  emit: (payload) => console.log(JSON.stringify(payload)),
+};
+
+/**
+ * Asks whether a restart is pending and, if so, injects the directive. Always returns 0:
+ * this hook sits in front of every prompt the owner types, so its own breakage must never
+ * become theirs — an unreadable brain, a hiccup in the verdict, anything unexpected leaves
+ * the prompt untouched, in silence.
+ */
+export function runPromptNudge(deps = realNudgeDeps) {
+  try {
+    const directive = restartPromptDirective(deps.pending(deps.brainDir()));
+    if (directive) {
+      deps.emit({ hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: directive } });
+    }
+  } catch {
+    // Silent by design: see the doc comment above.
+  }
+  return 0;
+}
+
+if (isEntrypoint(import.meta.url, process.argv[1])) {
+  process.exit(runPromptNudge());
+}

--- a/scripts/prompt-restart-nudge.test.mjs
+++ b/scripts/prompt-restart-nudge.test.mjs
@@ -1,0 +1,143 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { runPromptNudge, realNudgeDeps } from "./prompt-restart-nudge.mjs";
+import { RESTART_FLAG_REL } from "./lib/restart-nudge.mjs";
+
+// This test file sits in scripts/, exactly like the hook — so the brain root is one
+// level up from HERE too, computed independently of the code under test.
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const BRAIN_ROOT = resolve(SCRIPTS_DIR, "..");
+
+// F20's delivery half. The verdict itself is decided elsewhere (restart-signal.mjs reads the
+// disk, restart-nudge.mjs writes the words); this file is only the contract with the harness —
+// ask, and answer in the one dialect `UserPromptSubmit` acts on.
+function deps({ pending = false } = {}) {
+  const emitted = [];
+  const asked = [];
+  return {
+    emitted,
+    asked,
+    brainDir: () => "/brain",
+    pending: (repo) => {
+      asked.push(repo);
+      return pending;
+    },
+    emit: (payload) => emitted.push(payload),
+  };
+}
+
+test("a pending restart is injected as context, on the one channel Desktop receives", () => {
+  const d = deps({ pending: true });
+
+  assert.equal(runPromptNudge(d), 0);
+  assert.deepEqual(d.asked, ["/brain"], "the verdict is asked of the brain the script lives in");
+  assert.equal(d.emitted.length, 1);
+  assert.equal(d.emitted[0].hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.match(d.emitted[0].hookSpecificOutput.additionalContext, /old engine/i);
+  assert.equal(
+    d.emitted[0].hookSpecificOutput.permissionDecision,
+    undefined,
+    "it injects and never blocks: a wrong verdict costs a sentence, not a locked-out owner",
+  );
+});
+
+// The normal case, on every prompt of every session for the rest of the brain's life: it must
+// add exactly nothing. An `additionalContext` emitted with an empty body would still be a
+// paragraph of instructions the model reads before each answer.
+test("a converged brain has nothing injected into its prompts", () => {
+  const d = deps();
+
+  assert.equal(runPromptNudge(d), 0);
+  assert.deepEqual(d.emitted, []);
+});
+
+test("a verdict that blows up leaves the prompt alone, and the hook still exits 0", () => {
+  const emitted = [];
+  const code = runPromptNudge({
+    brainDir: () => "/brain",
+    pending: () => {
+      throw new Error("unreadable .cache");
+    },
+    emit: (payload) => emitted.push(payload),
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(emitted, []);
+});
+
+// ── realNudgeDeps — the wiring nothing above can reach ───────────────────────
+// Every test above injects its own deps, so the REAL ones — where the brain root is
+// read from, which disk verdict is consulted, the one line the harness parses — are
+// observed by nobody. A mis-wire here passes all three and nudges nobody.
+
+test("realNudgeDeps.brainDir is the brain root, one level above scripts/", () => {
+  assert.equal(realNudgeDeps.brainDir(), BRAIN_ROOT);
+});
+
+test("realNudgeDeps.emit prints the payload as ONE line of JSON on stdout", () => {
+  const original = console.log;
+  const lines = [];
+  console.log = (line) => lines.push(line);
+  try {
+    realNudgeDeps.emit({ hookSpecificOutput: { hookEventName: "UserPromptSubmit" } });
+  } finally {
+    console.log = original;
+  }
+
+  assert.deepEqual(lines, ['{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit"}}']);
+});
+
+test("realNudgeDeps.pending reads the flag on disk, for the brain it is handed", () => {
+  const dir = mkdtempSync(join(tmpdir(), "prompt-nudge-"));
+  try {
+    assert.equal(realNudgeDeps.pending(dir), false, "an empty folder is not a brain awaiting a restart");
+
+    mkdirSync(join(dir, ".cache"), { recursive: true });
+    writeFileSync(join(dir, RESTART_FLAG_REL), "restart needed\n");
+
+    assert.equal(realNudgeDeps.pending(dir), true);
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+// The whole hook, run the way the harness runs it: a real child process, the payload on
+// stdout. The only test that exercises the entrypoint guard — i.e. that the file DOES
+// something when executed. The flag is planted in the real brain root (it lives under the
+// gitignored .cache/, so it commits nothing) because that root is what the script derives.
+test("run as the harness runs it, the hook injects the directive on stdout", () => {
+  const flag = join(BRAIN_ROOT, RESTART_FLAG_REL);
+  const preexisting = existsSync(flag);
+  if (!preexisting) {
+    mkdirSync(dirname(flag), { recursive: true });
+    writeFileSync(flag, "restart needed (test)\n");
+  }
+  try {
+    const run = spawnSync(process.execPath, [join(SCRIPTS_DIR, "prompt-restart-nudge.mjs")], {
+      encoding: "utf8",
+    });
+
+    assert.equal(run.status, 0, run.stderr);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+    assert.match(payload.hookSpecificOutput.additionalContext, /old engine/i);
+  } finally {
+    if (!preexisting) rmSync(flag, { force: true });
+  }
+});
+
+test("what it injects stays short — volume IS the defect (F5)", () => {
+  // Harsher than the bound on a session start: this rides EVERY prompt while the restart is
+  // pending, so an owner who keeps working reads it again and again. Long enough to say what
+  // to do, short enough that re-reading it costs nothing.
+  const d = deps({ pending: true });
+  runPromptNudge(d);
+
+  const injected = d.emitted[0].hookSpecificOutput.additionalContext;
+  assert.ok(injected.length <= 360, `the injected directive grew to ${injected.length} chars:\n${injected}`);
+});

--- a/scripts/session-self-heal.mjs
+++ b/scripts/session-self-heal.mjs
@@ -27,6 +27,7 @@ import { fileURLToPath } from "node:url";
 import { detectSelfHealGap } from "./lib/self-heal-detect.mjs";
 import { computeApplyPlan } from "./lib/engine-apply-plan.mjs";
 import { RESTART_FLAG_REL } from "./lib/restart-nudge.mjs";
+import { armRestartPending } from "./lib/restart-signal.mjs";
 import { rehydrationPlan, unwiredFiles } from "./lib/brain-rehydrate.mjs";
 
 export async function sessionSelfHeal({
@@ -196,14 +197,15 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     // (status-line.mjs) can show the Desktop-visible nudge. Fail-soft: a flag-write hiccup
     // must never break self-heal, so swallow errors (the systemMessage line still ships).
     setRestartPending: (pending) => {
-      const flagPath = join(brainDir, RESTART_FLAG_REL);
+      // Arming goes through restart-signal.mjs — the one owner of the flag's path and body,
+      // now that three surfaces write it (this self-heal, the updater, and the pull detection
+      // of F20). Clearing stays here: it is this hook's own job, and only its own.
+      if (pending) {
+        armRestartPending({ repo: brainDir, mkdirSync, writeFileSync });
+        return;
+      }
       try {
-        if (pending) {
-          mkdirSync(dirname(flagPath), { recursive: true });
-          writeFileSync(flagPath, "restart needed to finish the engine update\n");
-        } else {
-          rmSync(flagPath, { force: true });
-        }
+        rmSync(join(brainDir, RESTART_FLAG_REL), { force: true });
       } catch {
         /* fail-soft: the nudge is a convenience, never a blocker */
       }

--- a/scripts/session-status.mjs
+++ b/scripts/session-status.mjs
@@ -19,7 +19,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 import { execFileSync, spawn } from "node:child_process";
 import { createRequire } from "node:module";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hasGeminiKey, geminiKeyRequired } from "./lib/gemini-key.mjs";
@@ -29,7 +29,8 @@ import { sweepThenPull } from "./lib/startup-sync.mjs";
 import { bootstrapSessionHooks } from "./lib/hook-bootstrap.mjs";
 import { bootstrapReassuranceMessage } from "./lib/self-heal-message.mjs";
 import { restartNudgeSegment } from "./lib/restart-nudge.mjs";
-import { restartPendingOnDisk } from "./lib/restart-signal.mjs";
+import { restartPendingOnDisk, armRestartPending } from "./lib/restart-signal.mjs";
+import { pulledPaths, frozenWiringIn } from "./lib/frozen-wiring.mjs";
 import { readStartupVersionLine } from "./lib/engine-version.mjs";
 import { buildStatusHookOutput } from "./lib/status-hook-output.mjs";
 import { deriveWanted } from "./session-self-heal.mjs";
@@ -72,12 +73,23 @@ const short = git(["rev-parse", "--short", "HEAD"]).out.trim();
 const porcelain = git(["status", "--porcelain"]).out;
 const uncommittedVault = countVaultUncommitted(porcelain);
 const conflictedCount = countUnmerged(porcelain);
-const changedCount =
+const pulled =
   pullOk && !/already up to date|déjà à jour/i.test(pullOut)
-    ? git(["diff", "--name-only", "ORIG_HEAD", "HEAD"]).out
-        .split("\n")
-        .filter((l) => l.trim().length > 0).length
-    : 0;
+    ? pulledPaths(git(["diff", "--name-only", "ORIG_HEAD", "HEAD"]).out)
+    : [];
+const changedCount = pulled.length;
+
+// F20: the pull that just ran can land the ENGINE itself — the case of a second machine,
+// updated elsewhere yesterday. Every hook, skill, MCP server and CLAUDE.md this session
+// uses was frozen a few milliseconds ago, so the code that just arrived will not answer a
+// single question today, and until now nothing said so: `.cache/restart-needed` is written
+// only by an update that ran HERE, and it is gitignored, so machine A's flag never travels.
+// The pull's own file list is the missing signal — arm the flag, and the nudge below (read
+// from disk, a few lines further) leads the banner as it already does for the other causes.
+// A brain with no remote pulls nothing, so this stays silent there, by construction.
+if (frozenWiringIn(pulled).length > 0) {
+  armRestartPending({ repo: REPO, mkdirSync, writeFileSync });
+}
 const repoLine = repoStatusLine({ pullOk, pullOut, short, changedCount, uncommittedVault, conflictedCount });
 
 // ─── RAG line: docCount (db) vs .md files on disk ────────────────────────────

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -24,7 +24,7 @@ import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { RESTART_FLAG_REL } from "./lib/restart-nudge.mjs";
+import { armRestartPending } from "./lib/restart-signal.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
 
 import {
@@ -381,13 +381,10 @@ export async function updateEngine({
 // alone scrolls away). The next fresh, converged session clears it
 // (session-self-heal). Fail-soft: the nudge is a convenience, never a blocker.
 export function armRestartFlag(brainDir) {
-  try {
-    const flagPath = join(brainDir, RESTART_FLAG_REL);
-    mkdirSync(dirname(flagPath), { recursive: true });
-    writeFileSync(flagPath, "restart needed to finish the engine update\n");
-  } catch {
-    /* fail-soft */
-  }
+  // One owner for the flag's path and body (restart-signal.mjs): three surfaces arm it —
+  // this updater, the self-heal, and the pull detection (F20) — and a fourth spelling of
+  // the same file is a signal nobody reads.
+  armRestartPending({ repo: brainDir, mkdirSync, writeFileSync });
 }
 
 // The real I/O the CLI runs on: the brain the script lives in


### PR DESCRIPTION
## v4.7.0 — The One Where It Knows You Haven't Restarted Yet

The short leg of the trilogy, and the only one whose scope was cut rather than grown: it ships **what one
morning's field session raised**, plus the dependency pins we wrote ourselves. Everything else moves to
v4.8.0 with its analysis intact.

Two of the three findings are the **same root on two clocks**: a session start is a race between what
arrives and what reads it, and in both races the reassuring sentence won. Newer engine code lands after the
session froze its wiring → the whole conversation is answered by the old code, silently. Notes land after
the scan that counted them → *"pending, they'll catch up next session"*, while nothing was scheduled and
the watcher sat idle.

**The user-facing note is the source of truth for what ships:**
[`release-v4.7.0-note.draft.md`](maintainers/plans/prospective/release-v4.7.0-note.draft.md).

### What is in it

- **A machine that is behind now says so** — detected from the startup pull's **own file list**, which the
  session already computed and threw away to keep a count. `lib/frozen-wiring.mjs` names which of those
  paths a session freezes at start (hooks, skills, settings, the constitution, both MCP servers, the
  version vector); a match arms the flag the existing nudge already reads. A pull that brought only notes
  arms nothing; a brain with no remote is silent by construction, pinned by a test.
- **The nudge reaches Desktop, and repeats** — a `UserPromptSubmit` hook injecting the directive on every
  prompt while the flag is armed. It **injects, never blocks**: that event can refuse a prompt outright,
  and a wrong verdict must cost a sentence, not a locked-out owner. It is the first deterministic Desktop
  cue for a stale engine.
- **The shortfall model** (`rag/src/lib/index-shortfall.ts`) reads the run record the banner already reads
  — one source, not a second opinion — and separates **five** states that were rendered as one sentence:
  refused notes, a quota wall, a run in flight, notes that arrived after the scan, and a catch-up that has
  already failed.
- **And it acts on the one it can fix**: the arrival case schedules a catch-up through the
  `ReindexScheduler` that was sitting idle, armed for an event that had already happened. Both surfaces do
  it — startup (which owns the scheduler) and `vault_stats` (where the sentence "catching up now" is
  printed, so the ask has to happen there or it is the old promise in newer words). Bounded by progress,
  in memory, per server process.
- **`/universe` and `/univers`** — two thin aliases at the root, both locales getting both. They **point**
  at `switch` and explain nothing: the reconciler never removes a skill, so a second copy of the rules
  would outlive any repair. Guarded on the four things that break an alias silently (the folder the CLI
  routes on, the declared `name:`, the target still existing, and the description's cost in the
  always-loaded layer).
- **PR #56, already merged into `main`** — the dependency pins, ours, replacing two drive-by PRs from a
  fork (#48, #52). Both were applied to a throwaway copy and re-audited: **neither closed its advisory**,
  because `rag` pulls `fast-uri` through its own `ajv` too. Ours pins both through `overrides` in both
  packages: `rag` 12 → 9, `local-mirror` 6 → 5. The rest of the audit is named in the PR body rather than
  quietly left.

### Choices worth reviewing

- **The nudge does not name the privacy case.** A banner that already printed a profile is not un-leaked by
  a restart, so naming it buys nothing actionable and dates the copy to one release.
- **The SessionStart banner was deliberately left alone.** It still says "auto catch-up in the background"
  for an unexplained shortfall — a sentence this release makes **true** for the first time. It cannot know
  about the process-local bound (it runs before the server), so a permanently stalled gap is named by the
  vault↔index crosscheck that already exists for exactly that.
- **Three existing expectations were repointed, deliberately** (`3.1b`, `4.2`, `C.13`): they encoded the
  promise this finding is about. The cap case gained a test of its own so the fix cannot swap one wrong
  cause for another.
- **Option A for the aliases, not a rename of `/switch`.** On a deployed brain a rename **is** an alias
  plus a stale duplicate, since the reconciler installs skills by directory name and never removes one.

### Verification

- **Mutation, both halves, per file rather than averaged.** `rag`: **94.44 % → 100 %** on the two files
  changed. `scripts`: **83.33 % → 97.56 %** on the four written. The `scripts` number is the one worth a
  reviewer's minute — it was a **design** defect, not thin tests: `lib/restart-signal.mjs` wrote its
  fail-soft **twice per signal** (an initializer *and* a `catch`), so each half silently covered for the
  other and neither could be shown to work. Stated once, it became testable. `lib/frozen-wiring.mjs` had
  only ever been fed CRLF, so a splitter that knew only CRLF passed — on Unix the whole stdout would have
  come back as one path and the machine that is behind would have gone silent everywhere *but* Windows.
  Detail: [`maintainers/mutation/RESULTS.md`](../../mutation/RESULTS.md) § v4.7.0.
- **§10, the marketing re-read: nothing became false.** Two things became **true** and are now sold — the
  stale-engine cue, and "always catches up", which was partly unearned until this release (the arrival case
  never caught up). Boards re-read through their alt texts, **not** re-rendered.
- **CI**: the full matrix — Node 22/24/26 × macOS + Windows, plus the Windows installer end-to-end.
