### PR TITLE
ci(mutation): the nightly clones the whole history, so a score can be measured at all

### DIFF
--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -54,7 +54,15 @@ jobs:
           - package: scripts
             extra: "--inPlace"
     steps:
+      # fetch-depth: 0 — the suites under mutation assert against REAL git history:
+      # the QA fixtures replay a brain from tag v3.6.0, one test checks that every
+      # waived sha is still reachable, and the manifest-integrity checks walk
+      # `git ls-files`. A shallow, tagless clone fails them in Stryker's own initial
+      # test run, before a single mutant, so the job reports a truncated checkout and
+      # never a score. Every ci.yml job running these suites pins the same thing.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node 24
         uses: actions/setup-node@v4


### PR DESCRIPTION
## The failure

The nightly mutation run has failed **every morning since at least 3 September** (4 nights in a row),
each time after ~1h30 of compute, and **never on a mutant**. The suites it measures assert against
**real git history**: the QA fixtures replay a brain from tag `v3.6.0`, one test checks that every
waived sha is still reachable, and the manifest-integrity checks walk `git ls-files`. A shallow,
tagless checkout fails them inside Stryker's own initial test run — before a single mutant is created
— so the job reports a truncated clone and no score at all.

## The fix

`fetch-depth: 0` on the nightly's checkout, with the reason written above it. Every `ci.yml` job that
runs these suites already pins it (lines 65 and 93); the nightly was the only one that did not.

**Eight lines, one file, no production code.**

## Why this replaces #85 rather than rebasing it

PR #85 carried this same fix, plus six other commits. **Five of them already landed on `main`**
through the v5.1.0 release (`scripts/lib/instrumented-source.mjs` and the guards that stand down when
the runner has rewritten their source — same files, same patches, different sha). Rebasing that branch
would have replayed work that is already present, on a branch five days behind `main`.

So this branch takes today's `main` and adds **only what is missing**. #85 is closed as superseded.

## Checks

- The change is a workflow file, so the proof is the next nightly run: it should reach a **score**
  rather than a truncated-clone failure. Worth a look tomorrow morning.
- `node --test scripts/lib/*.test.mjs` — 2661 pass, 0 fail (unchanged: nothing here touches them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kC2WGTrTJNyR97eMHhZ17
