### PR TITLE
ci(mutation): the nightly clones the whole history, so the score can be measured at all

### DIFF
--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -54,7 +54,15 @@ jobs:
           - package: scripts
             extra: "--inPlace"
     steps:
+      # fetch-depth: 0 — the suites under mutation assert against REAL git history:
+      # the QA fixtures replay a brain from tag v3.6.0, one test checks that every
+      # waived sha is still reachable, and the manifest-integrity checks walk
+      # `git ls-files`. A shallow, tagless clone fails them in Stryker's own initial
+      # test run, before a single mutant, so the job reports a truncated checkout and
+      # never a score. Every ci.yml job running these suites pins the same thing.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node 24
         uses: actions/setup-node@v4

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -153,20 +153,39 @@ _(That plan is archived; these came here so it could close. They belong to no mi
       that legitimately customizes an engine skill? Correct the first time, noise the tenth. Only
       living with it for a few days answers it, and the escape hatch (`/permissions`) already exists.
       **Nothing to build; something to notice.**
-- [x] **The nightly mutation run on `main` fails every night, and the cause is a missing checkout
-      line** _(read 2026-09-02; it had gone unread since 2026-08-22)_. Every scheduled run listed
-      still fails, back to 2026-08-26 at least. Only `mutate · scripts` is red — `rag` and
-      `local-mirror` pass — and it dies in Stryker's **initial test run, before a single mutant**,
-      on the tests that need real git history: the QA fixtures that replay from tag `v3.6.0`, the
-      one asserting every waived sha is still reachable, the release-table and manifest integrity
-      checks. `.github/workflows/mutation-nightly.yml` checks out with **`actions/checkout@v4` and
-      no `fetch-depth`** (shallow, no tags), while every `ci.yml` job running that same suite pins
-      **`fetch-depth: 0`**. So the score has been unmeasured for a fortnight and the job is not
-      reporting a weak suite, it is reporting a truncated clone.
-- [ ] **The fix, not yet applied**: add `with: fetch-depth: 0` to the nightly's checkout, dispatch
-      the workflow by hand, and confirm the `scripts` score comes back honest before trusting the
-      cron again. Left for the owner to schedule: it touches CI on `main`, and the chantier open at
-      the time (#84) had a standing instruction not to take on adjacent work.
+- [x] **The nightly mutation run on `main` fails every night, and it has TWO causes, not one**
+      _(read at last 2026-09-02; unread since 2026-08-22)_. Every scheduled run still fails, back to
+      2026-08-26 at least. Only `mutate · scripts` is red (`rag` and `local-mirror` pass), and it
+      dies in Stryker's **initial test run, before a single mutant** — so the job has never been
+      reporting a weak suite, it has been reporting an environment it cannot run in. Eight tests
+      failed; the two causes split them four and four.
+  - [x] **Cause 1, a truncated clone — fixed, PR [#85](https://github.com/tpierrain/kenjaku/pull/85).**
+        `mutation-nightly.yml` checked out with bare `actions/checkout@v4` (shallow, no tags) while
+        every `ci.yml` job running these same suites pins `fetch-depth: 0`. Four of the eight need
+        real history: the QA fixtures replaying a brain from tag `v3.6.0` (EN, FR and the CRLF one)
+        and `every waived sha is a real commit that is still reachable`. A hand-dispatched run on
+        the fix branch confirms it: **8 failures → 4**.
+  - [ ] **Cause 2, source-scanning guards versus instrumentation — DIAGNOSED, NOT FIXED, and it is
+        a design call.** _Reproduced locally 2026-09-02 in a throwaway worktree off `main`, so it is
+        measured and not inferred._ Four tests do not test behaviour at all, they **read the engine's
+        own source text**: the byte fingerprints of a release's merge files, `every script an engine
+        script SPAWNS is itself carried`, `no module composes a child-process request at the call
+        site`, and the byte-dated doctrine fixture. Stryker's whole job is to **rewrite that source
+        text** to inject mutants (157 files, 9 833 mutants), so those four fail under **every**
+        configuration: `--inPlace` as CI runs it (4 fail), the `batch` config (3), and the committed
+        sandbox config is worse (8 — it also lacks `.git`). ⚠️ Which means the note in
+        `stryker.scripts.batch.config.mjs` saying *"the whole harness suite dry-runs green here"* is
+        **stale**: it was true on 2026-07-28, before these guards were written.
+    - [ ] **The evidence for whatever gets chosen**: skipping exactly those four by name makes the
+          dry run pass in CI's own shape (verified with a throwaway probe config). So the run is
+          four skips away from producing a score again.
+    - [ ] **Option A, ten minutes**: skip them by name from the mutation command. Brittle — a
+          renamed test silently un-skips — but the failure is loud, not silent.
+    - [ ] **Option B, recommended**: each guard **detects an instrumented tree and skips itself,
+          naming why**. It survives renames, and it puts the reason where a reader will look instead
+          of in a CI flag. Costs four test files and their own tests, test-first.
+    - [ ] Either way, dispatch the workflow by hand afterwards and read the score before the cron is
+          trusted again — that was the rollout condition when this workflow was written.
 
 ## How each release is cut, when it gets there
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -153,9 +153,20 @@ _(That plan is archived; these came here so it could close. They belong to no mi
       that legitimately customizes an engine skill? Correct the first time, noise the tenth. Only
       living with it for a few days answers it, and the escape hatch (`/permissions`) already exists.
       **Nothing to build; something to notice.**
-- [ ] **The nightly mutation run on `main` has failed two nights** (2026-08-22, 2026-08-23) and nobody
-      has read it. Pre-existing, unrelated to the cut — and unread CI is the exact shape that cost
-      this project three hours on 2026-08-23. Read it before anything else in this section.
+- [x] **The nightly mutation run on `main` fails every night, and the cause is a missing checkout
+      line** _(read 2026-09-02; it had gone unread since 2026-08-22)_. Every scheduled run listed
+      still fails, back to 2026-08-26 at least. Only `mutate · scripts` is red — `rag` and
+      `local-mirror` pass — and it dies in Stryker's **initial test run, before a single mutant**,
+      on the tests that need real git history: the QA fixtures that replay from tag `v3.6.0`, the
+      one asserting every waived sha is still reachable, the release-table and manifest integrity
+      checks. `.github/workflows/mutation-nightly.yml` checks out with **`actions/checkout@v4` and
+      no `fetch-depth`** (shallow, no tags), while every `ci.yml` job running that same suite pins
+      **`fetch-depth: 0`**. So the score has been unmeasured for a fortnight and the job is not
+      reporting a weak suite, it is reporting a truncated clone.
+- [ ] **The fix, not yet applied**: add `with: fetch-depth: 0` to the nightly's checkout, dispatch
+      the workflow by hand, and confirm the `scripts` score comes back honest before trusting the
+      cron again. Left for the owner to schedule: it touches CI on `main`, and the chantier open at
+      the time (#84) had a standing instruction not to take on adjacent work.
 
 ## How each release is cut, when it gets there
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -165,27 +165,34 @@ _(That plan is archived; these came here so it could close. They belong to no mi
         real history: the QA fixtures replaying a brain from tag `v3.6.0` (EN, FR and the CRLF one)
         and `every waived sha is a real commit that is still reachable`. A hand-dispatched run on
         the fix branch confirms it: **8 failures → 4**.
-  - [ ] **Cause 2, source-scanning guards versus instrumentation — DIAGNOSED, NOT FIXED, and it is
-        a design call.** _Reproduced locally 2026-09-02 in a throwaway worktree off `main`, so it is
-        measured and not inferred._ Four tests do not test behaviour at all, they **read the engine's
-        own source text**: the byte fingerprints of a release's merge files, `every script an engine
-        script SPAWNS is itself carried`, `no module composes a child-process request at the call
-        site`, and the byte-dated doctrine fixture. Stryker's whole job is to **rewrite that source
-        text** to inject mutants (157 files, 9 833 mutants), so those four fail under **every**
-        configuration: `--inPlace` as CI runs it (4 fail), the `batch` config (3), and the committed
-        sandbox config is worse (8 — it also lacks `.git`). ⚠️ Which means the note in
-        `stryker.scripts.batch.config.mjs` saying *"the whole harness suite dry-runs green here"* is
-        **stale**: it was true on 2026-07-28, before these guards were written.
-    - [ ] **The evidence for whatever gets chosen**: skipping exactly those four by name makes the
-          dry run pass in CI's own shape (verified with a throwaway probe config). So the run is
-          four skips away from producing a score again.
-    - [ ] **Option A, ten minutes**: skip them by name from the mutation command. Brittle — a
-          renamed test silently un-skips — but the failure is loud, not silent.
-    - [ ] **Option B, recommended**: each guard **detects an instrumented tree and skips itself,
-          naming why**. It survives renames, and it puts the reason where a reader will look instead
-          of in a CI flag. Costs four test files and their own tests, test-first.
-    - [ ] Either way, dispatch the workflow by hand afterwards and read the score before the cron is
-          trusted again — that was the rollout condition when this workflow was written.
+  - [x] **Cause 2, source-scanning guards versus instrumentation — FIXED** _(the owner picked
+        option B, 2026-09-02; commits on the same PR)_. Four tests do not test behaviour at all,
+        they **read the engine's own source text**: the byte fingerprints of a release's merge
+        files, `every script an engine script SPAWNS is itself carried`, `no module composes a
+        child-process request at the call site`, and the byte-dated doctrine fixture. Stryker's
+        whole job is to **rewrite that source text** to inject mutants (157 files, 9 833 mutants),
+        so those four failed under **every** configuration tried: `--inPlace` as CI runs it (4
+        fail), the `batch` config (3), and the committed sandbox config worst of all (8 — it also
+        lacks `.git`).
+    - [x] **What was built**: `scripts/lib/instrumented-source.mjs` answers one question — has this
+          text been rewritten by the runner — and each guard asks it about the very files it is
+          about to read, standing down with a sentence that says so. Neither a false red nor a
+          silent green, and it survives a rename, which a skip-by-name would not.
+    - [x] **The trap it was written around, and it fired**: the detector is itself engine source,
+          read by the guards it protects, so a detector matching the bare word would silence all
+          four on a clean checkout with nothing to see. It matches the runner's HASHED identifiers,
+          its own test pins that — and caught the module's own doc comment before the wiring
+          existed.
+    - [x] **Verified in CI's exact shape**: `--inPlace`, full scope, in a throwaway worktree —
+          *"Initial test run succeeded … the dry-run has been completed successfully"*. The nightly
+          can produce a score again.
+    - [ ] **What is left, and it is the owner's**: merge PR #85, then **dispatch the workflow by
+          hand and read the score** before the cron is trusted again — that was the rollout
+          condition when this workflow was written, and no session should declare it met.
+    - [ ] ⚠️ **A stale note to correct while nearby**: `stryker.scripts.batch.config.mjs` says
+          *"the whole harness suite dry-runs green here"*. It was true on 2026-07-28, before these
+          guards were written; it is now true again for a different reason, and the comment
+          explains neither.
 
 ## How each release is cut, when it gets there
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -30,6 +30,11 @@
   `templates/fr/**`, or write into either of his two real brains.
 - **One tidy-up is decided and NOT done** — § *The fold that is owed*. Five minutes of editing; it
   belongs to whoever opens v5.2's universe group.
+- 🙋 **ONE THING WAITS ON THE OWNER AND ON NOBODY ELSE** _(2026-09-02)_: **merge
+  [PR #85](https://github.com/tpierrain/kenjaku/pull/85), then dispatch the nightly mutation
+  workflow by hand and READ the score.** Both causes of its fortnight of red are fixed and verified
+  in CI's own shape (§ *Inherited from v5.0.0*), but "dispatch and read before trusting the cron"
+  is the rollout condition that workflow was written with, and no session may declare it met.
 
 > **The two-release split is the owner's, 2026-08-23**: *« ce serait bien de faire une petite issue
 > pour bug fixer les issues remontées par Stefan ces prochains jours (une 5.1), puis de traiter les

--- a/scripts/lib/engine-fingerprints.test.mjs
+++ b/scripts/lib/engine-fingerprints.test.mjs
@@ -9,6 +9,7 @@ import { fingerprint } from "./engine-source.mjs";
 import { deliveredSources } from "./engine-fingerprint-table.mjs";
 import { isStrayArtifactRel } from "./engine-base.mjs";
 import { parseLsFilesEolZ } from "./tracked-files.mjs";
+import { instrumentationStandDown } from "./instrumented-source.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // THE FRESHNESS GUARD on `scripts/lib/engine-fingerprints.json` (plan S7-2).
@@ -48,8 +49,15 @@ const git = (args) => execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf
 const trackedFiles = git(["ls-files"]).split("\n").filter(Boolean);
 const eolByPath = parseLsFilesEolZ(git(["ls-files", "--eol", "-z"]));
 
-test("the table covers every merge file of the release being cut, in every locale", () => {
-  const uncovered = deliveredSources({ manifest, sourceFiles: trackedFiles, eolByPath, read })
+test("the table covers every merge file of the release being cut, in every locale", (t) => {
+  const delivered = deliveredSources({ manifest, sourceFiles: trackedFiles, eolByPath, read });
+
+  // A fingerprint IS the bytes: under a mutation run the bytes on disk are the
+  // runner's, not the release's, and every row would read as missing.
+  const standDown = instrumentationStandDown(delivered.map(({ sourcePath, content }) => ({ name: sourcePath, source: content })));
+  if (standDown) return t.skip(standDown);
+
+  const uncovered = delivered
     .filter(({ content, rel }) => !(fingerprint(content) in (table.files?.[rel] ?? {})))
     .map(({ sourcePath }) => sourcePath);
 

--- a/scripts/lib/engine-manifest-integrity.test.mjs
+++ b/scripts/lib/engine-manifest-integrity.test.mjs
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 
 import { matchesAny } from "./glob-match.mjs";
 import { selectModulesToCheck } from "./health-activation.mjs";
+import { instrumentationStandDown } from "./instrumented-source.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // engine-manifest integrity — a structural guard over the REAL repo-root
@@ -321,10 +322,17 @@ const spawnedScriptsIn = (files) => [
   ),
 ].sort();
 
-test("engine-manifest — every script an engine script SPAWNS is itself carried (a detached child fails silently)", () => {
+test("engine-manifest — every script an engine script SPAWNS is itself carried (a detached child fails silently)", (t) => {
   const carriedScripts = trackedFiles.filter(
     (file) => file.startsWith("scripts/") && file.endsWith(".mjs") && !file.endsWith(".test.mjs"),
   );
+
+  // The scan reads call sites out of the source text, and a mutation run rewrites
+  // every one of them: the scan comes back empty and reads as a defect.
+  const standDown = instrumentationStandDown(
+    carriedScripts.map((file) => ({ name: file, source: readFileSync(join(repoRoot, file), "utf8") })),
+  );
+  if (standDown) return t.skip(standDown);
 
   const spawned = spawnedScriptsIn(carriedScripts);
   assert.ok(

--- a/scripts/lib/entrypoint-discipline.test.mjs
+++ b/scripts/lib/entrypoint-discipline.test.mjs
@@ -9,6 +9,7 @@ import {
   hasEntrypointTail,
   findInlineInvocations,
 } from "./entrypoint-discipline.mjs";
+import { instrumentationStandDown } from "./instrumented-source.mjs";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // findHandRolledGuards — every spelling of "am I the entry point?" that is NOT
@@ -415,10 +416,15 @@ test("every top-level script has a test sibling (allowlist may only shrink)", ()
   );
 });
 
-test("no module composes a child-process request at the call site (allowlist may only shrink)", () => {
-  const offenders = allScriptModules()
-    .filter((f) => findInlineInvocations(readFileSync(f, "utf8")).length > 0)
-    .map(rel);
+test("no module composes a child-process request at the call site (allowlist may only shrink)", (t) => {
+  const modules = allScriptModules().map((f) => ({ name: rel(f), source: readFileSync(f, "utf8") }));
+
+  // Same reason as the spawn scan: this reads call sites, and a mutation run has
+  // rewritten every one of them, so every exemption would read as no longer needed.
+  const standDown = instrumentationStandDown(modules);
+  if (standDown) return t.skip(standDown);
+
+  const offenders = modules.filter(({ source }) => findInlineInvocations(source).length > 0).map(({ name }) => name);
 
   assert.deepEqual(
     offenders.filter((f) => !INLINE_INVOCATION_EXEMPT.has(f)),

--- a/scripts/lib/instrumented-source.mjs
+++ b/scripts/lib/instrumented-source.mjs
@@ -1,0 +1,54 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// instrumented-source.mjs — telling the repository's own bytes from a mutation
+// runner's rewrite of them.
+//
+// A handful of this repo's guards do not test behaviour at all: they read the
+// ENGINE'S SOURCE TEXT and judge it (the byte fingerprints of a release's merge
+// files, which scripts spawn which, which modules still compose a child-process
+// request at the call site). Mutation testing's whole job is to rewrite that same
+// text — 157 files, ~10 000 mutants — so under a mutation run those guards are
+// reading a copy that is not the repository's, and they fail saying so in terms
+// that read exactly like a real defect.
+//
+// It has cost real time: the nightly whole-engine measurement failed every night
+// from 2026-08-22, and half of what it reported was this (the other half a shallow
+// clone). A guard cannot be right about text that has been rewritten underneath it,
+// so it stands down and SAYS SO, which is the one outcome that is neither a false
+// red nor a silent green.
+//
+// The detector matches the runner's HASHED identifiers, never the bare word: this
+// module is itself engine source, read by the very guards it protects, and a
+// detector that fired on prose about instrumentation would silence all of them on a
+// clean checkout with nothing at all to see. Its own test pins that.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * What StrykerJS injects into every file it instruments: a namespace, a coverage
+ * recorder and the mutant switch, each suffixed with the run's hash — `stryNS_`
+ * followed by five hex digits. All three, because a file can carry one without the
+ * others. And written here WITHOUT its hash on purpose: spelled in full, this very
+ * comment would match, and the detector would report itself. Its test pins that.
+ */
+const MARKER = /\bstry(?:NS|Cov|MutAct)_[0-9a-f]{4,}\b/;
+
+/** Has this text been rewritten by the mutation runner? */
+export function isInstrumented(source) {
+  return typeof source === "string" && MARKER.test(source);
+}
+
+/**
+ * Why a source-reading guard must stand down, or `null` when it may judge.
+ *
+ * @param {Array<{name: string, source: string}>} entries the texts the guard is about to read
+ * @returns {string | null} a sentence for `t.skip(...)`, naming the rewritten files
+ */
+export function instrumentationStandDown(entries) {
+  const rewritten = entries.filter(({ source }) => isInstrumented(source)).map(({ name }) => name);
+  if (rewritten.length === 0) return null;
+  return (
+    "the mutation runner has rewritten the engine's source text " +
+    `(${rewritten.join(", ")}), and this guard judges source text: it cannot tell the ` +
+    "repository's bytes from an instrumented copy of them, so it stands down rather than " +
+    "report a defect that is not there"
+  );
+}

--- a/scripts/lib/instrumented-source.test.mjs
+++ b/scripts/lib/instrumented-source.test.mjs
@@ -1,0 +1,75 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// instrumented-source.test.mjs — the detector that lets a source-reading guard
+// tell the repository's bytes from a mutation runner's rewrite of them.
+// ─────────────────────────────────────────────────────────────────────────────
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { instrumentationStandDown, isInstrumented } from "./instrumented-source.mjs";
+
+const PLAIN = `import { join } from "node:path";\nexport const go = () => join("a", "b");\n`;
+
+test("plain engine source is not instrumented, and asks no guard to stand down", () => {
+  assert.equal(isInstrumented(PLAIN), false);
+  assert.equal(instrumentationStandDown([{ name: "scripts/a.mjs", source: PLAIN }]), null);
+});
+
+// Three markers, because Stryker emits three and a detector that knows only the
+// famous one is blind to the file that happens to carry the other two.
+test("each of the runner's three markers is recognised on its own", () => {
+  const markers = {
+    "the mutant switch": `if (stryMutAct_9fa48("12")) {}`,
+    "the coverage recorder": `stryCov_9fa48("7");`,
+    "the namespace it declares": `var stryNS_9fa48 = {};`,
+  };
+  for (const [what, source] of Object.entries(markers)) {
+    assert.equal(isInstrumented(source), true, `${what} means the text was rewritten`);
+  }
+});
+
+// The trap this detector exists inside: it is itself engine source, read by the very
+// guards it protects. A detector that matched the bare word would fire on every file
+// that TALKS about instrumentation — starting with its own — and silence all four
+// guards for good, on a clean checkout, with nothing to see.
+test("the bare word is not the marker: only the runner's hashed identifiers count", () => {
+  assert.equal(isInstrumented("// stryMutAct_ is what the mutation runner injects"), false);
+  assert.equal(isInstrumented("const name = 'stryNS_' + suffix;"), false);
+});
+
+test("this module's own source does not trip its own detector", () => {
+  const own = readFileSync(fileURLToPath(new URL("./instrumented-source.mjs", import.meta.url)), "utf8");
+  assert.equal(isInstrumented(own), false, "a detector that fires on itself silences every guard that consults it");
+});
+
+test("the stand-down names every rewritten file, and no clean one", () => {
+  const reason = instrumentationStandDown([
+    { name: "scripts/z.mjs", source: `stryCov_9fa48("1");` },
+    { name: "scripts/clean.mjs", source: PLAIN },
+    { name: "scripts/a.mjs", source: `if (stryMutAct_9fa48("2")) {}` },
+  ]);
+
+  assert.match(reason, /scripts\/z\.mjs/);
+  assert.match(reason, /scripts\/a\.mjs/);
+  assert.doesNotMatch(reason, /scripts\/clean\.mjs/, "a file that was not rewritten is not evidence of anything");
+});
+
+// A skip message nobody understands is a skip nobody questions: the sentence has to
+// say what happened and why judging is impossible, not merely that it gave up.
+test("the stand-down says what happened, so a reader is not left guessing why a guard went quiet", () => {
+  const reason = instrumentationStandDown([{ name: "scripts/a.mjs", source: `var stryNS_9fa48 = {};` }]);
+  assert.match(reason, /mutation/i);
+  assert.match(reason, /source text/i);
+});
+
+test("nothing to judge is not a reason to stand down", () => {
+  assert.equal(instrumentationStandDown([]), null);
+});
+
+test("an unreadable or empty source is not instrumented, and never throws", () => {
+  for (const source of ["", null, undefined]) {
+    assert.equal(isInstrumented(source), false, `${JSON.stringify(source)} carries no marker`);
+  }
+  assert.equal(instrumentationStandDown([{ name: "scripts/a.mjs", source: null }]), null);
+});

--- a/scripts/lib/instrumented-source.test.mjs
+++ b/scripts/lib/instrumented-source.test.mjs
@@ -5,6 +5,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { instrumentationStandDown, isInstrumented } from "./instrumented-source.mjs";
@@ -39,7 +40,19 @@ test("the bare word is not the marker: only the runner's hashed identifiers coun
 });
 
 test("this module's own source does not trip its own detector", () => {
-  const own = readFileSync(fileURLToPath(new URL("./instrumented-source.mjs", import.meta.url)), "utf8");
+  const onDisk = readFileSync(fileURLToPath(new URL("./instrumented-source.mjs", import.meta.url)), "utf8");
+
+  // Under a mutation run this very file is one of the rewritten ones, and reading it
+  // off disk would find the runner's markers rather than ours. The property being
+  // pinned is about the bytes we COMMIT, so in that case ask git for them — which
+  // keeps the assertion meaningful instead of standing it down into a tautology.
+  const own = isInstrumented(onDisk)
+    ? execFileSync("git", ["show", "HEAD:scripts/lib/instrumented-source.mjs"], {
+        cwd: fileURLToPath(new URL("../..", import.meta.url)),
+        encoding: "utf8",
+      })
+    : onDisk;
+
   assert.equal(isInstrumented(own), false, "a detector that fires on itself silences every guard that consults it");
 });
 

--- a/scripts/lib/release-fixture-doctrine.test.mjs
+++ b/scripts/lib/release-fixture-doctrine.test.mjs
@@ -62,6 +62,7 @@ import {
 // ancestor, which is exactly the tautology this repo's QA is built to avoid.
 import { readInstalledMergeFiles, syncBaseTree } from "./engine-base-fs.mjs";
 import { buildProvenance, fingerprint, reseedProvenance } from "./engine-source.mjs";
+import { instrumentationStandDown } from "./instrumented-source.mjs";
 
 const DOCTRINE = "CLAUDE.engine.md";
 const TAG = "v3.6.0";
@@ -270,6 +271,11 @@ const HOOK = "scripts/auto-commit.mjs";
 const HOOK_AT_TAG = () => readFileSync(join(FIXTURES, "blobs", TAG, HOOK), "utf8");
 
 test("QA v3.6.0 → HEAD — a frozen engine SCRIPT is healed too, and named by the tag its BYTES came from", async (t) => {
+  // The whole assertion is that the hook's CURRENT bytes are recognised by the
+  // fingerprint table. Under a mutation run they are the runner's bytes, in no row.
+  const standDown = instrumentationStandDown([{ name: HOOK, source: readRepo(HOOK) }]);
+  if (standDown) return t.skip(standDown);
+
   const { brainDir, manifest } = brainAtRelease(TAG, { edits: { [HOOK]: HOOK_AT_TAG() } });
   t.after(() => rmSync(brainDir, { recursive: true, force: true }));
   assert.equal(manifest.provenance?.[HOOK], undefined, "the frozen cohort again, on another family");


### PR DESCRIPTION
## What was wrong

The nightly mutation run on `main` has failed **every night since at least 2026-08-26** and had gone unread since 2026-08-22. The red says nothing about test quality: only `mutate · scripts` fails (`rag` and `local-mirror` pass), and it dies in **Stryker's initial test run, before a single mutant**. Eight tests failed, and they had **two independent causes**. This PR fixes both.

## Cause 1 — a truncated clone

`mutation-nightly.yml` checked out with bare `actions/checkout@v4` — shallow, no tags — while **every `ci.yml` job running those same suites already pins `fetch-depth: 0`**. Four of the eight failures need real git history: the QA fixtures that replay a brain from tag `v3.6.0` (EN, FR, and the CRLF-recorded one), and `every waived sha is a real commit that is still reachable`.

**Verified**: a hand-dispatched run took the `scripts` job from **8 failures to 4**.

## Cause 2 — source-scanning guards versus instrumentation

The remaining four are structural, and no checkout flag reaches them. Those tests do not exercise behaviour at all: they **read the engine's own source text** (the byte fingerprints of a release's merge files, `every script an engine script SPAWNS is itself carried`, `no module composes a child-process request at the call site`, and the byte-dated doctrine fixture). Stryker's whole job is to **rewrite that source text** — 157 files, 9 833 mutants — so those four failed under every configuration: `--inPlace` as CI runs it (4), the `batch` config (3), the committed sandbox config worst of all (8, since it also lacks `.git`).

`scripts/lib/instrumented-source.mjs` answers one question — has this text been rewritten by the mutation runner — and each guard asks it about the very files it is about to read, **standing down with a sentence that says so**. Neither a false red nor a silent green, and it survives a test being renamed, which skipping by name would not.

One detail is load-bearing rather than fussy: the detector matches the runner's **hashed** identifiers, never the bare word. The module is itself engine source, read by the guards it protects, so a detector that fired on prose about instrumentation would silence all four on a clean checkout with nothing at all to see. Its own test pins that — and caught exactly that case, on this file's own doc comment, before the wiring was written.

**Verified in CI's exact shape** (`--inPlace`, full scope, throwaway worktree): *"Initial test run succeeded … The dry-run has been completed successfully."*

## What is deliberately NOT done here

Merging this and then **dispatching the workflow by hand to read the score** is the rollout condition this workflow was written with. That belongs to a human, not to the session that wrote the fix.

⚠️ Note in passing: the comment in `stryker.scripts.batch.config.mjs` claiming *"the whole harness suite dry-runs green here"* is stale — true on 2026-07-28, before those guards existed. Left alone rather than half-corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117grTZwPKh8fwDLWWrG9tt