### PR TITLE
v4.9.1 — the switch that stayed on the machine

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -1,6 +1,6 @@
 {
   "env": {
-    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "350000"
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "450000"
   },
   "permissions": {
     "allow": [

--- a/SETUP.md
+++ b/SETUP.md
@@ -163,6 +163,9 @@ node installer.mjs --non-interactive --name "second-brain" --owner "Jane Doe" --
 - **Commit per edit, push once per turn.** Each file change is committed locally and instantly
   (the `Write|Edit` hook). The actual **push is debounced**: it runs **once per turn**, at the end
   (the `Stop` hook), pushing all the turn's commits in one go — instead of a network push per edit.
+  **That end-of-turn pass first commits anything still uncommitted**, then pushes: a file one of your
+  brain's own scripts wrote is not something Claude *edited*, so no `Write|Edit` hook saw it — it
+  leaves with the rest of the turn instead of lingering on this machine until the next session.
   A failed push is non-blocking: your commits stay local and the **next turn catches up**. For
   syncing changes made on *another* machine mid-session, use the `/sync` skill.
 - **A note you write yourself is committed too, without waiting for Claude.** Type a note straight
@@ -181,7 +184,8 @@ node installer.mjs --non-interactive --name "second-brain" --owner "Jane Doe" --
   brain would quietly stop syncing between machines.
 - **And a sweep at every session start, to catch what the others miss.** Before its startup
   `git pull --rebase`, your brain commits anything still uncommitted: notes you wrote **with your brain
-  closed**, so no hook and no watcher was there to see them, or engine files left over by an update. You
+  closed**, so neither hook nor watcher was there to see them, or engine files left behind by a session
+  that never reached its end-of-turn pass (a crash, a window closed mid-run). You
   will see an `auto: session-start sweep …` commit when that happens. It is **local only**, and it is
   what keeps your sync from silently blocking. **One exception, on purpose:** if git stopped on a
   **conflict** (the same note changed on two machines), nothing is committed for you — the startup

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -5,7 +5,7 @@
     "rag": "1.4.0",
     "local-mirror": "0.3.0",
     "constitutionTemplate": "1.3.0",
-    "scripts": "1.13.0"
+    "scripts": "1.13.1"
   },
   "indexSchemaVersion": 2,
   "regimes": {

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -120,8 +120,9 @@
     file, no phone-home). The "update available" check is **deferred** (opt-in, non-blocking, cache-decoupled).
     First semver tag = `v3.0.0`. **Scope: Second brain (runtime) + Installer.**
   - [`0018-force-autocompaction-350k-out-of-the-box.md`](decisions/0018-force-autocompaction-350k-out-of-the-box.md) —
-    **every brain forces aggressive auto-compaction**: bakes `CLAUDE_CODE_AUTO_COMPACT_WINDOW=350000` so **no
-    brain exceeds a 350k effective context out of the box** ("levier 2"). Absolute `…WINDOW` var (reliable, self-
+    **every brain forces aggressive auto-compaction**: bakes `CLAUDE_CODE_AUTO_COMPACT_WINDOW` so **no
+    brain exceeds the calibrated effective context out of the box** ("levier 2"; 350k at decision time,
+    raised to 450k in v4.9.1 — issue #63, amendment in the ADR). Absolute `…WINDOW` var (reliable, self-
     clamps ≤ model limit → inert/harmless on 200k plans) over the buggy percentage override. **Scope: Second
     brain (runtime) + Installer.**
   - [`0019-import-previous-brain-is-a-keyword-skill.md`](decisions/0019-import-previous-brain-is-a-keyword-skill.md) —

--- a/maintainers/decisions/0018-force-autocompaction-350k-out-of-the-box.md
+++ b/maintainers/decisions/0018-force-autocompaction-350k-out-of-the-box.md
@@ -1,6 +1,6 @@
 # ADR 0018 — Every brain forces aggressive auto-compaction: no second brain exceeds a 350k effective context out of the box
 
-- **STATUS:** ACCEPTED (2026-06-14).
+- **STATUS:** ACCEPTED (2026-06-14) · AMENDED (2026-08-15 — window raised 350000 → 450000, see _Amendment_ below).
 - **Scope:** Second brain (runtime) + Installer — the installer bakes the `env` block into the brain's
   `settings.json` (from the template); Claude Code (the runtime) consumes the variable to cap the effective
   context and trigger compaction earlier.
@@ -98,7 +98,7 @@ lock-in**.
   contexts far too small) and a single absolute value can't serve both tiers; 200k users' default (~166k) is
   already lean enough.
 
-## Amendment — v4.9.1 (issue #63)
+## Amendment — 2026-08-15, v4.9.1 (issue #63)
 
 The baked default is raised **350000 → 450000**: 350k compacted too early on long capture sessions,
 and the absolute variable still self-clamps on smaller-window models (the no-op guarantee above is

--- a/maintainers/decisions/0018-force-autocompaction-350k-out-of-the-box.md
+++ b/maintainers/decisions/0018-force-autocompaction-350k-out-of-the-box.md
@@ -97,3 +97,10 @@ lock-in**.
 - **A lower value (e.g. < 200k) to also benefit small-context users.** Would clobber the 1M advantage (clamp big
   contexts far too small) and a single absolute value can't serve both tiers; 200k users' default (~166k) is
   already lean enough.
+
+## Amendment — v4.9.1 (issue #63)
+
+The baked default is raised **350000 → 450000**: 350k compacted too early on long capture sessions,
+and the absolute variable still self-clamps on smaller-window models (the no-op guarantee above is
+unchanged). Same regime, same overridability — **new brains only**, deployed brains keep their own
+`settings.json`. Guard test updated (`scripts/lib/settings-template.test.mjs`).

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -15,7 +15,7 @@
 | Package | Mutation score | As of | Detail |
 |---|---|---|---|
 | **rag** | **90.42 %** | 2026-07-16 (post-B2/B3) | [re-audit #2](#full-rag-re-audit-2--2026-07-16-post-b2b3-hardening) — production-only. Not re-measured package-wide since; the [v4.4.0 targeted run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) over the 10 files that release changed reads **93.93 %**, with its two new files at **100 %**. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) over its 6 changed files reads **94.67 %**, with the file it creates at **100 %**. The [v4.7.0 run](#v470--the-short-visibility-release-rag--scripts--2026-08-05) over the 2 files that release changed reads **94.44 %** first pass, **100 % on both** after the survivors were closed |
-| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new). The [v4.6.0 run](#v460--the-vaults-identity-release-scripts-only--2026-08-03) measured the 7 files that release changed: **all seven end at 96 % or above, two at 100 %**, every remaining survivor a pre-listed equivalent. It then ran a **second pass after the review fixes** (those fixes changed production code, so the first numbers no longer covered it): 4 files re-measured, 3 of them at **96.88–100 %**, plus `lib/hooks-reconcile.mjs` — a file this release only grazes — at **78.69 %**, whose 24 remaining survivors are pre-existing and named rather than implied. The [v4.7.0 run](#v470--the-short-visibility-release-rag--scripts--2026-08-05) measured the 4 files that release wrote: **83.33 % → 97.56 %**, two of them at **100 %**, the two survivors left both pre-listed equivalents — and the low first-pass number was a **design** defect (a fail-soft written twice, so neither half was observable), not thin tests. The [v4.8.0 run](#v480--the-release-that-looks-upstream-scripts-only--2026-08-05) is the biggest targeted pass so far — **16 files**, six batches: **thirteen end at 94 % or above**, one at 100 %, and the three that do not are the **named structural debt** (two files with no test sibling at 0 %, `engine-fetch.mjs`'s real git runner at 54.05 %), whose two remedies the owner **arbitrated into v4.9.0**, then **re-arbitrated in writing** (2026-08-08) onto the unfreeze release that follows it, rather than left implied. The [v4.9.0 run](#v490--the-universes-release-scripts-only--2026-08-08) measured the 6 files that release changed: **the two files it WROTE end at 100.00 % and 95.28 %**, `update-engine.mjs` at **98.44 %** and `reconcile-brain.mjs` at **96.11 %** — and the two entrypoint-tier files it merely grazed both **rose**, `session-universe.mjs` **39.39 % → 66.18 %** and `session-status.mjs` **0.00 % → 8.67 %**, still debt 1 rather than new rot |
+| **scripts** (harness) | **97.27 %** | 2026-06-23 baseline | 3 weak files since hardened to 92–100 % (no full re-audit; `lib/**` already 100 %). The three files audited on [2026-07-27](#increment-25-engine-skill-refresh--step-10--2026-07-27) are now hardened too: `update-engine.mjs` **98.49 %**, `reconcile-brain.mjs` **96.45 %**, `engine-source.mjs` **93.02 %** (every survivor killed or recorded as equivalent). The four files touched on [2026-07-28](#v430-the-harness-side-of-the-review-fixes--2026-07-28) were measured the same way, after the review fixes: `engine-commit.mjs` **100 %**, `startup-sync.mjs` **100 %**, `repo-status.mjs` **97.44 %**, `auto-commit.mjs` **98.04 %** (98.37 % together, every survivor an accepted equivalent). ⚠️ **The baseline flatters the package**: the [v4.4.0 run](#v440--the-field-fixes-release-rag--scripts--2026-07-28--2026-08-02) measured 16 files one by one and found **two at 0 %** — `session-status.mjs` and `status-line.mjs`, top-level scripts no test can import. **[Named debt](#the-two-0--files--named-debt-and-not-a-regression)**, carried by every published tag. The [v4.5.0 run](#v450--the-silence-stops-passing-release-rag--scripts--2026-08-03) measured 15 more files one by one: **seven of them end at 100 %, twelve of the fifteen at 92 % or above**, and the three `session-*` scripts confirm the same top-level tier (`session-status.mjs` still **0 %**, inherited rather than new). The [v4.6.0 run](#v460--the-vaults-identity-release-scripts-only--2026-08-03) measured the 7 files that release changed: **all seven end at 96 % or above, two at 100 %**, every remaining survivor a pre-listed equivalent. It then ran a **second pass after the review fixes** (those fixes changed production code, so the first numbers no longer covered it): 4 files re-measured, 3 of them at **96.88–100 %**, plus `lib/hooks-reconcile.mjs` — a file this release only grazes — at **78.69 %**, whose 24 remaining survivors are pre-existing and named rather than implied. The [v4.7.0 run](#v470--the-short-visibility-release-rag--scripts--2026-08-05) measured the 4 files that release wrote: **83.33 % → 97.56 %**, two of them at **100 %**, the two survivors left both pre-listed equivalents — and the low first-pass number was a **design** defect (a fail-soft written twice, so neither half was observable), not thin tests. The [v4.8.0 run](#v480--the-release-that-looks-upstream-scripts-only--2026-08-05) is the biggest targeted pass so far — **16 files**, six batches: **thirteen end at 94 % or above**, one at 100 %, and the three that do not are the **named structural debt** (two files with no test sibling at 0 %, `engine-fetch.mjs`'s real git runner at 54.05 %), whose two remedies the owner **arbitrated into v4.9.0**, then **re-arbitrated in writing** (2026-08-08) onto the unfreeze release that follows it, rather than left implied. The [v4.9.0 run](#v490--the-universes-release-scripts-only--2026-08-08) measured the 6 files that release changed: **the two files it WROTE end at 100.00 % and 95.28 %**, `update-engine.mjs` at **98.44 %** and `reconcile-brain.mjs` at **96.11 %** — and the two entrypoint-tier files it merely grazed both **rose**, `session-universe.mjs` **39.39 % → 66.18 %** and `session-status.mjs` **0.00 % → 8.67 %**, still debt 1 rather than new rot. The [v4.9.1 run](#v491--the-switch-that-leaves-the-machine-scripts-only--2026-08-15) measured the 6 files that hotfix changed, over **three passes** (production moved twice): **the two files it WROTE both end at 100.00 %**, the untested CLI wiring goes **25 % → 100 %**, and the four others land at **95.92–99.66 %** — every survivor left a named equivalent |
 | **local-mirror** | **90.44 %** | 2026-07-28 (v4.2.0) | [re-audit](#full-local-mirror-re-audit--2026-07-28-v420) — +336 mutants since the 95.63 % below (auto-refresh growth); this release's own survivors were found and killed before tagging. The two files v4.3.0 touched were re-measured [after the review fixes](#v430-after-the-review-fixes--2026-07-28): `markdown.ts` **100 %**, `local-mirror.ts` **96.86 %**. **v4.4.0 touches no `src/**` file here — the number carries over, deliberately not re-measured** |
 
 Pinned to the release that ships the hardened tests: **v3.4.2** (local-mirror pinned at 78.69 % there —
@@ -138,6 +138,65 @@ survivors there are **documented equivalent mutants** (unkillable without touchi
 "effective 100 %" on non-equivalents. The lowest never-hardened tiers, the natural next "B5" targets,
 are rag's **embedders** (~82 %) and `search-degradation` / `reindex-scheduler` / `index-freshness`, plus
 local-mirror's `fs-state-store` and `content-hash`.
+
+---
+
+## v4.9.1 — the switch that leaves the machine (`scripts` only) — 2026-08-15
+
+**Scope decided on the diff** (`main...hotfix/v4.9.1-universe-pointer`), the targeted run §5ter
+prescribes before a tag: **6 production files, all under `scripts/`** — two of them written by this
+release. `rag/**` and `local-mirror/**` are untouched by this hotfix, so those packages' numbers carry
+over, deliberately not re-measured. Run in the disposable worktree `kenjaku-mut-v491`, with
+`rag/node_modules` symlinked in and `vault-write-guard.test.mjs` verified there first (**22 pass,
+0 skipped**): mutants facing a suite that cannot judge them is §5quater's fiction with a score on top.
+
+**Three passes, because production moved twice.** Pass 1 measured what was first written; pass 2 came
+after the three adversarial reviews changed production code (so pass 1 no longer covered it); pass 3
+re-measured the two files that changed again afterwards. A number is only true of the code it ran on.
+
+| File | Pass 1 (37029b8) | Pass 2 (fff4ca1) | Pass 3 (2500b52) | Survivors left |
+|---|---|---|---|---|
+| `lib/universe-persist.mjs` *(new)* | 91.80 % | **100.00 %** | — | 0 |
+| `lib/entrypoint.mjs` | — | **100.00 %** | — | 0 |
+| `set-active-universe.mjs` | 25.00 % | **100.00 %** | — | 0 |
+| `lib/universes.mjs` | 89.26 % | — | **99.66 %** | 1, equivalent |
+| `auto-push.mjs` | 92.55 % | 94.90 % | **95.92 %** | 4, all equivalent |
+| `auto-commit.mjs` | — | **98.31 %** | — | 1, entry-guard tier |
+
+**The two files this release WROTE both end at 100 %**, and the one that started at **25 %** —
+`set-active-universe.mjs`, the CLI wiring nothing imported — ends at **100 %**. That jump is the whole
+lesson of the release, and it was not paid by more assertions: it was paid by a test the **test-quality
+review demanded**, one that runs the real entry point **in a subprocess**. It immediately found that a
+brain reached through a **symlinked path** ran `/switch` *without persisting it* — a silent no-op no
+in-process test could see, on the exact promise this hotfix exists to keep.
+
+**Every survivor left is a named equivalent**, not a gap:
+
+- **`auto-push.mjs` ×3 + `auto-commit.mjs` ×1 — the entry guard.** `if (isEntryPoint(process.argv[1],
+  import.meta.url))` mutated to `true` / `false` / emptied. A hook module imported by its test is by
+  definition not the entry point; the composition root beneath it is exercised by the subprocess test,
+  which runs the *file*, not the import. Same tier already accepted for every other hook.
+- **`auto-push.mjs` ×1 — `.trim()` under `Number()`.** `Number(git([...]).out.trim())` → without the
+  `.trim()`: `Number(" 2\n")` is `2`, and `Number("")` and `Number(" \n")` are both falsy through the
+  `|| 0`. No git output can distinguish them.
+- **`lib/universes.mjs` ×1 — `parsed?.universes` → `parsed.universes`.** `JSON.parse("null")` is legal,
+  so the mutant throws where the original reads `undefined` — but the `catch` around it returns the
+  **same `[]`**, and nothing else observes the difference. Considered and declined: deleting the `?.`
+  would kill the mutant (the "simplify production rather than excuse the mutant" reflex) at the cost of
+  making a *normal* input travel through an exception path. The optional chain states the intent; the
+  catch is the net for the rest.
+
+**What pass 3 changed, and why it was not optional.** Both files it re-measured had moved *after* pass 2:
+`universes.mjs` had its 32 survivors killed and a dead regex quantifier simplified out (89.26 % →
+**99.66 %**), and `auto-push.mjs` gained a whole-text pin on `SWEEP_FAILED_WARNING` — the warning that
+tells a user some changes stayed uncommitted — which took the last half-blankable mutant with it
+(94.90 % → **95.92 %**). Re-running only the changed files is §5ter applied twice in one release.
+
+**Reproduce**: batch recipe of §"Reproduce" below, worktree `kenjaku-mut-v491`, logs
+[`reports/v491-batch1.log`](reports/v491-batch1.log),
+[`reports/v491-batch2-postreview.log`](reports/v491-batch2-postreview.log),
+[`reports/v491-batch3a-universes.log`](reports/v491-batch3a-universes.log),
+[`reports/v491-batch3b-auto-push.log`](reports/v491-batch3b-auto-push.log).
 
 ---
 

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -74,12 +74,32 @@
       survivors triaged and killed in 2500b52 (whole-result asserts, multi-word parse, corrupt
       registry, byte-pinned newline, defensive copies, idempotent create) + dead regex quantifier
       simplified out; a couple of readRegistry catch-net mutants are equivalents (ENOENT path)._
+      _Item (3) DONE (2026-08-15 · 0163b55): `engineVersion.scripts` 1.13.0 → **1.13.1** (patch — this
+      closes a hole in a shipped promise rather than adding a capability); rag / local-mirror /
+      constitutionTemplate verified untouched, `indexSchemaVersion` stays 2. The two new files ship
+      under the existing `scripts/lib/**` replace regime — nothing to add to the manifest._
+      _Item (4) DONE — §10 marketing-surface re-read (2026-08-15 · 56be05f). **Verdict, including the
+      boring half.** (Q1, made false or imprecise) **one** finding, fixed: SETUP §"Commit per edit, push
+      once per turn" described the `Stop` hook as push-only, which is precisely what this release
+      changes; its session-start-sweep bullet was re-positioned with it. (Q2, made true and unsold)
+      **nothing to add** — and the notable point is *why*: v4.9.1 changes no marketing sentence because
+      it **repairs two already-published ones**. README's "since v4.9.0 the universe you are working in
+      follows you" and the "Nothing to save, nothing to lose / auto-committed the instant it's written"
+      blurb were both half-true while the pointer stayed on the machine; the code now matches the copy,
+      so the copy stands. **Boards re-read** (`board-flow` "Save & back up", `board-anatomy` hooks list,
+      via their README alt texts + `marketing-image-prompts.md`): still accurate, **no re-render**.
+      EN-QUOI-C-EST-DIFFERENT and CONNECTORS: nothing touched by this release. **Decided no-change, on
+      record**: README's two technical bullets ("auto-push on the Stop event") are not false and adding
+      the sweep there would buy mechanism at the cost of §11 brevity — SETUP is where that contract
+      lives._
       **RESUME HERE after `/clear`:** (1) mutation pass 3 in the worktree `kenjaku-mut-v491` (advance
       it to 2500b52 first: `git reset --hard 2500b52 && git clean -fd`) over `scripts/lib/universes.mjs
       + scripts/auto-push.mjs` (both changed after pass 2 — universes prod regex + the warning pin),
-      expect ≥ pass-2 numbers; (2) pin all numbers in `mutation/RESULTS.md` (new v4.9.1 section,
-      newest-first, name the equivalents); (3) bump `engineVersion.scripts` in `engine-manifest.json`
-      (fleet-review NIT); (4) §10 marketing-surface re-read (CONVENTIONS); (5) release note
+      expect ≥ pass-2 numbers — **IN FLIGHT (2026-08-15)**: two batches, logs
+      `mutation/reports/v491-batch3a-universes.log` (296 mutants) and `…-batch3b-auto-push.log`;
+      `rag/node_modules` symlinked into the worktree and `vault-write-guard.test.mjs` verified at
+      22 pass / 0 skipped there first; (2) pin all numbers in `mutation/RESULTS.md` (new v4.9.1 section,
+      newest-first, name the equivalents); (3) ✅ done, see above; (4) ✅ done, see above; (5) release note
       (non-dev-first tone, cf. memory), merge to main, tag **v4.9.1**, close #69/#63/#65;
       (6) `git worktree remove /Users/tpierrain/Dev/kenjaku-mut-v491 --force`; (7) debrief the two
       experiments in this plan (data so far: reviews found 1 blocker-class silent-no-op (symlink

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -110,6 +110,33 @@
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,
       mutation floor held or not, what the owner's review caught; write the verdict here, then let
       the owner decide what graduates (to the unfreeze QA, and/or to the harness TDD rule).
+      _Draft verdict (2026-08-15, written before pass 3 closed — the one number it waits on is whether
+      pass 3 confirms the floor; everything else is already observed):_
+
+      **1. The process experiment (test-first small batches instead of strict baby-steps): PASSED on
+      its own terms, and the terms were the point.** The deal was "process discipline traded for
+      outcome measurement", judged by the mutation score against the `v4.9.0` floor. Measured:
+      pass 1 **89.15 %** on first writing, then **97.71 %** after the reviews — with the two files this
+      release WROTE (`universe-persist.mjs`, `entrypoint.mjs`) at **100 %**, and `set-active-universe.mjs`
+      going 25 % → 100 % once the wiring got a real test. That is at or above the v4.9.0 comparison
+      (its two new files: 100.00 % / 95.28 %). **What it does NOT prove**: that the mode is free. The
+      first pass left the wiring untested at 25 % — a small-batch blind spot a baby-step on that seam
+      would likely have caught — and it took an external review to demand the subprocess test that
+      closed it. Honest reading: **the mode holds the floor when the review and mutation nets are
+      actually run**, not on its own.
+      **2. The work-mode pilot (delegate the edges, keep the TDD core in the main session): PASSED, with
+      one sizing rule earned.** Three adversarial reviews on the branch diff returned **one
+      blocker-class finding** (a symlinked brain path ran `/switch` **without** persisting — a silent
+      no-op that no existing test could see) plus **two real defects** fixed before the tag (the silent
+      sweep failure, the un-scoped commit that swallowed pre-staged work). That is the pilot paying for
+      itself in one release. The sizing rule: **inline survivor triage beat fan-out at this size** —
+      32 survivors on one file were faster read and killed in the main session than dispatched one
+      judge per survivor. Fan-out earns its keep on *independent lenses*, not on *many small
+      look-alikes*.
+      **3. What the owner has to decide** (not decided here): whether the relaxed TDD mode graduates
+      into the `tdd-discipline` skill (his signature, per this plan's own rule that the skill stays
+      untouched until the debrief), and whether the review-fan-out becomes standing QA for the
+      unfreeze chantier, where fixtures × versions is the natural fan-out shape.
 
 ## Work-mode experiment (owner's ask, 2026-08-15 — decide at kickoff)
 

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -26,9 +26,11 @@
       `scripts/lib/universe-persist.mjs`: scoped commit of `.vault-rag/` + push via the Stop hook's
       `attemptPush` (autopush opt-in respected); `runSwitchCli` reports `wrote`; loud warnings on
       commit/push failure. Test-first batch (experiment mode), suite 1683 green.
-- [ ] **(b) Remove the class**: the Stop hook (`auto-push.mjs`) becomes **sweep-commit then push**, so
+- [x] **(b) Remove the class**: the Stop hook (`auto-push.mjs`) becomes **sweep-commit then push**, so
       any out-of-band engine write (today's pointer, tomorrow's whatever) leaves the machine at session
-      end instead of waiting for the next session's sweep.
+      end instead of waiting for the next session's sweep. _(2026-08-15 · 88499d3)_ — reuses
+      `attemptCommit` (same message, same unmerged-tree refusal), best-effort wrapped; the test fake
+      now counts commits so `rev-list` answers like real git (kills the push-before-sweep mutant).
 - [ ] **Decide (not necessarily ship): the stale-wins regression.** Should the SessionStart sweep
       refuse — or at least warn — before committing a pointer that is *behind* the remote? (Issue #69's
       closing note.) If deferred, say so here with the reason.

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -95,17 +95,20 @@
       **RESUME HERE after `/clear`:** (1) mutation pass 3 in the worktree `kenjaku-mut-v491` (advance
       it to 2500b52 first: `git reset --hard 2500b52 && git clean -fd`) over `scripts/lib/universes.mjs
       + scripts/auto-push.mjs` (both changed after pass 2 — universes prod regex + the warning pin),
-      expect ≥ pass-2 numbers — **IN FLIGHT (2026-08-15)**: two batches, logs
-      `mutation/reports/v491-batch3a-universes.log` (296 mutants) and `…-batch3b-auto-push.log`;
+      **✅ DONE (2026-08-15)**: `universes.mjs` **89.26 → 99.66 %** (1 survivor) and `auto-push.mjs`
+      **94.90 → 95.92 %** (4 survivors) — **every survivor left across the whole release is a named
+      equivalent**. Logs `mutation/reports/v491-batch3a-universes.log` + `…-batch3b-auto-push.log`;
       `rag/node_modules` symlinked into the worktree and `vault-write-guard.test.mjs` verified at
-      22 pass / 0 skipped there first; (2) pin all numbers in `mutation/RESULTS.md` (new v4.9.1 section,
-      newest-first, name the equivalents); (3) ✅ done, see above; (4) ✅ done, see above; (5) **drafted**
+      22 pass / 0 skipped there first; (2) **✅ DONE (2026-08-15 · 25b6ea6)** — `mutation/RESULTS.md`
+      has its v4.9.1 section (newest-first, the three passes, every equivalent named including the
+      `parsed?.universes` production simplification considered and declined), and the head table's
+      `scripts` row now mentions the run; (3) ✅ done, see above; (4) ✅ done, see above; (5) **drafted**
       (2026-08-15 · e2b5cb3 — `release-v4.9.1-note.md`; two things left to the owner IN the file: the
       title, 3 candidates, and the mutation figures pass 3 pins), then release note
       (non-dev-first tone, cf. memory), merge to main, tag **v4.9.1**, close #69/#63/#65;
       (6) `git worktree remove /Users/tpierrain/Dev/kenjaku-mut-v491 --force`; (7) debrief the two
       experiments in this plan (data so far: reviews found 1 blocker-class silent-no-op (symlink
-      entrypoint), 2 real defects fixed pre-tag, mutation floor HELD at 97.71 % under test-first
+      entrypoint), 2 real defects fixed pre-tag, mutation floor HELD (pass 3: 95.92–100 % per file) under test-first
       small batches; inline survivor triage beat fan-out at this size)._
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,
       mutation floor held or not, what the owner's review caught; write the verdict here, then let

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -106,10 +106,19 @@
       (2026-08-15 · e2b5cb3 — `release-v4.9.1-note.md`; two things left to the owner IN the file: the
       title, 3 candidates, and the mutation figures pass 3 pins), then release note
       (non-dev-first tone, cf. memory), merge to main, tag **v4.9.1**, close #69/#63/#65;
-      (6) `git worktree remove /Users/tpierrain/Dev/kenjaku-mut-v491 --force`; (7) debrief the two
+      (6) ✅ DONE — worktree `kenjaku-mut-v491` removed (2026-08-15). *(`kenjaku-mut-v490` still exists,
+      left over from the previous release — not this plan's business, but worth a `worktree remove` next
+      time someone passes.)* (7) debrief the two
       experiments in this plan (data so far: reviews found 1 blocker-class silent-no-op (symlink
       entrypoint), 2 real defects fixed pre-tag, mutation floor HELD (pass 3: 95.92–100 % per file) under test-first
       small batches; inline survivor triage beat fan-out at this size)._
+- [ ] **THE ONLY THING LEFT — the owner's go to publish.** Everything upstream of the tag is done:
+      branch green (harness suite **1714 pass / 0 fail**, CI green on every pushed commit), mutation
+      pinned, §10 done, manifest bumped, note written. **Waiting on Thomas for two calls**: (i) the
+      release **title** (3 candidates in `release-v4.9.1-note.md`, my pick: *"The One Where the Switch
+      Actually Leaves"*), and (ii) the **go to merge `hotfix/v4.9.1-universe-pointer` into `main`, tag
+      v4.9.1, publish the note and close #69/#63/#65** — a publish is his call, not mine. Nothing else
+      blocks; on his go this is one sequence with no thinking left in it.
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,
       mutation floor held or not, what the owner's review caught; write the verdict here, then let
       the owner decide what graduates (to the unfreeze QA, and/or to the harness TDD rule).

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -31,9 +31,15 @@
       end instead of waiting for the next session's sweep. _(2026-08-15 · 88499d3)_ — reuses
       `attemptCommit` (same message, same unmerged-tree refusal), best-effort wrapped; the test fake
       now counts commits so `rev-list` answers like real git (kills the push-before-sweep mutant).
-- [ ] **Decide (not necessarily ship): the stale-wins regression.** Should the SessionStart sweep
+- [x] **Decide (not necessarily ship): the stale-wins regression.** Should the SessionStart sweep
       refuse — or at least warn — before committing a pointer that is *behind* the remote? (Issue #69's
-      closing note.) If deferred, say so here with the reason.
+      closing note.) If deferred, say so here with the reason. _(2026-08-15 · owner's call, in
+      conversation)_ — **DEFERRED, nothing ships.** Reason: (a)+(b) remove the dirty-pointer state the
+      regression needs (the switch commits+pushes itself; the Stop hook sweeps any leftover), so the
+      SessionStart sweep can no longer meet a stale *uncommitted* pointer except once, on a pre-fix
+      brain. The residual committed-but-behind case already fails loud: `git pull --rebase` conflicts
+      on the one-line pointer file and stops for the interactive rule ("the machine you sit at wins").
+      A further guard would be noise for a window that no longer exists.
 - [ ] **Rider #63**: raise default `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to `450000` in
       `.claude/settings.json.template` + its guard test (`settings-template.test.mjs`). New brains only.
 - [ ] **Rider #65**: `⚠️ ` prefix on `nativeConnectorsReminder()` (`scripts/lib/universes.mjs`) + its

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -99,7 +99,9 @@
       `mutation/reports/v491-batch3a-universes.log` (296 mutants) and `…-batch3b-auto-push.log`;
       `rag/node_modules` symlinked into the worktree and `vault-write-guard.test.mjs` verified at
       22 pass / 0 skipped there first; (2) pin all numbers in `mutation/RESULTS.md` (new v4.9.1 section,
-      newest-first, name the equivalents); (3) ✅ done, see above; (4) ✅ done, see above; (5) release note
+      newest-first, name the equivalents); (3) ✅ done, see above; (4) ✅ done, see above; (5) **drafted**
+      (2026-08-15 · e2b5cb3 — `release-v4.9.1-note.md`; two things left to the owner IN the file: the
+      title, 3 candidates, and the mutation figures pass 3 pins), then release note
       (non-dev-first tone, cf. memory), merge to main, tag **v4.9.1**, close #69/#63/#65;
       (6) `git worktree remove /Users/tpierrain/Dev/kenjaku-mut-v491 --force`; (7) debrief the two
       experiments in this plan (data so far: reviews found 1 blocker-class silent-no-op (symlink

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -52,6 +52,13 @@
       mutation batch on the 4 touched prod files, running in disposable worktree `kenjaku-mut-v491`
       (log: `mutation/reports/v491-batch1.log`). On resume: read both results, fix what they teach,
       then pin numbers and release._
+      _Fleet review landed (2026-08-15 · fixes b471e57): merge regime DOES deliver auto-push.mjs to
+      the fleet (verified, engine-apply-plan carve-out) — the class-removal claim holds. Two real
+      findings fixed: the Stop sweep now shouts on "failed" (SWEEP_FAILED_WARNING), and the switch
+      commit is pathspec-scoped so pre-staged work stays out and stays staged. To do at tag time
+      (review NIT): bump `engineVersion.scripts` in `engine-manifest.json`. Since prod code changed
+      after the mutation batch started, re-measure `auto-push.mjs` + `universe-persist.mjs` off the
+      fixes before pinning. Correctness + test-quality reviews still pending._
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,
       mutation floor held or not, what the owner's review caught; write the verdict here, then let
       the owner decide what graduates (to the unfreeze QA, and/or to the harness TDD rule).

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -40,10 +40,11 @@
       brain. The residual committed-but-behind case already fails loud: `git pull --rebase` conflicts
       on the one-line pointer file and stops for the interactive rule ("the machine you sit at wins").
       A further guard would be noise for a window that no longer exists.
-- [ ] **Rider #63**: raise default `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to `450000` in
+- [x] **Rider #63**: raise default `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to `450000` in
       `.claude/settings.json.template` + its guard test (`settings-template.test.mjs`). New brains only.
-- [ ] **Rider #65**: `⚠️ ` prefix on `nativeConnectorsReminder()` (`scripts/lib/universes.mjs`) + its
-      test.
+      _(2026-08-15 · 44c5482)_ — plus an amendment in ADR 0018 and a de-hardcoded maintainers index line.
+- [x] **Rider #65**: `⚠️ ` prefix on `nativeConnectorsReminder()` (`scripts/lib/universes.mjs`) + its
+      test. _(2026-08-15 · 3412882)_
 - [ ] **Release tail**: mutation pass on touched files (pin numbers in `mutation/RESULTS.md`), §10
       marketing-surface re-read, release note, tag **v4.9.1**, close issues #69/#63/#65.
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -56,9 +56,19 @@
       the fleet (verified, engine-apply-plan carve-out) — the class-removal claim holds. Two real
       findings fixed: the Stop sweep now shouts on "failed" (SWEEP_FAILED_WARNING), and the switch
       commit is pathspec-scoped so pre-staged work stays out and stays staged. To do at tag time
-      (review NIT): bump `engineVersion.scripts` in `engine-manifest.json`. Since prod code changed
-      after the mutation batch started, re-measure `auto-push.mjs` + `universe-persist.mjs` off the
-      fixes before pinning. Correctness + test-quality reviews still pending._
+      (review NIT): bump `engineVersion.scripts` in `engine-manifest.json`._
+      _Correctness + test-quality reviews landed (2026-08-15 · fixes fff4ca1): mid-merge partial-commit
+      refusal → calm DEFER to the Stop sweep; push gated on committed; buildGit timeout 10s; realpath
+      entry guards (auto-push + the shared lib/entrypoint.mjs — the subprocess wiring test the review
+      demanded immediately caught that a symlinked brain path ran /switch WITHOUT persisting). Declined
+      as NIT, on record: detached-HEAD switch reports success while its commit can orphan (broken-brain
+      tier, SessionStart machinery already complains there)._
+      _Mutation pass 1 (on 37029b8, log `mutation/reports/v491-batch1.log`): overall 89.15 % —
+      universe-persist 91.80 %, auto-push 92.55 %, universes 89.26 % (32 survivors to triage),
+      set-active-universe 25 % (the untested wiring — since covered by the subprocess test). Next:
+      re-measure the 5 prod files changed by the review fixes (universe-persist, auto-push,
+      auto-commit, entrypoint, set-active-universe) in the worktree, triage universes.mjs survivors,
+      pin RESULTS.md, then §10 re-read, release note, tag._
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,
       mutation floor held or not, what the owner's review caught; write the verdict here, then let
       the owner decide what graduates (to the unfreeze QA, and/or to the harness TDD rule).

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -47,6 +47,11 @@
       test. _(2026-08-15 · 3412882)_
 - [ ] **Release tail**: mutation pass on touched files (pin numbers in `mutation/RESULTS.md`), §10
       marketing-surface re-read, release note, tag **v4.9.1**, close issues #69/#63/#65.
+      _In flight (2026-08-15): work-mode pilot engaged — 3 adversarial review subagents on the branch
+      diff (lenses: git semantics / fleet deployment via manifest regimes / test quality) + targeted
+      mutation batch on the 4 touched prod files, running in disposable worktree `kenjaku-mut-v491`
+      (log: `mutation/reports/v491-batch1.log`). On resume: read both results, fix what they teach,
+      then pin numbers and release._
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,
       mutation floor held or not, what the owner's review caught; write the verdict here, then let
       the owner decide what graduates (to the unfreeze QA, and/or to the harness TDD rule).

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -64,11 +64,27 @@
       as NIT, on record: detached-HEAD switch reports success while its commit can orphan (broken-brain
       tier, SessionStart machinery already complains there)._
       _Mutation pass 1 (on 37029b8, log `mutation/reports/v491-batch1.log`): overall 89.15 % —
-      universe-persist 91.80 %, auto-push 92.55 %, universes 89.26 % (32 survivors to triage),
-      set-active-universe 25 % (the untested wiring — since covered by the subprocess test). Next:
-      re-measure the 5 prod files changed by the review fixes (universe-persist, auto-push,
-      auto-commit, entrypoint, set-active-universe) in the worktree, triage universes.mjs survivors,
-      pin RESULTS.md, then §10 re-read, release note, tag._
+      universe-persist 91.80 %, auto-push 92.55 %, universes 89.26 % (32 survivors), set-active-universe
+      25 % (the untested wiring)._
+      _Mutation pass 2 post-review-fixes (on fff4ca1, log `v491-batch2-postreview.log`): **97.71 %** —
+      universe-persist **100 %**, entrypoint **100 %**, set-active-universe **25 → 100 %** (the
+      subprocess test), auto-commit 98.31 %, auto-push 94.90 %. Of its 6 survivors, 5 are the
+      documented equivalent tier (entry guards ×4, `.trim()` under Number()); the 6th
+      (SWEEP_FAILED_WARNING half-blankable) is killed by 2500b52's whole-text pin. universes.mjs's 32
+      survivors triaged and killed in 2500b52 (whole-result asserts, multi-word parse, corrupt
+      registry, byte-pinned newline, defensive copies, idempotent create) + dead regex quantifier
+      simplified out; a couple of readRegistry catch-net mutants are equivalents (ENOENT path)._
+      **RESUME HERE after `/clear`:** (1) mutation pass 3 in the worktree `kenjaku-mut-v491` (advance
+      it to 2500b52 first: `git reset --hard 2500b52 && git clean -fd`) over `scripts/lib/universes.mjs
+      + scripts/auto-push.mjs` (both changed after pass 2 — universes prod regex + the warning pin),
+      expect ≥ pass-2 numbers; (2) pin all numbers in `mutation/RESULTS.md` (new v4.9.1 section,
+      newest-first, name the equivalents); (3) bump `engineVersion.scripts` in `engine-manifest.json`
+      (fleet-review NIT); (4) §10 marketing-surface re-read (CONVENTIONS); (5) release note
+      (non-dev-first tone, cf. memory), merge to main, tag **v4.9.1**, close #69/#63/#65;
+      (6) `git worktree remove /Users/tpierrain/Dev/kenjaku-mut-v491 --force`; (7) debrief the two
+      experiments in this plan (data so far: reviews found 1 blocker-class silent-no-op (symlink
+      entrypoint), 2 real defects fixed pre-tag, mutation floor HELD at 97.71 % under test-first
+      small batches; inline survivor triage beat fan-out at this size)._
 - [ ] **Debrief the two experiments** (work-mode pilot + process experiment below): wall-clock felt,
       mutation floor held or not, what the owner's review caught; write the verdict here, then let
       the owner decide what graduates (to the unfreeze QA, and/or to the harness TDD rule).

--- a/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
+++ b/maintainers/plans/prospective/hotfix-v4.9.1-universe-pointer-action.md
@@ -20,8 +20,12 @@
 
 ## Tracking
 
-- [ ] **(a) Close the reported case in the `/switch` path**: after the pointer is written, commit and
+- [x] **(a) Close the reported case in the `/switch` path**: after the pointer is written, commit and
       push it explicitly (deterministic, in `set-active-universe.mjs` or its caller). TDD baby-steps.
+      _(2026-08-15 · 7220b3a, branch `hotfix/v4.9.1-universe-pointer`)_ — new
+      `scripts/lib/universe-persist.mjs`: scoped commit of `.vault-rag/` + push via the Stop hook's
+      `attemptPush` (autopush opt-in respected); `runSwitchCli` reports `wrote`; loud warnings on
+      commit/push failure. Test-first batch (experiment mode), suite 1683 green.
 - [ ] **(b) Remove the class**: the Stop hook (`auto-push.mjs`) becomes **sweep-commit then push**, so
       any out-of-band engine write (today's pointer, tomorrow's whatever) leaves the machine at session
       end instead of waiting for the next session's sweep.

--- a/maintainers/plans/prospective/release-v4.9.1-note.md
+++ b/maintainers/plans/prospective/release-v4.9.1-note.md
@@ -1,0 +1,92 @@
+# v4.9.1 — release note (draft)
+
+> Draft for the GitHub release body, written per `CONVENTIONS.md` §11: non-developer first, technical
+> depth kept but moved below the `---`. **Two things are still the owner's call**: the title (three
+> candidates below) and the mutation figures in *Under the hood*, which are pinned from pass 3.
+
+**Title candidates** (the series uses *"The One Where…"*):
+
+1. **v4.9.1 — The One Where the Switch Actually Leaves** ⭐ (says what was wrong, in the user's terms)
+2. v4.9.1 — The One Where It Really Does Travel
+3. v4.9.1 — The One Where Your Context Stops Coming Back
+
+---
+
+**If you keep several universes, the context you switch into now actually leaves the computer you
+switched it on.** v4.9.0 said it would follow you; in practice it was saved on that machine and never
+sent anywhere, so the computer you opened next stayed in the sphere you had left.
+
+Nothing was ever lost or damaged — your notes, your universes and your history were never in question.
+What could be wrong was *which* sphere your brain answered from.
+
+### What you get
+
+- 🌌 **The switch travels for real.** Switch to a client on your laptop, close it, open your desktop
+  tomorrow: it lands in that same context. Until now the switch was written on the laptop and stayed
+  there, so the other machine kept answering from the sphere you had moved out of — quietly, since
+  answering from the wrong sphere looks exactly like answering.
+- 🔙 **The context you left can no longer come back on its own.** When both machines had something to
+  say about it, the one that was *catching up* could save its own out-of-date context first and win. If
+  you ever saw yourself pushed back into a previous sphere without touching anything, that was it.
+- 💾 **Whatever your brain writes for itself now leaves with the rest.** Files your brain writes on its
+  own are not things you or Claude *edited*, so nothing was watching them. At the end of every turn your
+  brain now saves whatever is still unsaved before backing it up — so it is a whole family of small
+  things that stops staying behind on one machine, not just this one.
+- 🧵 **New brains hold more of a long conversation before compressing it.** The window before your brain
+  has to summarise what was said grows by roughly a third. This one applies to **brains installed from
+  now on**; an existing brain keeps the setting you already have, deliberately — it is yours.
+
+### What you have to do
+
+Ask for **`/update-engine`** once.
+
+**Nothing is re-read and nothing is re-encoded**: this release does not touch your notes or your search
+index, so there is nothing to wait for.
+
+---
+
+### Under the hood
+
+**The mechanism.** `/switch` writes the active-universe pointer (`.vault-rag/active-universe`) through a
+shell command, so it fires no `Write|Edit` event — and both halves of the persistence net were listening
+for exactly that: `auto-commit.mjs` matches `Write|Edit` only, and the `Stop` hook was push-only. The
+switch therefore survived as a dirty file until the *next* session's start-up sweep, which is also why a
+second machine could commit its own stale pointer first (issue #69, measured on a real brain with a
+timeline).
+
+Two fixes, one for the case and one for the class:
+
+1. **The switch persists itself** (`scripts/lib/universe-persist.mjs`): after the pointer is written it
+   is committed — **pathspec-scoped** to `.vault-rag/`, so anything you had staged stays staged and
+   stays yours — and pushed through the same opt-in path as every other push. Failure is loud, not
+   assumed.
+2. **The `Stop` hook became sweep-then-push** (`scripts/auto-push.mjs`): the turn's last hand now commits
+   whatever is dirty before pushing. That removes the class — today's pointer, tomorrow's whatever —
+   rather than the one reported instance. A sweep that fails says so; an unmerged tree is deferred to the
+   session-start banner that already owns that alarm.
+
+**Deliberately not shipped.** A guard refusing to commit a pointer that is *behind* the remote was
+considered and deferred, in writing: the two fixes above remove the dirty-pointer window it would have
+protected, and the remaining case (committed but behind) already stops loudly on a rebase conflict,
+where the standing rule applies — the machine you are sitting at wins.
+
+**The two riders.** `CLAUDE_CODE_AUTO_COMPACT_WINDOW` default 350k → 450k in the settings template
+(ADR 0018 amended in place, per CONVENTIONS §6bis; new brains only — an installed brain's settings are
+merged, never overwritten). And the native-connectors reminder now carries a `⚠️` so it reads as the
+caution it is. *(Issues #63 and #65.)*
+
+**How this reaches you.** `scripts/lib/**` is a `replace` regime and `scripts/auto-push.mjs` a `merge`
+one, so `/update-engine` delivers both — verified against the manifest rather than assumed. Engine
+version vector: `scripts` 1.13.0 → **1.13.1**.
+
+**The quality of what ships.** Three independent adversarial reviews ran on the branch (git semantics,
+fleet deployment through the update regimes, test quality) before anything was tagged; what they raised
+was fixed on the branch. The most useful of them demanded a test that runs the real `/switch` entry
+point in a subprocess — which immediately showed that a brain reached through a symlinked path would run
+the switch *without* persisting it. That is the net doing its job.
+
+**Mutation snapshot** (targeted run over the files this release changed, `maintainers/mutation/RESULTS.md`
+§ v4.9.1): _TO PIN from pass 3 — pass 2 read **97.71 %** overall, with `universe-persist.mjs`,
+`entrypoint.mjs` and `set-active-universe.mjs` at **100 %**._
+
+Closes #69, #63, #65.

--- a/maintainers/plans/prospective/release-v4.9.1-note.md
+++ b/maintainers/plans/prospective/release-v4.9.1-note.md
@@ -1,14 +1,12 @@
-# v4.9.1 — release note (draft)
+# v4.9.1 — The One Where Your Context Stops Coming Back
 
-> Draft for the GitHub release body, written per `CONVENTIONS.md` §11: non-developer first, technical
-> depth kept but moved below the `---`. The mutation figures are **pinned** (pass 3, 2026-08-15).
-> **One thing is still the owner's call**: the title — three candidates below.
-
-**Title candidates** (the series uses *"The One Where…"*):
-
-1. **v4.9.1 — The One Where the Switch Actually Leaves** ⭐ (says what was wrong, in the user's terms)
-2. v4.9.1 — The One Where It Really Does Travel
-3. v4.9.1 — The One Where Your Context Stops Coming Back
+> **This file mirrors the PUBLISHED release body.** Written per `CONVENTIONS.md` §11: non-developer
+> first, technical depth kept but moved below the `---`. Mutation figures pinned from pass 3
+> (2026-08-15). **Title arbitrated by the owner** (2026-08-15) among three candidates: he took the one
+> naming the symptom people actually lived — the old context coming back on its own — over my pick
+> (*"The One Where the Switch Actually Leaves"*, which named the mechanism) and over the self-
+> deprecating echo of v4.9.0 (*"The One Where It Really Does Travel"*). Recorded so it is not
+> re-litigated. Everything below this note is the body verbatim.
 
 ---
 

--- a/maintainers/plans/prospective/release-v4.9.1-note.md
+++ b/maintainers/plans/prospective/release-v4.9.1-note.md
@@ -1,8 +1,8 @@
 # v4.9.1 — release note (draft)
 
 > Draft for the GitHub release body, written per `CONVENTIONS.md` §11: non-developer first, technical
-> depth kept but moved below the `---`. **Two things are still the owner's call**: the title (three
-> candidates below) and the mutation figures in *Under the hood*, which are pinned from pass 3.
+> depth kept but moved below the `---`. The mutation figures are **pinned** (pass 3, 2026-08-15).
+> **One thing is still the owner's call**: the title — three candidates below.
 
 **Title candidates** (the series uses *"The One Where…"*):
 
@@ -85,8 +85,11 @@ was fixed on the branch. The most useful of them demanded a test that runs the r
 point in a subprocess — which immediately showed that a brain reached through a symlinked path would run
 the switch *without* persisting it. That is the net doing its job.
 
-**Mutation snapshot** (targeted run over the files this release changed, `maintainers/mutation/RESULTS.md`
-§ v4.9.1): _TO PIN from pass 3 — pass 2 read **97.71 %** overall, with `universe-persist.mjs`,
-`entrypoint.mjs` and `set-active-universe.mjs` at **100 %**._
+**Mutation snapshot** (targeted run over the six production files this release changed, three passes —
+one per time production moved; `maintainers/mutation/RESULTS.md` § v4.9.1): **the two files this release
+wrote both end at 100 %**, the CLI wiring that no test imported goes **25 % → 100 %**, and the four
+others land between **95.92 % and 99.66 %**. Every survivor left is a named equivalent — the entry-point
+guard, a `.trim()` no git output can distinguish, and one optional chain whose `catch` already returns
+the same value.
 
 Closes #69, #63, #65.

--- a/scripts/auto-commit.mjs
+++ b/scripts/auto-commit.mjs
@@ -24,6 +24,9 @@ export function buildGit(repo, execFile = execFileSync) {
         cwd: repo,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        // A hung git maps to a plain {ok:false} instead of stalling the hook
+        // indefinitely (review, v4.9.1); same guard as auto-push's buildGit.
+        timeout: 10000,
       });
       return { out: out ?? "", ok: true };
     } catch (e) {

--- a/scripts/auto-commit.test.mjs
+++ b/scripts/auto-commit.test.mjs
@@ -173,6 +173,8 @@ test("buildGit — maps a successful execFile to {out, ok:true} with the right g
   assert.equal(seen[0].opts.cwd, "/repo");
   assert.equal(seen[0].opts.encoding, "utf8");
   assert.deepEqual(seen[0].opts.stdio, ["ignore", "pipe", "pipe"]);
+  // A hung git must not stall the PostToolUse hook indefinitely (review, v4.9.1).
+  assert.equal(seen[0].opts.timeout, 10000);
 });
 
 test("buildGit — null execFile output becomes '' (ok:true)", () => {

--- a/scripts/auto-push.mjs
+++ b/scripts/auto-push.mjs
@@ -14,7 +14,7 @@ import { execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { shouldPush } from "./lib/git-push.mjs";
-import { attemptCommit } from "./auto-commit.mjs";
+import { attemptCommit, isEntryPoint } from "./auto-commit.mjs";
 
 // attemptPush — testable core. `git` is an injected runner (args[]) → {out, ok};
 // `sleep` is an injected blocking pause (ms). Returns "pushed" | "skipped" |
@@ -59,6 +59,11 @@ export function buildGit(repo, execFile = execFileSync) {
         cwd: repo,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        // A hung git (dead network mount, wedged credential helper) maps to a
+        // plain {ok:false} instead of eating the hook's whole 30s budget — a
+        // hook killed at ITS deadline mid-commit can leave .git/index.lock
+        // behind, while a timed-out child is reaped cleanly here.
+        timeout: 10000,
       });
       return { out: out ?? "", ok: true };
     } catch (e) {
@@ -122,7 +127,11 @@ export function realHookDeps(metaUrl) {
 
 // ── CLI entry (the actual Stop hook) ─────────────────────────────────────────
 // Guarded so importing this module in tests does NOT run it. Wires the real
-// git/sleep/write, then ALWAYS exits 0 (ignores the hook stdin).
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+// git/sleep/write, then ALWAYS exits 0 (ignores the hook stdin). isEntryPoint
+// compares REAL paths (review finding, v4.9.1): the bare resolve() comparison
+// silently disarmed the whole hook on any brain whose path holds a symlink
+// (macOS /var → /private/var being the everyday case) — auto-commit.mjs had
+// learned this already; the guard is now shared.
+if (isEntryPoint(process.argv[1], import.meta.url)) {
   process.exit(runHook(realHookDeps(import.meta.url)));
 }

--- a/scripts/auto-push.mjs
+++ b/scripts/auto-push.mjs
@@ -75,6 +75,14 @@ export const PUSH_FAILED_WARNING =
   "\n⚠️  PUSH FAILED — local commits OK but not pushed. Check your network; " +
   "the next turn will retry automatically (or run: git push).\n";
 
+// Said out loud because the silent version IS issue #69's failure class: a git
+// that refuses every sweep (stale .git/index.lock, missing identity) would
+// otherwise leave changes uncommitted at every turn end with no signal at all.
+export const SWEEP_FAILED_WARNING =
+  "\n⚠️  SWEEP FAILED — some changes stay uncommitted on this machine. Run " +
+  "`git status` in your brain to see what stopped the commit (a stale " +
+  ".git/index.lock or a missing git identity are the usual causes).\n";
+
 // Runs the hook: SWEEP-commit, then push (issue #69, class removal). A file
 // written through Bash — yesterday the universe pointer, tomorrow anything —
 // never fires the PostToolUse net; the Stop hook is the turn's last hand, so it
@@ -86,9 +94,12 @@ export const PUSH_FAILED_WARNING =
 // warning on push failure. ALWAYS returns 0. `write` is injected for testing.
 export function runHook({ git, sleep, write }) {
   try {
-    attemptCommit({ git });
+    // "failed" is worth a shout (review finding, v4.9.1) — "conflicted" is not:
+    // the SessionStart banner already owns the unmerged-tree alarm.
+    if (attemptCommit({ git }) === "failed") write(SWEEP_FAILED_WARNING);
   } catch {
-    // Best-effort: the push below still ships whatever is already committed.
+    // A THROWING runner means git itself is broken — the push below fails too
+    // and its warning already says "check"; one shout per turn is enough.
   }
   if (attemptPush({ git, sleep }) === "failed") write(PUSH_FAILED_WARNING);
   return 0;

--- a/scripts/auto-push.mjs
+++ b/scripts/auto-push.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 // ─────────────────────────────────────────────────────────────────────────────
-// auto-push.mjs — Stop hook. Pushes the pending commits ONCE per turn (the Stop
-// event fires once per main-agent turn, whatever the number of edits), so 30
-// edits = 30 local commits + 1 push. Best-effort: never blocks the turn, always
-// exits 0. auto-commit.mjs (PostToolUse) stays commit-only.
+// auto-push.mjs — Stop hook. SWEEP-commits any out-of-band write (a Bash-side
+// file the PostToolUse net cannot see — issue #69), then pushes the pending
+// commits ONCE per turn (the Stop event fires once per main-agent turn, whatever
+// the number of edits), so 30 edits = 30 local commits + 1 push. Best-effort:
+// never blocks the turn, always exits 0. auto-commit.mjs (PostToolUse) stays
+// commit-only.
 //
 // Cross-OS: pure Node, no shell dependency. Repo root derived from the script
 // location (not the hook's cwd).
@@ -12,6 +14,7 @@ import { execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { shouldPush } from "./lib/git-push.mjs";
+import { attemptCommit } from "./auto-commit.mjs";
 
 // attemptPush — testable core. `git` is an injected runner (args[]) → {out, ok};
 // `sleep` is an injected blocking pause (ms). Returns "pushed" | "skipped" |
@@ -72,9 +75,21 @@ export const PUSH_FAILED_WARNING =
   "\n⚠️  PUSH FAILED — local commits OK but not pushed. Check your network; " +
   "the next turn will retry automatically (or run: git push).\n";
 
-// Runs the hook: attempt the push, print a non-blocking warning on failure.
-// ALWAYS returns 0 (best-effort). `write` is injected for testing.
+// Runs the hook: SWEEP-commit, then push (issue #69, class removal). A file
+// written through Bash — yesterday the universe pointer, tomorrow anything —
+// never fires the PostToolUse net; the Stop hook is the turn's last hand, so it
+// commits whatever is dirty before pushing, instead of leaving the dirt to a
+// next-session sweep that can lose to another machine's stale state. The sweep
+// reuses attemptCommit (same message, same refusal of an unmerged tree) and is
+// wrapped best-effort: it assumes buildGit's non-throwing runner, and a hook
+// must never let a persistence hiccup block the turn. Prints a non-blocking
+// warning on push failure. ALWAYS returns 0. `write` is injected for testing.
 export function runHook({ git, sleep, write }) {
+  try {
+    attemptCommit({ git });
+  } catch {
+    // Best-effort: the push below still ships whatever is already committed.
+  }
   if (attemptPush({ git, sleep }) === "failed") write(PUSH_FAILED_WARNING);
   return 0;
 }

--- a/scripts/auto-push.test.mjs
+++ b/scripts/auto-push.test.mjs
@@ -263,9 +263,13 @@ test("runHook — a conflicted tree stays silent here (the SessionStart banner o
   assert.deepEqual(writes, []);
 });
 
-test("SWEEP_FAILED_WARNING — names the failure and points at git status", () => {
-  assert.match(SWEEP_FAILED_WARNING, /SWEEP FAILED/);
-  assert.match(SWEEP_FAILED_WARNING, /git status/);
+test("SWEEP_FAILED_WARNING — whole-text pin (fragment matches let half of it blank)", () => {
+  assert.equal(
+    SWEEP_FAILED_WARNING,
+    "\n⚠️  SWEEP FAILED — some changes stay uncommitted on this machine. Run " +
+      "`git status` in your brain to see what stopped the commit (a stale " +
+      ".git/index.lock or a missing git identity are the usual causes).\n"
+  );
 });
 
 test("runHook — a clean tree sweeps nothing (no add, no commit)", () => {

--- a/scripts/auto-push.test.mjs
+++ b/scripts/auto-push.test.mjs
@@ -12,6 +12,7 @@ import {
   realHookDeps,
   PUSH_FAILED_WARNING,
 } from "./auto-push.mjs";
+import { COMMIT_MESSAGE } from "./auto-commit.mjs";
 
 // auto-push.mjs is the Stop hook: it pushes the pending commits ONCE per turn,
 // best-effort. attemptPush() is the testable core — the git runner is injected,
@@ -29,24 +30,33 @@ import {
 // so mutating ANY arg string (e.g. "--get", "@{u}..HEAD") yields an unknown
 // command → a broken/neutral {ok:false} answer that fails the happy path → the
 // mutant is caught. Records every call so tests can assert push discipline.
-function makeGit({ remote = "", autopush = false, upstream = false, unpushed = 0, pushOk = true } = {}) {
+function makeGit({ remote = "", autopush = false, upstream = false, unpushed = 0, pushOk = true, status = "" } = {}) {
   const calls = [];
   // Real git output carries trailing newlines → the code must .trim(); we mirror
   // that so trim-removing mutants change the outcome.
-  const responses = {
+  // Commits are COUNTED so `rev-list` answers like real git: a commit the sweep
+  // just made becomes pending. A mutant pushing BEFORE the sweep reads 0 pending
+  // → skips the push → the ordering test fails it.
+  let commits = 0;
+  const responses = () => ({
+    "status --porcelain": { out: status, ok: true },
+    "add .": { out: "", ok: true },
+    [`commit -m ${COMMIT_MESSAGE}`]: { out: "", ok: true },
     "remote": { out: remote, ok: true },
     "config --get secondbrain.autopush": { out: autopush ? "true\n" : "", ok: true },
     "rev-parse --abbrev-ref --symbolic-full-name @{u}": {
       out: upstream ? "origin/main\n" : "",
       ok: upstream,
     },
-    "rev-list --count @{u}..HEAD": { out: `${unpushed}\n`, ok: true },
+    "rev-list --count @{u}..HEAD": { out: `${unpushed + commits}\n`, ok: true },
     "push": { out: pushOk ? "" : "fatal: unable to access", ok: pushOk },
-  };
+  });
   const git = (args) => {
     const key = args.join(" ");
     calls.push(key);
-    return responses[key] ?? { out: "", ok: false };
+    const res = responses()[key] ?? { out: "", ok: false };
+    if (key.startsWith("commit ") && res.ok) commits += 1;
+    return res;
   };
   return { git, calls };
 }
@@ -184,6 +194,51 @@ test("runHook — successful push → no warning, returns 0", () => {
   const code = runHook({ git, sleep: () => {}, write: (s) => writes.push(s) });
   assert.equal(code, 0);
   assert.equal(writes.length, 0);
+});
+
+// ── Stop-hook sweep (issue #69, class removal): commit out-of-band writes ────
+// A file written through Bash (yesterday the universe pointer, tomorrow anything)
+// never fires the PostToolUse net. The Stop hook is the last hand of the turn, so
+// it sweeps: commit whatever is dirty, THEN push — instead of leaving the dirt to
+// a next-session sweep that can lose to another machine's stale state.
+
+test("runHook — sweeps out-of-band dirt into a commit BEFORE pushing", () => {
+  const { git, calls } = makeGit({
+    remote: "origin", autopush: true, upstream: true, unpushed: 0,
+    status: " M .vault-rag/active-universe\n",
+  });
+  const code = runHook({ git, sleep: () => {}, write: () => {} });
+
+  assert.equal(code, 0);
+  const add = calls.indexOf("add .");
+  const commit = calls.indexOf(`commit -m ${COMMIT_MESSAGE}`);
+  const push = calls.indexOf("push");
+  assert.ok(add !== -1, "the dirt is staged");
+  assert.ok(commit !== -1, "the dirt is committed");
+  assert.ok(push !== -1, "then pushed");
+  assert.ok(add < commit && commit < push, `sweep before push, got: ${calls.join(" | ")}`);
+});
+
+test("runHook — refuses to sweep an unmerged tree but still pushes what is committed", () => {
+  const { git, calls } = makeGit({
+    remote: "origin", autopush: true, upstream: true, unpushed: 2,
+    status: "UU vault/note.md\n",
+  });
+  const code = runHook({ git, sleep: () => {}, write: () => {} });
+
+  assert.equal(code, 0);
+  assert.ok(!calls.includes("add ."), "an unmerged tree is never staged (conflict markers)");
+  assert.ok(calls.includes("push"), "the already-committed work still leaves the machine");
+});
+
+test("runHook — a clean tree sweeps nothing (no add, no commit)", () => {
+  const { git, calls } = makeGit({
+    remote: "origin", autopush: true, upstream: true, unpushed: 3, status: "",
+  });
+  runHook({ git, sleep: () => {}, write: () => {} });
+
+  assert.ok(!calls.includes("add ."));
+  assert.ok(!calls.some((c) => c.startsWith("commit")));
 });
 
 test("PUSH_FAILED_WARNING — mentions the push failure and the retry", () => {

--- a/scripts/auto-push.test.mjs
+++ b/scripts/auto-push.test.mjs
@@ -11,6 +11,7 @@ import {
   realWrite,
   realHookDeps,
   PUSH_FAILED_WARNING,
+  SWEEP_FAILED_WARNING,
 } from "./auto-push.mjs";
 import { COMMIT_MESSAGE } from "./auto-commit.mjs";
 
@@ -229,6 +230,39 @@ test("runHook — refuses to sweep an unmerged tree but still pushes what is com
   assert.equal(code, 0);
   assert.ok(!calls.includes("add ."), "an unmerged tree is never staged (conflict markers)");
   assert.ok(calls.includes("push"), "the already-committed work still leaves the machine");
+});
+
+test("runHook — a sweep that git refuses is said OUT LOUD (review finding, v4.9.1)", () => {
+  // A stale .git/index.lock or a missing git identity makes attemptCommit return
+  // "failed" at EVERY Stop — silently swallowed, that is issue #69's silent-
+  // persistence class relocated into the hook itself.
+  const { git } = makeGit({
+    remote: "origin", autopush: true, upstream: true, unpushed: 0,
+    status: " M .vault-rag/active-universe\n",
+  });
+  const gitRefusingCommit = (args) =>
+    args[0] === "commit" ? { out: "fatal: no user.email", ok: false } : git(args);
+  const writes = [];
+  const code = runHook({ git: gitRefusingCommit, sleep: () => {}, write: (s) => writes.push(s) });
+
+  assert.equal(code, 0);
+  assert.deepEqual(writes, [SWEEP_FAILED_WARNING]);
+});
+
+test("runHook — a conflicted tree stays silent here (the SessionStart banner owns that shout)", () => {
+  const { git } = makeGit({
+    remote: "origin", autopush: true, upstream: true, unpushed: 0,
+    status: "UU vault/note.md\n",
+  });
+  const writes = [];
+  runHook({ git, sleep: () => {}, write: (s) => writes.push(s) });
+
+  assert.deepEqual(writes, []);
+});
+
+test("SWEEP_FAILED_WARNING — names the failure and points at git status", () => {
+  assert.match(SWEEP_FAILED_WARNING, /SWEEP FAILED/);
+  assert.match(SWEEP_FAILED_WARNING, /git status/);
 });
 
 test("runHook — a clean tree sweeps nothing (no add, no commit)", () => {

--- a/scripts/auto-push.test.mjs
+++ b/scripts/auto-push.test.mjs
@@ -151,6 +151,9 @@ test("buildGit — maps a successful execFile to {out, ok:true} with the right g
   assert.equal(seen[0].opts.cwd, "/repo");
   assert.equal(seen[0].opts.encoding, "utf8");
   assert.deepEqual(seen[0].opts.stdio, ["ignore", "pipe", "pipe"]);
+  // A hung git (dead network mount, wedged credential helper) must not eat the
+  // Stop hook's whole 30s budget — nor block a /switch (review finding, v4.9.1).
+  assert.equal(seen[0].opts.timeout, 10000);
 });
 
 test("buildGit — null execFile output becomes '' (ok:true)", () => {

--- a/scripts/lib/entrypoint.mjs
+++ b/scripts/lib/entrypoint.mjs
@@ -10,11 +10,24 @@
 // runtime uses instead.
 // ─────────────────────────────────────────────────────────────────────────────
 import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
 
 // True when `metaUrl` (an import.meta.url) denotes the same file as `argv1`
 // (a process.argv[1] filesystem path) — i.e. this module is the entry point.
 // Canonicalise argv1 through pathToFileURL (the same transform the runtime applies
-// to build import.meta.url) so backslashes, drive letters and spaces all match.
+// to build import.meta.url) so backslashes, drive letters and spaces all match —
+// and through realpathSync first (review, v4.9.1): Node realpath-resolves the
+// main module, so a SYMLINKED argv1 (macOS /var → /private/var, any aliased
+// brain path) never matched and the guarded block silently skipped. A path that
+// does not resolve (unit tests use fictional ones) is compared as spelled.
 export function isEntrypoint(metaUrl, argv1) {
-  return metaUrl === pathToFileURL(argv1).href;
+  if (!argv1) return false;
+  let path = argv1;
+  try {
+    path = realpathSync(argv1);
+  } catch {
+    // Nonexistent argv1: fall back to the literal spelling — it can still match
+    // a metaUrl built from the same fictional path, never a real module's.
+  }
+  return metaUrl === pathToFileURL(path).href;
 }

--- a/scripts/lib/entrypoint.test.mjs
+++ b/scripts/lib/entrypoint.test.mjs
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { pathToFileURL } from "node:url";
+import { mkdtempSync, writeFileSync, symlinkSync, realpathSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { isEntrypoint } from "./entrypoint.mjs";
 
 test("isEntrypoint — true when the meta-url is the canonical URL of argv1", () => {
@@ -12,6 +15,35 @@ test("isEntrypoint — false for a different file", () => {
   const argv1 = "/Users/dev/brain/scripts/clear-example-notes.mjs";
   const otherUrl = pathToFileURL("/Users/dev/brain/scripts/reindex.mjs").href;
   assert.equal(isEntrypoint(otherUrl, argv1), false);
+});
+
+test("isEntrypoint — true when argv1 reaches the file THROUGH a symlink (review, v4.9.1)", () => {
+  // Node realpath-resolves the MAIN module by default, so import.meta.url holds
+  // the real path while argv1 keeps the symlinked spelling (macOS /var →
+  // /private/var being the everyday case: every tmpdir path). Unresolved, the
+  // guard silently never fires — set-active-universe.mjs then switches without
+  // persisting, the exact defect #69 is about. Same lesson as auto-commit.mjs's
+  // isEntryPoint, now shared by the ONE canonical predicate.
+  const dir = mkdtempSync(join(tmpdir(), "entrypoint-"));
+  try {
+    const realDir = realpathSync(dir); // tmpdir itself may sit behind a symlink
+    writeFileSync(join(realDir, "tool.mjs"), "// empty\n");
+    symlinkSync(realDir, join(realDir, "alias"), "dir");
+    const throughSymlink = join(realDir, "alias", "tool.mjs");
+    const metaUrl = pathToFileURL(join(realDir, "tool.mjs")).href; // what Node builds
+
+    assert.equal(isEntrypoint(metaUrl, throughSymlink), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("isEntrypoint — false for a missing or empty argv1 (imported, not spawned)", () => {
+  const metaUrl = pathToFileURL("/Users/dev/brain/scripts/tool.mjs").href;
+  assert.equal(isEntrypoint(metaUrl, undefined), false);
+  assert.equal(isEntrypoint(metaUrl, ""), false);
+  // A nonexistent argv1 (realpath throws) must degrade to a plain mismatch, not crash.
+  assert.equal(isEntrypoint(metaUrl, "/no/such/file.mjs"), false);
 });
 
 test("isEntrypoint — true when argv1 contains a space (percent-encoded path)", () => {

--- a/scripts/lib/settings-template.test.mjs
+++ b/scripts/lib/settings-template.test.mjs
@@ -24,9 +24,12 @@ function generatedSettings() {
   return JSON.parse(content);
 }
 
-test("settings template bakes CLAUDE_CODE_AUTO_COMPACT_WINDOW=350000 into env", () => {
+// 450000 since v4.9.1 (issue #63): 350k compacted too early for long capture
+// sessions; the ceiling leaves headroom while staying under the model window.
+// New brains only — deployed brains keep their own settings.json.
+test("settings template bakes CLAUDE_CODE_AUTO_COMPACT_WINDOW=450000 into env", () => {
   const settings = generatedSettings();
-  assert.equal(settings.env?.CLAUDE_CODE_AUTO_COMPACT_WINDOW, "350000");
+  assert.equal(settings.env?.CLAUDE_CODE_AUTO_COMPACT_WINDOW, "450000");
 });
 
 test("the autocompact threshold is a STRING (env values must be strings)", () => {

--- a/scripts/lib/universe-persist.mjs
+++ b/scripts/lib/universe-persist.mjs
@@ -29,6 +29,20 @@ export const SWITCH_NOT_COMMITTED_WARNING =
   "\n⚠️  SWITCH NOT COMMITTED — the universe changed on THIS machine only and " +
   "will not travel. Run `git status` in your brain to see what stopped the commit.";
 
+// Calm on purpose: a deferral is the NORMAL outcome mid-merge, not a failure —
+// the Stop-hook sweep commits (unscoped) at turn end, which git does allow there.
+export const SWITCH_COMMIT_DEFERRED_NOTE =
+  "\nNote: a merge/rebase is in progress here, so the switch will be committed " +
+  "with it at the end of the turn.";
+
+// The states in which git REFUSES a partial (pathspec) commit — "fatal: cannot
+// do a partial commit during a merge" — reproduced live on both merge and
+// rebase (correctness review, v4.9.1). Probed via rev-parse so the answer is
+// git's own, not a guess about .git internals.
+const IN_PROGRESS_HEADS = ["MERGE_HEAD", "REBASE_HEAD", "CHERRY_PICK_HEAD"];
+const operationInProgress = (git) =>
+  IN_PROGRESS_HEADS.some((h) => git(["rev-parse", "-q", "--verify", h]).ok);
+
 // Commits the .vault-rag state (pointer + registry). Returns "committed" |
 // "clean" | "conflicted" | "failed" — same vocabulary as attemptCommit, same
 // shared treeState refusal of an unmerged tree (committing there would bury
@@ -37,6 +51,9 @@ export const SWITCH_NOT_COMMITTED_WARNING =
 export function commitUniverseState({ git, name }) {
   const state = treeState(git(["status", "--porcelain"]).out);
   if (state !== "dirty") return state;
+  // A paused merge/rebase whose conflicts are already staged reads "dirty", but
+  // a pathspec commit is refused there: hands off entirely, defer to the sweep.
+  if (operationInProgress(git)) return "deferred";
   if (!git(["add", "-A", "--", ".vault-rag"]).ok) return "failed";
   // The gate AND the commit both carry the pathspec (review finding, v4.9.1):
   // unscoped, work the owner had already staged — a draft, a half-finished
@@ -49,10 +66,12 @@ export function commitUniverseState({ git, name }) {
 }
 
 // The whole persistence: commit, then push through the Stop hook's own logic
-// (remote + `secondbrain.autopush` opt-in + upstream + something to push).
+// (remote + `secondbrain.autopush` opt-in + upstream + something to push). The
+// push is GATED on this switch having committed (review finding): a failed or
+// deferred commit must not turn a switch into a push of unrelated local commits.
 export function persistUniverseSwitch({ git, sleep, name }) {
   const commit = commitUniverseState({ git, name });
-  const push = attemptPush({ git, sleep });
+  const push = commit === "committed" ? attemptPush({ git, sleep }) : "skipped";
   return { commit, push };
 }
 
@@ -60,13 +79,14 @@ export function persistUniverseSwitch({ git, sleep, name }) {
 // carries the slug): read-only commands and refused switches never touch git.
 // Failures are appended to the user-facing message, never swallowed: the switch
 // itself did happen on disk (code stays 0), but the owner must hear it stayed
-// local.
+// local. A deferral (paused merge/rebase) is noted calmly, not shouted.
 export function runSwitchCliPersisted(io, dir, argv, { git, sleep }) {
   const res = runSwitchCli(io, dir, argv);
-  if (res.code !== 0 || !res.wrote) return res;
+  if (!res.wrote) return res;
   const { commit, push } = persistUniverseSwitch({ git, sleep, name: res.wrote });
   let message = res.message;
   if (commit === "failed" || commit === "conflicted") message += SWITCH_NOT_COMMITTED_WARNING;
+  if (commit === "deferred") message += SWITCH_COMMIT_DEFERRED_NOTE;
   if (push === "failed") message += PUSH_FAILED_WARNING;
   return { ...res, message };
 }

--- a/scripts/lib/universe-persist.mjs
+++ b/scripts/lib/universe-persist.mjs
@@ -1,0 +1,66 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// universe-persist.mjs — makes a universe switch LEAVE THE MACHINE (issue #69).
+//
+// WHY this exists: `/switch` writes the .vault-rag pointer through Bash, so
+// neither half of the persistence net sees it — auto-commit is a PostToolUse
+// hook on Write|Edit, and the Stop hook is push-only. The switch survived as a
+// dirty file; close the laptop and the "universe travels with you" promise of
+// v4.9.0 was void. Same invariant as engine-commit.mjs: a deterministic write
+// owns its own commit, and here its own push too — waiting for the next
+// session's sweep is exactly the window where a second machine's stale pointer
+// wins (the observed ping-pong).
+//
+// The staging is SCOPED to .vault-rag/: a switch must never sweep the owner's
+// pending notes under its own message. The push reuses the Stop hook's
+// attemptPush, so the `secondbrain.autopush` opt-in and its retry are decided
+// in ONE place. `git`/`sleep` are injected (same runner shape as auto-commit's).
+// ─────────────────────────────────────────────────────────────────────────────
+import { treeState } from "./repo-status.mjs";
+import { attemptPush, PUSH_FAILED_WARNING } from "../auto-push.mjs";
+import { runSwitchCli } from "./universes.mjs";
+
+export function switchCommitMessage(name) {
+  return `auto: switch active universe to '${name}'`;
+}
+
+// Loud, because the alternative is the silent v4.9.0 defect: a pointer that
+// looks switched here and never reaches the other machines.
+export const SWITCH_NOT_COMMITTED_WARNING =
+  "\n⚠️  SWITCH NOT COMMITTED — the universe changed on THIS machine only and " +
+  "will not travel. Run `git status` in your brain to see what stopped the commit.";
+
+// Commits the .vault-rag state (pointer + registry). Returns "committed" |
+// "clean" | "conflicted" | "failed" — same vocabulary as attemptCommit, same
+// shared treeState refusal of an unmerged tree (committing there would bury
+// `<<<<<<<` markers). "clean" also covers the idempotent re-switch: the scoped
+// add staged nothing, so there is nothing to say. NEVER throws.
+export function commitUniverseState({ git, name }) {
+  const state = treeState(git(["status", "--porcelain"]).out);
+  if (state !== "dirty") return state;
+  if (!git(["add", "-A", "--", ".vault-rag"]).ok) return "failed";
+  if (git(["diff", "--cached", "--quiet"]).ok) return "clean";
+  return git(["commit", "-m", switchCommitMessage(name)]).ok ? "committed" : "failed";
+}
+
+// The whole persistence: commit, then push through the Stop hook's own logic
+// (remote + `secondbrain.autopush` opt-in + upstream + something to push).
+export function persistUniverseSwitch({ git, sleep, name }) {
+  const commit = commitUniverseState({ git, name });
+  const push = attemptPush({ git, sleep });
+  return { commit, push };
+}
+
+// runSwitchCli, then persistence — but ONLY when the CLI says it wrote (`wrote`
+// carries the slug): read-only commands and refused switches never touch git.
+// Failures are appended to the user-facing message, never swallowed: the switch
+// itself did happen on disk (code stays 0), but the owner must hear it stayed
+// local.
+export function runSwitchCliPersisted(io, dir, argv, { git, sleep }) {
+  const res = runSwitchCli(io, dir, argv);
+  if (res.code !== 0 || !res.wrote) return res;
+  const { commit, push } = persistUniverseSwitch({ git, sleep, name: res.wrote });
+  let message = res.message;
+  if (commit === "failed" || commit === "conflicted") message += SWITCH_NOT_COMMITTED_WARNING;
+  if (push === "failed") message += PUSH_FAILED_WARNING;
+  return { ...res, message };
+}

--- a/scripts/lib/universe-persist.mjs
+++ b/scripts/lib/universe-persist.mjs
@@ -38,8 +38,14 @@ export function commitUniverseState({ git, name }) {
   const state = treeState(git(["status", "--porcelain"]).out);
   if (state !== "dirty") return state;
   if (!git(["add", "-A", "--", ".vault-rag"]).ok) return "failed";
-  if (git(["diff", "--cached", "--quiet"]).ok) return "clean";
-  return git(["commit", "-m", switchCommitMessage(name)]).ok ? "committed" : "failed";
+  // The gate AND the commit both carry the pathspec (review finding, v4.9.1):
+  // unscoped, work the owner had already staged — a draft, a half-finished
+  // conflict resolution — rode along under the switch message. Scoped, it stays
+  // exactly where they left it: staged, uncommitted, theirs.
+  if (git(["diff", "--cached", "--quiet", "--", ".vault-rag"]).ok) return "clean";
+  return git(["commit", "-m", switchCommitMessage(name), "--", ".vault-rag"]).ok
+    ? "committed"
+    : "failed";
 }
 
 // The whole persistence: commit, then push through the Stop hook's own logic

--- a/scripts/lib/universe-persist.test.mjs
+++ b/scripts/lib/universe-persist.test.mjs
@@ -6,6 +6,7 @@ import {
   runSwitchCliPersisted,
   switchCommitMessage,
   SWITCH_NOT_COMMITTED_WARNING,
+  SWITCH_COMMIT_DEFERRED_NOTE,
 } from "./universe-persist.mjs";
 import { PUSH_FAILED_WARNING } from "../auto-push.mjs";
 import { writeRegistry, writeActiveUniverse, readActiveUniverse } from "./universes.mjs";
@@ -27,74 +28,89 @@ function fakeFs(initial = {}) {
   };
 }
 
-// Recording git fake: `responses` maps a joined-args PREFIX to its {out, ok};
-// anything unmapped succeeds with empty output. `calls` keeps the full sequence
-// so a test can claim "this never committed" — not just "the result looked ok".
+// Recording git fake, EXACT-keyed on the full command (args.join(" ")) with a
+// STRICT default: an unmapped command answers {ok:false} — same discipline (and
+// same reason) as auto-push.test.mjs's makeGit. Mutating ANY arg — dropping the
+// `-- .vault-rag` pathspec included — produces an unknown command, a broken
+// answer, a failed happy path: the mutant dies structurally. Commits are COUNTED
+// so an unmapped `rev-list` answers like real git (a commit the code just made
+// becomes pending): a mutant pushing BEFORE the commit reads 0 pending, skips
+// the push, and fails the ordering assertion.
 function fakeGit(responses = {}) {
   const calls = [];
+  let commits = 0;
   const git = (args) => {
     calls.push(args);
     const key = args.join(" ");
-    for (const [prefix, res] of Object.entries(responses)) {
-      if (key.startsWith(prefix)) return { out: "", ok: true, ...res };
+    if (key === "rev-list --count @{u}..HEAD" && !(key in responses)) {
+      return { out: `${commits}\n`, ok: true };
     }
-    return { out: "", ok: true };
+    const mapped = responses[key];
+    const result = mapped ? { out: "", ok: true, ...mapped } : { out: "", ok: false };
+    if (result.ok && args[0] === "commit") commits += 1;
+    return result;
   };
   git.calls = calls;
   return git;
 }
 
-const has = (calls, ...prefix) =>
-  calls.some((args) => prefix.every((word, i) => args[i] === word));
+const keysOf = (git) => git.calls.map((args) => args.join(" "));
+const has = (git, key) => keysOf(git).includes(key);
+
+// The exact commands of a healthy acme-bound persistence, spelled out once.
+const MSG_ACME = "auto: switch active universe to 'acme'";
+const MSG_BLUE = "auto: switch active universe to 'blue'";
+const commitPath = (msg, status = " M .vault-rag/active-universe\n") => ({
+  "status --porcelain": { out: status },
+  "add -A -- .vault-rag": {},
+  "diff --cached --quiet -- .vault-rag": { ok: false }, // our files ARE staged
+  [`commit -m ${msg} -- .vault-rag`]: {},
+});
+// A push-ready repo, opted in — mapped EXPLICITLY (an upstream by accident is a
+// test lying about its arrangement).
+const pushReady = () => ({
+  "remote": { out: "origin\n" },
+  "config --get secondbrain.autopush": { out: "true\n" },
+  "rev-parse --abbrev-ref --symbolic-full-name @{u}": { out: "origin/main\n" },
+  "push": {},
+});
 
 // ── commitUniverseState: the commit half, scoped to the .vault-rag state ─────
 
 test("commitUniverseState stages the .vault-rag state and commits with the switch message", () => {
-  const git = fakeGit({
-    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
-    "diff --cached --quiet": { ok: false }, // something IS staged
-  });
+  const git = fakeGit(commitPath(MSG_ACME));
 
   const result = commitUniverseState({ git, name: "acme" });
 
   assert.equal(result, "committed");
-  assert.ok(has(git.calls, "add", "-A", "--", ".vault-rag"));
-  assert.ok(has(git.calls, "commit", "-m", "auto: switch active universe to 'acme'"));
+  assert.ok(has(git, "add -A -- .vault-rag"));
+  assert.ok(has(git, `commit -m ${MSG_ACME} -- .vault-rag`));
+});
+
+test("switchCommitMessage names the universe it switched to", () => {
+  assert.equal(switchCommitMessage("blue-team"), "auto: switch active universe to 'blue-team'");
 });
 
 test("commitUniverseState scopes BOTH the emptiness gate and the commit to .vault-rag (review finding, v4.9.1)", () => {
   // Proved on a throwaway repo: an unscoped `git commit -m` swept the owner's
   // PRE-STAGED work (e.g. half-finished conflict resolutions, a staged draft)
-  // under the switch message. The pathspec keeps the commit surgical and leaves
-  // anything else exactly as staged.
-  const git = fakeGit({
-    "status --porcelain": { out: " M .vault-rag/active-universe\nM  vault/secret-draft.md\n" },
-    "diff --cached --quiet -- .vault-rag": { ok: false },
-  });
+  // under the switch message. The pathspec keeps the commit surgical. The strict
+  // fake already refuses unscoped variants; the deepEqual pins the exact shape.
+  const git = fakeGit(
+    commitPath(MSG_ACME, " M .vault-rag/active-universe\nM  vault/secret-draft.md\n")
+  );
 
   const result = commitUniverseState({ git, name: "acme" });
 
   assert.equal(result, "committed");
-  assert.ok(
-    git.calls.some((args) =>
-      assertDeepEqualLoose(args, ["diff", "--cached", "--quiet", "--", ".vault-rag"])),
-    `the emptiness gate must be scoped, got: ${JSON.stringify(git.calls)}`
+  assert.deepEqual(
+    git.calls.filter((a) => a[0] === "diff"),
+    [["diff", "--cached", "--quiet", "--", ".vault-rag"]]
   );
-  assert.ok(
-    git.calls.some((args) =>
-      assertDeepEqualLoose(args, ["commit", "-m", "auto: switch active universe to 'acme'", "--", ".vault-rag"])),
-    `the commit must carry the pathspec, got: ${JSON.stringify(git.calls)}`
+  assert.deepEqual(
+    git.calls.filter((a) => a[0] === "commit"),
+    [["commit", "-m", MSG_ACME, "--", ".vault-rag"]]
   );
-});
-
-// Exact-args comparison used by the scoping test (a prefix match would pass on
-// the very unscoped calls the test exists to refuse).
-function assertDeepEqualLoose(a, b) {
-  return a.length === b.length && a.every((x, i) => x === b[i]);
-}
-
-test("switchCommitMessage names the universe it switched to", () => {
-  assert.equal(switchCommitMessage("blue-team"), "auto: switch active universe to 'blue-team'");
 });
 
 test("commitUniverseState reports clean when the switch changed nothing on disk", () => {
@@ -102,13 +118,14 @@ test("commitUniverseState reports clean when the switch changed nothing on disk"
   // a /switch must never sweep the owner's pending notes under its own message.
   const git = fakeGit({
     "status --porcelain": { out: " M vault/pending-note.md\n" },
-    "diff --cached --quiet": { ok: true }, // nothing staged
+    "add -A -- .vault-rag": {},
+    "diff --cached --quiet -- .vault-rag": { ok: true }, // nothing of OURS staged
   });
 
   const result = commitUniverseState({ git, name: "acme" });
 
   assert.equal(result, "clean");
-  assert.ok(!has(git.calls, "commit"));
+  assert.ok(!git.calls.some((a) => a[0] === "commit"));
 });
 
 test("commitUniverseState does not even stage on a fully clean tree", () => {
@@ -117,7 +134,7 @@ test("commitUniverseState does not even stage on a fully clean tree", () => {
   const result = commitUniverseState({ git, name: "acme" });
 
   assert.equal(result, "clean");
-  assert.ok(!has(git.calls, "add"));
+  assert.ok(!git.calls.some((a) => a[0] === "add"));
 });
 
 test("commitUniverseState refuses an unmerged tree without staging anything", () => {
@@ -126,15 +143,52 @@ test("commitUniverseState refuses an unmerged tree without staging anything", ()
   const result = commitUniverseState({ git, name: "acme" });
 
   assert.equal(result, "conflicted");
-  assert.ok(!has(git.calls, "add"));
-  assert.ok(!has(git.calls, "commit"));
+  assert.ok(!git.calls.some((a) => a[0] === "add"));
+  assert.ok(!git.calls.some((a) => a[0] === "commit"));
+});
+
+test("commitUniverseState DEFERS during a merge in progress (partial commits are refused there)", () => {
+  // Reproduced on a real repo (correctness review, v4.9.1): once a merge's
+  // conflicts are resolved and staged, treeState reads "dirty" again — but
+  // `git commit -- pathspec` is a PARTIAL commit and git refuses it mid-merge
+  // ("fatal: cannot do a partial commit during a merge"). Deferring to the
+  // Stop-hook sweep is the correct move: it commits unscoped at turn end.
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "rev-parse -q --verify MERGE_HEAD": {},
+  });
+
+  const result = commitUniverseState({ git, name: "acme" });
+
+  assert.equal(result, "deferred");
+  assert.ok(!git.calls.some((a) => a[0] === "add"), "a paused merge is left untouched");
+});
+
+test("commitUniverseState DEFERS during a rebase too (same partial-commit refusal)", () => {
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "rev-parse -q --verify REBASE_HEAD": {},
+  });
+
+  assert.equal(commitUniverseState({ git, name: "acme" }), "deferred");
+});
+
+test("commitUniverseState reports failed when git refuses the ADD (index.lock tier)", () => {
+  // The one failure mode a second brain must never paper over (cf. auto-commit):
+  // a refused add reported as "clean" would claim persistence that never happened.
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "add -A -- .vault-rag": { ok: false, out: "fatal: Unable to create '.git/index.lock'" },
+  });
+
+  assert.equal(commitUniverseState({ git, name: "acme" }), "failed");
+  assert.ok(!git.calls.some((a) => a[0] === "commit"));
 });
 
 test("commitUniverseState reports failed when git refuses the commit", () => {
   const git = fakeGit({
-    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
-    "diff --cached --quiet": { ok: false },
-    commit: { ok: false, out: "fatal: no user.email" },
+    ...commitPath(MSG_ACME),
+    [`commit -m ${MSG_ACME} -- .vault-rag`]: { ok: false, out: "fatal: no user.email" },
   });
 
   assert.equal(commitUniverseState({ git, name: "acme" }), "failed");
@@ -142,33 +196,50 @@ test("commitUniverseState reports failed when git refuses the commit", () => {
 
 // ── persistUniverseSwitch: commit then push, reusing the Stop hook's opt-in ──
 
-test("persistUniverseSwitch commits then pushes when the owner opted into autopush", () => {
-  const git = fakeGit({
-    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
-    "diff --cached --quiet": { ok: false },
-    remote: { out: "origin\n" },
-    "config --get secondbrain.autopush": { out: "true\n" },
-    "rev-list --count": { out: "1\n" },
-  });
+test("persistUniverseSwitch commits THEN pushes when the owner opted into autopush", () => {
+  // Nothing pending beforehand: the push only has work BECAUSE the commit ran
+  // first (the fake's rev-list counts commits, like real git). A swapped order
+  // reads 0 pending, skips, and fails both assertions — the twin of the
+  // ordering pin in auto-push.test.mjs, absent here until the test review.
+  const git = fakeGit({ ...commitPath(MSG_ACME), ...pushReady() });
 
   const result = persistUniverseSwitch({ git, sleep: () => {}, name: "acme" });
 
   assert.deepEqual(result, { commit: "committed", push: "pushed" });
-  assert.ok(has(git.calls, "push"));
+  const keys = keysOf(git);
+  assert.ok(
+    keys.findIndex((k) => k.startsWith("commit ")) < keys.indexOf("push"),
+    `commit must precede push, got: ${keys.join(" | ")}`
+  );
 });
 
 test("persistUniverseSwitch never pushes when the owner has not opted in", () => {
   const git = fakeGit({
-    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
-    "diff --cached --quiet": { ok: false },
-    remote: { out: "origin\n" },
+    ...commitPath(MSG_ACME),
+    "remote": { out: "origin\n" },
     "config --get secondbrain.autopush": { out: "" },
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": { out: "origin/main\n" },
   });
 
   const result = persistUniverseSwitch({ git, sleep: () => {}, name: "acme" });
 
   assert.deepEqual(result, { commit: "committed", push: "skipped" });
-  assert.ok(!has(git.calls, "push"));
+  assert.ok(!has(git, "push"));
+});
+
+test("persistUniverseSwitch does not push AT ALL unless this switch committed (review finding)", () => {
+  // A failed or deferred commit must not turn the switch into a push of
+  // unrelated local commits (worst shape: pushing mid-rebase).
+  const git = fakeGit({
+    ...commitPath(MSG_ACME),
+    ...pushReady(),
+    [`commit -m ${MSG_ACME} -- .vault-rag`]: { ok: false, out: "fatal: no user.email" },
+  });
+
+  const result = persistUniverseSwitch({ git, sleep: () => {}, name: "acme" });
+
+  assert.deepEqual(result, { commit: "failed", push: "skipped" });
+  assert.ok(!has(git, "push"));
 });
 
 // ── runSwitchCliPersisted: the wired CLI — switch, then leave the machine ────
@@ -180,22 +251,22 @@ function twoUniverseFs() {
   return io;
 }
 
+const noPersistenceWarning = (message) => {
+  assert.ok(!message.includes(SWITCH_NOT_COMMITTED_WARNING));
+  assert.ok(!message.includes(PUSH_FAILED_WARNING));
+};
+
 test("runSwitchCliPersisted persists a successful switch and keeps the message intact", () => {
   const io = twoUniverseFs();
-  const git = fakeGit({
-    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
-    "diff --cached --quiet": { ok: false },
-  });
+  const git = fakeGit(commitPath(MSG_BLUE));
 
   const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
 
   assert.equal(res.code, 0);
   assert.match(res.message, /switched to 'blue'/);
-  // No PERSISTENCE warning (the connectors reminder may carry its own ⚠️).
-  assert.ok(!res.message.includes(SWITCH_NOT_COMMITTED_WARNING));
-  assert.ok(!res.message.includes(PUSH_FAILED_WARNING));
+  noPersistenceWarning(res.message); // the connectors reminder may carry its own ⚠️
   assert.equal(readActiveUniverse(io, DIR), "blue");
-  assert.ok(has(git.calls, "commit", "-m", "auto: switch active universe to 'blue'"));
+  assert.ok(has(git, `commit -m ${MSG_BLUE} -- .vault-rag`));
 });
 
 test("runSwitchCliPersisted touches git on neither a read-only command nor a refused switch", () => {
@@ -212,9 +283,8 @@ test("runSwitchCliPersisted touches git on neither a read-only command nor a ref
 test("runSwitchCliPersisted shouts when the switch could not be committed", () => {
   const io = twoUniverseFs();
   const git = fakeGit({
-    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
-    "diff --cached --quiet": { ok: false },
-    commit: { ok: false, out: "fatal: no user.email" },
+    ...commitPath(MSG_BLUE),
+    [`commit -m ${MSG_BLUE} -- .vault-rag`]: { ok: false, out: "fatal: no user.email" },
   });
 
   const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
@@ -224,19 +294,73 @@ test("runSwitchCliPersisted shouts when the switch could not be committed", () =
   assert.ok(res.message.includes(SWITCH_NOT_COMMITTED_WARNING));
 });
 
-test("runSwitchCliPersisted relays the Stop hook's warning when the push failed", () => {
+test("runSwitchCliPersisted shouts on an unmerged tree too (the other edge of the warning)", () => {
+  // A switch during an unresolved rebase leaves the pointer uncommitted just the
+  // same; claiming success silently there is the v4.9.0 defect all over again.
+  const io = twoUniverseFs();
+  const git = fakeGit({ "status --porcelain": { out: "UU vault/note.md\n" } });
+
+  const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
+
+  assert.equal(res.code, 0);
+  assert.ok(res.message.includes(SWITCH_NOT_COMMITTED_WARNING));
+});
+
+test("runSwitchCliPersisted says a deferral SOFTLY — a paused merge is not a failure", () => {
   const io = twoUniverseFs();
   const git = fakeGit({
     "status --porcelain": { out: " M .vault-rag/active-universe\n" },
-    "diff --cached --quiet": { ok: false },
-    remote: { out: "origin\n" },
-    "config --get secondbrain.autopush": { out: "true\n" },
-    "rev-list --count": { out: "1\n" },
-    push: { ok: false, out: "network unreachable" },
+    "rev-parse -q --verify MERGE_HEAD": {},
+  });
+
+  const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
+
+  assert.equal(res.code, 0);
+  assert.ok(res.message.includes(SWITCH_COMMIT_DEFERRED_NOTE));
+  assert.ok(!res.message.includes(SWITCH_NOT_COMMITTED_WARNING));
+});
+
+test("SWITCH_COMMIT_DEFERRED_NOTE — whole-text pin, calm on purpose", () => {
+  assert.equal(
+    SWITCH_COMMIT_DEFERRED_NOTE,
+    "\nNote: a merge/rebase is in progress here, so the switch will be committed " +
+      "with it at the end of the turn."
+  );
+});
+
+test("runSwitchCliPersisted raises NO false alarm on an idempotent re-switch (clean)", () => {
+  // Re-selecting the current universe rewrites the same bytes: git sees nothing,
+  // commit reports "clean" — and "clean" must not read as "not committed".
+  const io = twoUniverseFs();
+  const git = fakeGit({ "status --porcelain": { out: "" } });
+
+  const res = runSwitchCliPersisted(io, DIR, ["acme"], { git, sleep: () => {} });
+
+  assert.equal(res.code, 0);
+  noPersistenceWarning(res.message);
+});
+
+test("runSwitchCliPersisted relays the Stop hook's warning when the push failed", () => {
+  const io = twoUniverseFs();
+  const git = fakeGit({
+    ...commitPath(MSG_BLUE),
+    ...pushReady(),
+    "push": { ok: false, out: "network unreachable" },
   });
 
   const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
 
   assert.equal(res.code, 0);
   assert.ok(res.message.includes(PUSH_FAILED_WARNING));
+});
+
+test("SWITCH_NOT_COMMITTED_WARNING — the words ARE the feature (whole-text pin)", () => {
+  // Every other assertion compares against the constant itself; without this pin
+  // the whole text could rot to "\nx" with the suite green — on the one line that
+  // tells the owner their switch stayed local.
+  assert.equal(
+    SWITCH_NOT_COMMITTED_WARNING,
+    "\n⚠️  SWITCH NOT COMMITTED — the universe changed on THIS machine only and " +
+      "will not travel. Run `git status` in your brain to see what stopped the commit."
+  );
 });

--- a/scripts/lib/universe-persist.test.mjs
+++ b/scripts/lib/universe-persist.test.mjs
@@ -1,0 +1,209 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  commitUniverseState,
+  persistUniverseSwitch,
+  runSwitchCliPersisted,
+  switchCommitMessage,
+  SWITCH_NOT_COMMITTED_WARNING,
+} from "./universe-persist.mjs";
+import { PUSH_FAILED_WARNING } from "../auto-push.mjs";
+import { writeRegistry, writeActiveUniverse, readActiveUniverse } from "./universes.mjs";
+
+const DIR = "/brain/.vault-rag";
+
+// In-memory fs fake, same surface as universes.test.mjs's.
+function fakeFs(initial = {}) {
+  const files = new Map(Object.entries(initial));
+  return {
+    files,
+    existsSync: (p) => files.has(p),
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT: ${p}`);
+      return files.get(p);
+    },
+    writeFileSync: (p, data) => files.set(p, data),
+    mkdirSync: () => {},
+  };
+}
+
+// Recording git fake: `responses` maps a joined-args PREFIX to its {out, ok};
+// anything unmapped succeeds with empty output. `calls` keeps the full sequence
+// so a test can claim "this never committed" — not just "the result looked ok".
+function fakeGit(responses = {}) {
+  const calls = [];
+  const git = (args) => {
+    calls.push(args);
+    const key = args.join(" ");
+    for (const [prefix, res] of Object.entries(responses)) {
+      if (key.startsWith(prefix)) return { out: "", ok: true, ...res };
+    }
+    return { out: "", ok: true };
+  };
+  git.calls = calls;
+  return git;
+}
+
+const has = (calls, ...prefix) =>
+  calls.some((args) => prefix.every((word, i) => args[i] === word));
+
+// ── commitUniverseState: the commit half, scoped to the .vault-rag state ─────
+
+test("commitUniverseState stages the .vault-rag state and commits with the switch message", () => {
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "diff --cached --quiet": { ok: false }, // something IS staged
+  });
+
+  const result = commitUniverseState({ git, name: "acme" });
+
+  assert.equal(result, "committed");
+  assert.ok(has(git.calls, "add", "-A", "--", ".vault-rag"));
+  assert.ok(has(git.calls, "commit", "-m", "auto: switch active universe to 'acme'"));
+});
+
+test("switchCommitMessage names the universe it switched to", () => {
+  assert.equal(switchCommitMessage("blue-team"), "auto: switch active universe to 'blue-team'");
+});
+
+test("commitUniverseState reports clean when the switch changed nothing on disk", () => {
+  // Unrelated dirt only: the scoped add stages nothing, so nothing is committed —
+  // a /switch must never sweep the owner's pending notes under its own message.
+  const git = fakeGit({
+    "status --porcelain": { out: " M vault/pending-note.md\n" },
+    "diff --cached --quiet": { ok: true }, // nothing staged
+  });
+
+  const result = commitUniverseState({ git, name: "acme" });
+
+  assert.equal(result, "clean");
+  assert.ok(!has(git.calls, "commit"));
+});
+
+test("commitUniverseState does not even stage on a fully clean tree", () => {
+  const git = fakeGit({ "status --porcelain": { out: "" } });
+
+  const result = commitUniverseState({ git, name: "acme" });
+
+  assert.equal(result, "clean");
+  assert.ok(!has(git.calls, "add"));
+});
+
+test("commitUniverseState refuses an unmerged tree without staging anything", () => {
+  const git = fakeGit({ "status --porcelain": { out: "UU vault/note.md\n" } });
+
+  const result = commitUniverseState({ git, name: "acme" });
+
+  assert.equal(result, "conflicted");
+  assert.ok(!has(git.calls, "add"));
+  assert.ok(!has(git.calls, "commit"));
+});
+
+test("commitUniverseState reports failed when git refuses the commit", () => {
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "diff --cached --quiet": { ok: false },
+    commit: { ok: false, out: "fatal: no user.email" },
+  });
+
+  assert.equal(commitUniverseState({ git, name: "acme" }), "failed");
+});
+
+// ── persistUniverseSwitch: commit then push, reusing the Stop hook's opt-in ──
+
+test("persistUniverseSwitch commits then pushes when the owner opted into autopush", () => {
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "diff --cached --quiet": { ok: false },
+    remote: { out: "origin\n" },
+    "config --get secondbrain.autopush": { out: "true\n" },
+    "rev-list --count": { out: "1\n" },
+  });
+
+  const result = persistUniverseSwitch({ git, sleep: () => {}, name: "acme" });
+
+  assert.deepEqual(result, { commit: "committed", push: "pushed" });
+  assert.ok(has(git.calls, "push"));
+});
+
+test("persistUniverseSwitch never pushes when the owner has not opted in", () => {
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "diff --cached --quiet": { ok: false },
+    remote: { out: "origin\n" },
+    "config --get secondbrain.autopush": { out: "" },
+  });
+
+  const result = persistUniverseSwitch({ git, sleep: () => {}, name: "acme" });
+
+  assert.deepEqual(result, { commit: "committed", push: "skipped" });
+  assert.ok(!has(git.calls, "push"));
+});
+
+// ── runSwitchCliPersisted: the wired CLI — switch, then leave the machine ────
+
+function twoUniverseFs() {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme", "blue"]);
+  writeActiveUniverse(io, DIR, "acme");
+  return io;
+}
+
+test("runSwitchCliPersisted persists a successful switch and keeps the message intact", () => {
+  const io = twoUniverseFs();
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "diff --cached --quiet": { ok: false },
+  });
+
+  const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
+
+  assert.equal(res.code, 0);
+  assert.match(res.message, /switched to 'blue'/);
+  assert.doesNotMatch(res.message, /⚠️/u);
+  assert.equal(readActiveUniverse(io, DIR), "blue");
+  assert.ok(has(git.calls, "commit", "-m", "auto: switch active universe to 'blue'"));
+});
+
+test("runSwitchCliPersisted touches git on neither a read-only command nor a refused switch", () => {
+  for (const argv of [["list"], ["current"], [], ["ghost"]]) {
+    const io = twoUniverseFs();
+    const git = fakeGit();
+
+    runSwitchCliPersisted(io, DIR, argv, { git, sleep: () => {} });
+
+    assert.deepEqual(git.calls, [], `argv ${JSON.stringify(argv)} must not touch git`);
+  }
+});
+
+test("runSwitchCliPersisted shouts when the switch could not be committed", () => {
+  const io = twoUniverseFs();
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "diff --cached --quiet": { ok: false },
+    commit: { ok: false, out: "fatal: no user.email" },
+  });
+
+  const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
+
+  assert.equal(res.code, 0); // the switch itself DID happen on disk
+  assert.match(res.message, /switched to 'blue'/);
+  assert.ok(res.message.includes(SWITCH_NOT_COMMITTED_WARNING));
+});
+
+test("runSwitchCliPersisted relays the Stop hook's warning when the push failed", () => {
+  const io = twoUniverseFs();
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\n" },
+    "diff --cached --quiet": { ok: false },
+    remote: { out: "origin\n" },
+    "config --get secondbrain.autopush": { out: "true\n" },
+    "rev-list --count": { out: "1\n" },
+    push: { ok: false, out: "network unreachable" },
+  });
+
+  const res = runSwitchCliPersisted(io, DIR, ["blue"], { git, sleep: () => {} });
+
+  assert.equal(res.code, 0);
+  assert.ok(res.message.includes(PUSH_FAILED_WARNING));
+});

--- a/scripts/lib/universe-persist.test.mjs
+++ b/scripts/lib/universe-persist.test.mjs
@@ -62,6 +62,37 @@ test("commitUniverseState stages the .vault-rag state and commits with the switc
   assert.ok(has(git.calls, "commit", "-m", "auto: switch active universe to 'acme'"));
 });
 
+test("commitUniverseState scopes BOTH the emptiness gate and the commit to .vault-rag (review finding, v4.9.1)", () => {
+  // Proved on a throwaway repo: an unscoped `git commit -m` swept the owner's
+  // PRE-STAGED work (e.g. half-finished conflict resolutions, a staged draft)
+  // under the switch message. The pathspec keeps the commit surgical and leaves
+  // anything else exactly as staged.
+  const git = fakeGit({
+    "status --porcelain": { out: " M .vault-rag/active-universe\nM  vault/secret-draft.md\n" },
+    "diff --cached --quiet -- .vault-rag": { ok: false },
+  });
+
+  const result = commitUniverseState({ git, name: "acme" });
+
+  assert.equal(result, "committed");
+  assert.ok(
+    git.calls.some((args) =>
+      assertDeepEqualLoose(args, ["diff", "--cached", "--quiet", "--", ".vault-rag"])),
+    `the emptiness gate must be scoped, got: ${JSON.stringify(git.calls)}`
+  );
+  assert.ok(
+    git.calls.some((args) =>
+      assertDeepEqualLoose(args, ["commit", "-m", "auto: switch active universe to 'acme'", "--", ".vault-rag"])),
+    `the commit must carry the pathspec, got: ${JSON.stringify(git.calls)}`
+  );
+});
+
+// Exact-args comparison used by the scoping test (a prefix match would pass on
+// the very unscoped calls the test exists to refuse).
+function assertDeepEqualLoose(a, b) {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}
+
 test("switchCommitMessage names the universe it switched to", () => {
   assert.equal(switchCommitMessage("blue-team"), "auto: switch active universe to 'blue-team'");
 });

--- a/scripts/lib/universe-persist.test.mjs
+++ b/scripts/lib/universe-persist.test.mjs
@@ -160,7 +160,9 @@ test("runSwitchCliPersisted persists a successful switch and keeps the message i
 
   assert.equal(res.code, 0);
   assert.match(res.message, /switched to 'blue'/);
-  assert.doesNotMatch(res.message, /⚠️/u);
+  // No PERSISTENCE warning (the connectors reminder may carry its own ⚠️).
+  assert.ok(!res.message.includes(SWITCH_NOT_COMMITTED_WARNING));
+  assert.ok(!res.message.includes(PUSH_FAILED_WARNING));
   assert.equal(readActiveUniverse(io, DIR), "blue");
   assert.ok(has(git.calls, "commit", "-m", "auto: switch active universe to 'blue'"));
 });

--- a/scripts/lib/universes.mjs
+++ b/scripts/lib/universes.mjs
@@ -34,7 +34,9 @@ export function normalizeUniverseName(raw) {
     .replace(/[̀-ͯ]/g, "") // strip combining accent marks
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-") // any non-alphanumeric run → one hyphen
-    .replace(/^-+|-+$/g, ""); // trim leading/trailing hyphens
+    // Single `-`, not `-+`: runs are already collapsed above, so an edge can
+    // only carry ONE hyphen — the quantifier was dead regex (mutation pass).
+    .replace(/^-|-$/g, ""); // trim leading/trailing hyphens
 }
 
 /**

--- a/scripts/lib/universes.mjs
+++ b/scripts/lib/universes.mjs
@@ -143,7 +143,9 @@ export function runSwitchCli(io, dir, argv) {
         `cross-cutting (default) notes; say "search all universes" to span them. ` +
         `New notes you capture here will file under vault/${res.name}/.`
       : "";
-    return { code: 0, message: head + onboarding };
+    // `wrote` carries the written slug so the caller can persist the pointer
+    // (commit + push — issue #69: a Bash-side write is invisible to the hooks).
+    return { code: 0, message: head + onboarding, wrote: res.name };
   }
 
   // switch (fast path / explicit)
@@ -152,7 +154,7 @@ export function runSwitchCli(io, dir, argv) {
     // Landing in a named universe? Deterministically remind that the single-account
     // native connectors don't follow the switch (empty for the trivial toggles).
     const reminder = nativeConnectorsReminder({ from: current, to: res.name });
-    return { code: 0, message: `switched to '${res.name}'` + reminder };
+    return { code: 0, message: `switched to '${res.name}'` + reminder, wrote: res.name };
   }
   if (res.reason === "unknown") {
     return {

--- a/scripts/lib/universes.mjs
+++ b/scripts/lib/universes.mjs
@@ -177,7 +177,7 @@ export function nativeConnectorsReminder({ from, to }) {
   if (to === from) return "";
   if (to === DEFAULT_UNIVERSE) return "";
   return (
-    `\nHeads-up: native connectors (Slack, Notion, Google, mail…) are single-account and ` +
+    `\n⚠️ Heads-up: native connectors (Slack, Notion, Google, mail…) are single-account and ` +
     `don't follow this switch. If '${to}' uses different accounts, disconnect/reconnect them to match.`
   );
 }

--- a/scripts/lib/universes.test.mjs
+++ b/scripts/lib/universes.test.mjs
@@ -489,6 +489,9 @@ test("nativeConnectorsReminder warns when switching between two named universes"
   assert.match(msg, /single-account/i);
   // Names the target so the user knows which universe's accounts to line up.
   assert.match(msg, /'blue'/);
+  // ⚠️ prefix (issue #65): the reminder was read as informational and skimmed
+  // past; the warning glyph makes the accounts-don't-follow part land.
+  assert.match(msg, /\n⚠️ Heads-up:/u);
 });
 
 test("nativeConnectorsReminder stays silent when switching back to the default scope", () => {

--- a/scripts/lib/universes.test.mjs
+++ b/scripts/lib/universes.test.mjs
@@ -320,6 +320,61 @@ test("parseSwitchArgs: explicit create / switch / list / current verbs", () => {
   assert.deepEqual(parseSwitchArgs(["current"]), { action: "current" });
 });
 
+test("parseSwitchArgs keeps multi-word names intact, on every verb and on the bare path", () => {
+  // join("") survived on the explicit verb + bare paths (mutation pass, v4.9.1):
+  // "Blue Team" would silently become the DIFFERENT slug 'blueteam'.
+  assert.deepEqual(parseSwitchArgs(["switch", "Blue", "Team"]), { action: "switch", name: "Blue Team" });
+  assert.deepEqual(parseSwitchArgs(["create", "Blue", "Team"]), { action: "create", name: "Blue Team" });
+  assert.deepEqual(parseSwitchArgs(["Blue", "Team"]), { action: "switch", name: "Blue Team" });
+});
+
+test("addToRegistry returns a COPY even when it refuses (default or empty name)", () => {
+  // The refusal path returned [...registry]; a mutant returning [] would ERASE
+  // the caller's registry view on a no-op. Non-empty registry, both refusals.
+  const registry = ["acme"];
+  for (const refused of [DEFAULT_UNIVERSE, ""]) {
+    const out = addToRegistry(registry, refused);
+    assert.deepEqual(out, ["acme"]);
+    assert.notEqual(out, registry, "a fresh copy, not the same array");
+  }
+});
+
+test("readRegistry survives a CORRUPT registry file (malformed JSON → empty, not a crash)", () => {
+  const io = fakeFs({ [registryPath(DIR)]: "{ this is not json" });
+  assert.deepEqual(readRegistry(io, DIR), []);
+});
+
+test("readRegistry ignores a registry whose universes is not an array", () => {
+  const io = fakeFs({ [registryPath(DIR)]: JSON.stringify({ universes: "acme" }) });
+  assert.deepEqual(readRegistry(io, DIR), []);
+});
+
+test("writeRegistry writes pretty JSON with a trailing newline, byte for byte", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+  assert.equal(
+    io.files.get(registryPath(DIR)),
+    JSON.stringify({ universes: ["acme"] }, null, 2) + "\n"
+  );
+});
+
+test("switchToUniverse refuses a name that normalizes to empty", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+  assert.deepEqual(switchToUniverse(io, DIR, "!!"), { ok: false, reason: "empty" });
+});
+
+test("createAndSwitch on an existing universe does NOT rewrite the registry file", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+  const writesBefore = io.writes.filter((w) => w.path === registryPath(DIR)).length;
+
+  createAndSwitch(io, DIR, "acme");
+
+  const writesAfter = io.writes.filter((w) => w.path === registryPath(DIR)).length;
+  assert.equal(writesAfter, writesBefore, "an idempotent create must not touch the registry");
+});
+
 test("vaultRagDir joins the .vault-rag state dir onto the brain root", () => {
   assert.equal(vaultRagDir("/brain"), "/brain/.vault-rag");
 });
@@ -349,12 +404,19 @@ test("runSwitchCli create: registers, switches, exits 0, and gives the one-time 
 
   const res = runSwitchCli(io, DIR, ["create", "Acme"]);
 
-  assert.equal(res.code, 0);
-  assert.match(res.message, /created and switched to 'acme'/);
   // The FIRST created universe opens the gate → the CLI surfaces the onboarding
   // line deterministically (the skill relays it; the LLM never counts universes).
-  assert.match(res.message, /two universes/i);
-  assert.match(res.message, /all universes/i);
+  // Asserted WHOLE (mutation pass, v4.9.1): fragment matches let single clauses
+  // of the user-facing onboarding be blanked with the suite green.
+  assert.deepEqual(res, {
+    code: 0,
+    wrote: "acme",
+    message:
+      "created and switched to 'acme'\n" +
+      "You now have two universes. Searches stay in the active one plus your " +
+      'cross-cutting (default) notes; say "search all universes" to span them. ' +
+      "New notes you capture here will file under vault/acme/.",
+  });
   assert.equal(readActiveUniverse(io, DIR), "acme");
 });
 
@@ -364,9 +426,53 @@ test("runSwitchCli create of a SECOND universe: no onboarding line (gate already
 
   const res = runSwitchCli(io, DIR, ["create", "Blue"]);
 
-  assert.equal(res.code, 0);
-  assert.match(res.message, /created and switched to 'blue'/);
-  assert.doesNotMatch(res.message, /two universes/i);
+  // Exact equality: an appended stray suffix must fail this, not slip past a
+  // doesNotMatch on the onboarding fragment alone.
+  assert.deepEqual(res, { code: 0, message: "created and switched to 'blue'", wrote: "blue" });
+});
+
+test("runSwitchCli create of an EXISTING universe says switched, not created — exactly", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme", "blue"]);
+  writeActiveUniverse(io, DIR, "blue");
+
+  const res = runSwitchCli(io, DIR, ["create", "acme"]);
+
+  assert.deepEqual(res, { code: 0, message: "switched to 'acme'", wrote: "acme" });
+});
+
+test("runSwitchCli create with an unusable name says why, in full", () => {
+  const io = fakeFs();
+
+  assert.deepEqual(runSwitchCli(io, DIR, ["create", "!!"]), {
+    code: 1,
+    message: "cannot create universe (empty)",
+  });
+  assert.deepEqual(runSwitchCli(io, DIR, ["create", "Default"]), {
+    code: 1,
+    message: "cannot create universe (reserved)",
+  });
+});
+
+test("runSwitchCli with no args prints the whole menu: active + available", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+  writeActiveUniverse(io, DIR, "acme");
+
+  assert.deepEqual(runSwitchCli(io, DIR, []), {
+    code: 0,
+    message: "active: acme\navailable: default, acme",
+  });
+});
+
+test("runSwitchCli explicit switch with NO name says so, in full", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+
+  assert.deepEqual(runSwitchCli(io, DIR, ["switch"]), {
+    code: 1,
+    message: "no universe name given",
+  });
 });
 
 test("runSwitchCli switch to an unknown universe exits 1 and lists the available ones", () => {

--- a/scripts/lib/universes.test.mjs
+++ b/scripts/lib/universes.test.mjs
@@ -426,6 +426,26 @@ test("runSwitchCli list marks the active universe among all", () => {
   assert.match(res.message, / {2}default/);
 });
 
+// The CLI's caller (set-active-universe.mjs) must commit+push a pointer write
+// (issue #69: a Bash-side write is invisible to the PostToolUse net), so the
+// result SAYS when — and what — was written, instead of the caller parsing prose.
+test("runSwitchCli reports the written slug so the caller can persist it", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+
+  assert.equal(runSwitchCli(io, DIR, ["Acme"]).wrote, "acme");
+  assert.equal(runSwitchCli(io, DIR, ["create", "Blue Team"]).wrote, "blue-team");
+});
+
+test("runSwitchCli reports no write on read-only commands and refused switches", () => {
+  const io = fakeFs();
+  writeRegistry(io, DIR, ["acme"]);
+
+  for (const argv of [["list"], ["current"], [], ["ghost"], ["create", "!!"]]) {
+    assert.equal(runSwitchCli(io, DIR, argv).wrote, undefined, JSON.stringify(argv));
+  }
+});
+
 // ── resolveActiveUniverse: the pointer can outlive the universe it names ──────
 // Pointer and registry are committed together, so an ordinary rename/delete can
 // no longer split them. But a pointer that names a universe which no longer

--- a/scripts/set-active-universe.mjs
+++ b/scripts/set-active-universe.mjs
@@ -8,8 +8,9 @@
 //   node scripts/set-active-universe.mjs create <name>     # create-and-switch
 //   node scripts/set-active-universe.mjs list | current    # inspect
 //
-// All logic + tests live in scripts/lib/universes.mjs; this file only wires the
-// real fs and prints the result. Natural-language "create a universe X" routes
+// All logic + tests live in scripts/lib/universes.mjs (+ universe-persist.mjs
+// for the commit+push of the written pointer); this file only wires the real fs
+// and git and prints the result. Natural-language "create a universe X" routes
 // here too, so there is ONE canonical, deterministic surface (ADR 0009).
 // ─────────────────────────────────────────────────────────────────────────────
 import {
@@ -18,8 +19,11 @@ import {
   writeFileSync,
   mkdirSync,
 } from "node:fs";
-import { runSwitchCli, vaultRagDir } from "./lib/universes.mjs";
+import { vaultRagDir } from "./lib/universes.mjs";
+import { runSwitchCliPersisted } from "./lib/universe-persist.mjs";
 import { isEntrypoint } from "./lib/entrypoint.mjs";
+import { buildGit, repoRoot } from "./auto-commit.mjs";
+import { realSleep } from "./auto-push.mjs";
 
 // The fs surface universes.mjs expects — readFileSync always as UTF-8 text.
 export const realIo = {
@@ -30,7 +34,12 @@ export const realIo = {
 };
 
 if (isEntrypoint(import.meta.url, process.argv[1])) {
-  const { code, message } = runSwitchCli(realIo, vaultRagDir(), process.argv.slice(2));
+  // Persisted variant (issue #69): a pointer write commits + pushes itself —
+  // written through Bash, it is invisible to the PostToolUse/Stop hook net.
+  const { code, message } = runSwitchCliPersisted(realIo, vaultRagDir(), process.argv.slice(2), {
+    git: buildGit(repoRoot(import.meta.url)),
+    sleep: realSleep,
+  });
   console.log(message);
   process.exit(code);
 }

--- a/scripts/set-active-universe.test.mjs
+++ b/scripts/set-active-universe.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { realIo } from "./set-active-universe.mjs";
@@ -48,6 +48,35 @@ test("realIo + real git: a switch commits the pointer it wrote", () => {
     assert.match(log, /auto: switch active universe to 'acme'/);
     assert.match(log, /\.vault-rag\/active-universe/);
     assert.match(log, /\.vault-rag\/universes\.json/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// Review finding (v4.9.1), proved here on REAL git because it is exactly the kind
+// of semantics a fake cannot vouch for: work the owner had STAGED before the
+// switch must neither ride along in the switch commit nor lose its staged state.
+test("realIo + real git: a switch leaves the owner's pre-staged work alone", () => {
+  const repo = mkdtempSync(join(tmpdir(), "universe-repo-"));
+  try {
+    const raw = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" });
+    raw(["init"]);
+    raw(["config", "user.email", "test@example.com"]);
+    raw(["config", "user.name", "Test"]);
+    writeFileSync(join(repo, "secret-draft.md"), "not the switch's business\n");
+    raw(["add", "secret-draft.md"]);
+
+    const res = runSwitchCliPersisted(realIo, join(repo, ".vault-rag"), ["create", "Acme"], {
+      git: buildGit(repo),
+      sleep: () => {},
+    });
+
+    assert.equal(res.code, 0);
+    const show = raw(["show", "--stat", "--format=%s", "HEAD"]);
+    assert.match(show, /auto: switch active universe to 'acme'/);
+    assert.doesNotMatch(show, /secret-draft\.md/);
+    // …and it is still exactly where the owner left it: staged, uncommitted.
+    assert.match(raw(["diff", "--cached", "--name-only"]), /secret-draft\.md/);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/set-active-universe.test.mjs
+++ b/scripts/set-active-universe.test.mjs
@@ -1,13 +1,30 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, cpSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import { realIo } from "./set-active-universe.mjs";
 import { runSwitchCli, readActiveUniverse, readRegistry } from "./lib/universes.mjs";
-import { runSwitchCliPersisted } from "./lib/universe-persist.mjs";
+import {
+  runSwitchCliPersisted,
+  SWITCH_NOT_COMMITTED_WARNING,
+} from "./lib/universe-persist.mjs";
+import { PUSH_FAILED_WARNING } from "./auto-push.mjs";
 import { buildGit } from "./auto-commit.mjs";
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+
+// A throwaway git repo with an identity, so commits are accepted deterministically.
+function tempGitRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "universe-repo-"));
+  const raw = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" });
+  raw(["init"]);
+  raw(["config", "user.email", "test@example.com"]);
+  raw(["config", "user.name", "Test"]);
+  return { repo, raw };
+}
 
 // Proves the REAL fs adapter (realIo) — not the in-memory fake — actually creates
 // the .vault-rag dir, writes the registry + pointer and reads them back. Uses a
@@ -30,20 +47,18 @@ test("realIo: create-and-switch round-trips through the real filesystem", () => 
 // REAL repo leaves a commit containing the pointer — it no longer survives as a
 // dirty file waiting for a sweep that may lose to another machine's stale state.
 test("realIo + real git: a switch commits the pointer it wrote", () => {
-  const repo = mkdtempSync(join(tmpdir(), "universe-repo-"));
+  const { repo, raw } = tempGitRepo();
   try {
-    const raw = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" });
-    raw(["init"]);
-    raw(["config", "user.email", "test@example.com"]);
-    raw(["config", "user.name", "Test"]);
-
     const res = runSwitchCliPersisted(realIo, join(repo, ".vault-rag"), ["create", "Acme"], {
       git: buildGit(repo),
       sleep: () => {},
     });
 
     assert.equal(res.code, 0);
-    assert.doesNotMatch(res.message, /⚠️/u); // no remote → push skipped, silently
+    // No PERSISTENCE noise (no remote → push skipped, silently); asserted by
+    // content, not by glyph — the connectors reminder owns a ⚠️ of its own.
+    assert.ok(!res.message.includes(SWITCH_NOT_COMMITTED_WARNING));
+    assert.ok(!res.message.includes(PUSH_FAILED_WARNING));
     const log = raw(["log", "--stat", "--format=%s"]);
     assert.match(log, /auto: switch active universe to 'acme'/);
     assert.match(log, /\.vault-rag\/active-universe/);
@@ -54,17 +69,19 @@ test("realIo + real git: a switch commits the pointer it wrote", () => {
 });
 
 // Review finding (v4.9.1), proved here on REAL git because it is exactly the kind
-// of semantics a fake cannot vouch for: work the owner had STAGED before the
-// switch must neither ride along in the switch commit nor lose its staged state.
-test("realIo + real git: a switch leaves the owner's pre-staged work alone", () => {
-  const repo = mkdtempSync(join(tmpdir(), "universe-repo-"));
+// of semantics a fake cannot vouch for: work the owner had STAGED, MODIFIED or
+// merely left UNTRACKED before the switch must neither ride along in the switch
+// commit nor change state.
+test("realIo + real git: a switch leaves the owner's pending work alone (staged, dirty, untracked)", () => {
+  const { repo, raw } = tempGitRepo();
   try {
-    const raw = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" });
-    raw(["init"]);
-    raw(["config", "user.email", "test@example.com"]);
-    raw(["config", "user.name", "Test"]);
+    writeFileSync(join(repo, "tracked.md"), "v1\n");
+    raw(["add", "tracked.md"]);
+    raw(["commit", "-m", "seed"]);
+    writeFileSync(join(repo, "tracked.md"), "v2, not yet committed\n"); // dirty
     writeFileSync(join(repo, "secret-draft.md"), "not the switch's business\n");
-    raw(["add", "secret-draft.md"]);
+    raw(["add", "secret-draft.md"]); // staged
+    writeFileSync(join(repo, "scratch.md"), "untracked\n"); // untracked
 
     const res = runSwitchCliPersisted(realIo, join(repo, ".vault-rag"), ["create", "Acme"], {
       git: buildGit(repo),
@@ -74,9 +91,41 @@ test("realIo + real git: a switch leaves the owner's pre-staged work alone", () 
     assert.equal(res.code, 0);
     const show = raw(["show", "--stat", "--format=%s", "HEAD"]);
     assert.match(show, /auto: switch active universe to 'acme'/);
-    assert.doesNotMatch(show, /secret-draft\.md/);
-    // …and it is still exactly where the owner left it: staged, uncommitted.
-    assert.match(raw(["diff", "--cached", "--name-only"]), /secret-draft\.md/);
+    assert.doesNotMatch(show, /tracked\.md|secret-draft\.md|scratch\.md/);
+    // …and everything is still exactly where the owner left it.
+    const status = raw(["status", "--porcelain"]);
+    assert.match(status, /^A {2}secret-draft\.md$/m);
+    assert.match(status, /^ M tracked\.md$/m);
+    assert.match(status, /^\?\? scratch\.md$/m);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// The BLOCKER of the test review: nothing exercised the production wiring, so
+// reverting the entry point to the pre-fix, non-persisting runSwitchCli left the
+// whole suite green. This spawns the REAL script (the scripts/ tree is copied so
+// its module-anchored brain root lands on the throwaway repo) and requires the
+// commit — the exact regression this branch exists to prevent.
+test("the REAL entry point persists: spawning set-active-universe.mjs commits the switch", () => {
+  const { repo, raw } = tempGitRepo();
+  try {
+    cpSync(SCRIPTS_DIR, join(repo, "scripts"), { recursive: true });
+
+    const out = execFileSync(
+      process.execPath,
+      [join(repo, "scripts", "set-active-universe.mjs"), "create", "Acme"],
+      { cwd: repo, encoding: "utf8" }
+    );
+
+    assert.match(out, /created and switched to 'acme'/);
+    const log = raw(["log", "--stat", "--format=%s"]);
+    assert.match(log, /auto: switch active universe to 'acme'/);
+    assert.match(log, /\.vault-rag\/active-universe/);
+    assert.equal(
+      readFileSync(join(repo, ".vault-rag", "active-universe"), "utf8").trim(),
+      "acme"
+    );
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/set-active-universe.test.mjs
+++ b/scripts/set-active-universe.test.mjs
@@ -1,10 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { realIo } from "./set-active-universe.mjs";
 import { runSwitchCli, readActiveUniverse, readRegistry } from "./lib/universes.mjs";
+import { runSwitchCliPersisted } from "./lib/universe-persist.mjs";
+import { buildGit } from "./auto-commit.mjs";
 
 // Proves the REAL fs adapter (realIo) — not the in-memory fake — actually creates
 // the .vault-rag dir, writes the registry + pointer and reads them back. Uses a
@@ -20,5 +23,32 @@ test("realIo: create-and-switch round-trips through the real filesystem", () => 
     assert.equal(readActiveUniverse(realIo, dir), "acme-corp");
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The reported case of issue #69, end to end minus the argv shim: a switch on a
+// REAL repo leaves a commit containing the pointer — it no longer survives as a
+// dirty file waiting for a sweep that may lose to another machine's stale state.
+test("realIo + real git: a switch commits the pointer it wrote", () => {
+  const repo = mkdtempSync(join(tmpdir(), "universe-repo-"));
+  try {
+    const raw = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" });
+    raw(["init"]);
+    raw(["config", "user.email", "test@example.com"]);
+    raw(["config", "user.name", "Test"]);
+
+    const res = runSwitchCliPersisted(realIo, join(repo, ".vault-rag"), ["create", "Acme"], {
+      git: buildGit(repo),
+      sleep: () => {},
+    });
+
+    assert.equal(res.code, 0);
+    assert.doesNotMatch(res.message, /⚠️/u); // no remote → push skipped, silently
+    const log = raw(["log", "--stat", "--format=%s"]);
+    assert.match(log, /auto: switch active universe to 'acme'/);
+    assert.match(log, /\.vault-rag\/active-universe/);
+    assert.match(log, /\.vault-rag\/universes\.json/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
**The defect (issue #69, measured with a timeline on a real brain).** `/switch` writes the active-universe
pointer (`.vault-rag/active-universe`) through Bash, so neither half of the persistence net saw it:
`auto-commit.mjs` matches `Write|Edit` only, and the `Stop` hook was push-only. The switch survived as a
dirty file — close the laptop and it never left the machine — and worse, a second machine's session-start
sweep could commit its own **stale** pointer first, so the older universe silently won. That holes
v4.9.0's headline promise, *"the universe travels with you"*.

### What is in here

- **The reported case**: the switch persists itself (`scripts/lib/universe-persist.mjs`) — commit scoped
  by pathspec to `.vault-rag/` so anything staged stays staged, then push through the same opt-in path
  as every other push. Failure is loud.
- **The class**: the `Stop` hook is now **sweep-commit then push**, so any out-of-band engine write
  leaves the machine at the end of the turn instead of waiting for the next session's sweep.
- **Deliberately not shipped**: a guard against committing a pointer that is behind the remote —
  deferred in writing, because the two fixes above remove the window it would have protected and the
  residual case already stops loudly on a rebase conflict.
- **Riders**: auto-compact window default 350k → 450k in the settings template (new brains only), and a
  `⚠️` on the native-connectors reminder.
- **Docs**: SETUP's persistence contract (the §10 marketing re-read's single finding), ADR 0018
  amended in place, engine version vector `scripts` 1.13.0 → 1.13.1.

### Quality

Three independent adversarial reviews ran on this diff before the tag (git semantics, fleet deployment
through the update regimes, test quality); what they raised was fixed here. The most useful demanded a
test running the real `/switch` entry point in a subprocess — which immediately showed a brain reached
through a **symlinked path** ran the switch *without* persisting it.

Mutation, three passes (production moved twice), pinned in `maintainers/mutation/RESULTS.md` § v4.9.1:
the two files this release **wrote** end at **100 %**, the CLI wiring no test imported goes
**25 % → 100 %**, the four others land at **95.92–99.66 %**, and every survivor left is a named
equivalent. Harness suite: 1714 pass, 0 fail.

Closes #69
Closes #63
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)