### PR TITLE
docs(duo): the page opens on the shape — one brain, one remote, two machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,8 +503,9 @@ since is merged around your words, or offered to you as a choice. It's run **as 
 brains **in real use**, every upgrade **tested against existing brains before it ships** (the migration
 path is a **release gate**). What you share is the **generator** — one brain each, by default, and
 never a space at a vendor's. Two people who *want* one brain between them can have it — that's **duo
-mode**, deliberate and with its perimeter written down ([the duo-mode page](docs/duo-mode.md)); a choice you make, not
-the shape you are put in. And you could walk away from this repo tomorrow without losing a thing.
+mode**: *one* brain, *one* private remote, two machines, deliberate and with its perimeter written down
+([the duo-mode page](docs/duo-mode.md) opens on the diagram of what crosses, in which direction and how
+often); a choice you make, not the shape you are put in. And you could walk away from this repo tomorrow without losing a thing.
 
 *The market landscape (Notion AI, Mem, Reflect, Tana, Obsidian plugins, Khoj, AnythingLLM, NotebookLM,
 Glean…) is situated in [EN-QUOI §9](EN-QUOI-C-EST-DIFFERENT.md#9-for-the-record--and-compared-to-the-market-apps).*

--- a/docs/duo-mode.md
+++ b/docs/duo-mode.md
@@ -10,6 +10,54 @@ controls access. If you read one line, read this one.
 > **Sharing a brain shares what you wrote down, not what you can see in your own tools**
 > (mail, messages, calendar, Drive).
 
+## The shape of it, before anything else
+
+**A duo is not two brains talking to each other. It is ONE brain, checked out on two machines**, with
+**exactly one** private repository in the middle. Same notes, same skills, same engine on both sides;
+the repository is the only thing that joins them, and it is the same one for both people.
+
+```
+                  ONE brain · ONE private remote · TWO machines
+
+      THE OWNER'S MAC                              THE OTHER PERSON'S MAC
+ ┌──────────────────────┐                        ┌──────────────────────┐
+ │  the brain (a clone) │                        │  the brain (a clone) │
+ │   vault/  the notes  │                        │   vault/  the notes  │
+ │   rag/    the search │                        │   rag/    the search │
+ │   skills/ the recipes│                        │   skills/ the recipes│
+ └──────────────────────┘                        └──────────────────────┘
+       push │        ▲ pull                pull ▲        │ push
+        (1) ▼        │ (2)                  (2) │        ▼ (1)
+        ┌──────────────────────────────────────────────────────┐
+        │     THE private repository — exactly one, shared     │
+        │   the same remote URL on both machines, and its      │
+        │   collaborator list IS the access control (§2, §7)   │
+        └──────────────────────────────────────────────────────┘
+
+  (1) push — once per turn, at the end of each exchange with your brain
+  (2) pull — every ~90 s, while a brain window is open (REMOTE_SYNC_INTERVAL)
+
+  never travels: .env · .mcp.json · .claude/settings.json (machine-local, and
+  rebuilt by `rehydrate.mjs`) — and everything outside the vault: mail, DMs,
+  the workspaces only one of the two accounts belongs to.
+```
+
+Four things that diagram is there to settle:
+
+- **One remote, and only one.** The person joining **clones the owner's repository**; they never
+  create a second one, and they never run the installer (that would make a brand-new empty brain
+  standing beside the first). Two repositories is not a duo: it is two brains drifting apart, and
+  nothing will ever tell you they diverged.
+- **Sending happens once per turn.** At the end of each exchange with your brain, that turn's commits
+  are bundled and pushed. A failed push is not blocking, and is retried at the next turn. It requires
+  `git config secondbrain.autopush true` — without it, a brain commits locally and sends nothing.
+- **Receiving happens on a timer**: while a brain window is open, each machine checks about every
+  **90 seconds** whether the other one pushed, brings in what it finds, indexes it, and tells you at
+  your next message. Set `REMOTE_SYNC_INTERVAL` (seconds) in `.env` to change the cadence. It ticks
+  only while a window is open — this is not a background daemon, and nothing syncs overnight.
+- **Both directions are the same mechanism**, so there is no "main" machine and no "copy": whoever
+  writes, pushes; whoever has a window open, pulls. The two brains are peers.
+
 ---
 
 ## 1. What travels, and what does not

--- a/maintainers/plans/prospective/release-v5.1.0-note.md
+++ b/maintainers/plans/prospective/release-v5.1.0-note.md
@@ -66,6 +66,20 @@ A second brain has always been one person's. The moment someone else worked in i
 
 **Duo mode — when two of you work in one brain.** Nothing to turn on: your brain notices on its own that a second name is writing here — and rather than decide what that means, it asks you.
 
+**And what that means, in one picture.** Not two brains talking to each other: *one* brain, living on two machines, with **exactly one** private repository in the middle. Whoever writes sends at the end of their turn; whoever has a window open receives about every ninety seconds.
+
+```
+   THE OWNER'S MAC                              THE OTHER PERSON'S MAC
+   the brain (a clone)                          the brain (a clone)
+           │  ▲                                      ▲  │
+     push  │  │ pull                            pull │  │  push
+  once per │  │ every ~90 s              every ~90 s │  │  once per
+      turn ▼  │                                      │  ▼  turn
+        ┌────────────────────────────────────────────────┐
+        │      ONE private repository, shared by both    │
+        └────────────────────────────────────────────────┘
+```
+
 - 🙋 **It asks instead of assuming, because it cannot tell.** Your two computers may spell your name slightly differently, and from the inside that looks exactly like a colleague. So your brain puts the question to you once — *someone else, or you on another machine?* — and remembers your answer on both computers. Say it is you, and nothing of yours is ever filed apart.
 - 👥 **The same thing captured twice is stored once.** You and a colleague both come out of the same meeting and both ask your brain to keep it: it recognises that it already holds that source, and does not write a second copy.
 - 📆 **You both keep writing on the same day without colliding.** Two people's write-ups of the same day become one note each rather than one contested file.


### PR DESCRIPTION
## Why

The duo-mode page explained **what travels** before it ever said **what the thing is**. The misreading
that invites is the expensive one: *two brains talking to each other*, each with a repository of its
own. That is not a duo. It is two brains drifting apart, with nothing in the product to announce that
they diverged — the failure is silent by construction, and only a diagram makes it obvious enough to
avoid.

Asked to explain duo mode to a non-technical pair (an owner and the assistant joining him), the first
thing that had to be drawn was the shape. It belongs on the page, not in a private memo.

## What changes — three surfaces, no code

- **`docs/duo-mode.md`** opens on a new section, *The shape of it, before anything else*: one brain
  checked out on two machines, **exactly one** private repository between them, and both flows named
  with their cadence — push **once per turn** (and it needs `secondbrain.autopush`), pull **every
  ~90 s** while a window is open (`REMOTE_SYNC_INTERVAL`, `DEFAULT_INTERVAL_MS` in
  `scripts/lib/remote-sync.mjs`). The diagram also names what never travels: `.env`, `.mcp.json`,
  `.claude/settings.json`, and everything outside the vault.
- **`README.md`** says *one brain, one private remote, two machines* where it already named duo mode,
  and points at the page as the place where the flows are drawn.
- **The v5.1.0 release note** carries a condensed version of the picture beside the feature — in the
  repo file *and* on the published release, which was edited in place (owner's explicit go-ahead,
  2026-09-06).

Four points the diagram is there to settle, spelled out under it: one remote and only one (the joiner
**clones**, never runs the installer); sending is per-turn; receiving is on a timer and stops with the
window (no daemon, nothing syncs overnight); and neither machine is the main one — they are peers.

## Checks

- `node --test scripts/lib/*.test.mjs` — **2661 pass, 0 fail**.
- CI on the branch: **success**. Note that only the Windows harness tripwire actually ran; the Node
  matrix and the installer e2e were **skipped**, as they are for a Markdown-only change. This green
  therefore covers less than a code change's green would.
- Documentation only: no production file is touched, so no test was owed by the test-first rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kC2WGTrTJNyR97eMHhZ17
