### PR TITLE
fix: a brain must never run a build, and the ones already out there stop at their next update (#92)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -513,6 +513,11 @@ git config secondbrain.autopush true   # ← enables the hook's automatic push
 The brain will then push **once per turn** (the `Stop` hook), bundling that turn's commits; a failed
 push is non-blocking and retried at the next turn.
 
+> 🏗️ **That repository stores and syncs your notes. It never builds anything.** A brain is data, not
+> software under development: there is no test suite to run on it, so nothing there should ever start
+> a job on GitHub, cost you money, or mail you a failure. If you see Actions running in your brain's
+> repository, that is a defect — update your engine (§10), which removes them.
+
 ### On the second machine — clone, then **rehydrate**
 
 A clone is **not** a working brain yet, and that is normal: two of the files your brain runs on

--- a/docs/duo-mode.md
+++ b/docs/duo-mode.md
@@ -86,6 +86,11 @@ only administrative gesture, and it is a real decision.
 > That has been true since the day you wired a remote, and it is why the repository is **private**.
 > Sharing a brain is the decision to share a machine, not the decision to share a document.
 
+> 🏗️ **The repository stores and syncs. It never builds.** Two people writing notes all day is still
+> just notes arriving: nothing there should ever start a job on GitHub, bill either of you, or mail
+> anyone a failure. If Actions are running in a shared brain, that is a defect — update the engine
+> and they go away.
+
 ## 3. Joining — about ten minutes, once
 
 From the person joining, on their own computer:

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -5,7 +5,7 @@
     "rag": "1.5.0",
     "local-mirror": "0.3.0",
     "constitutionTemplate": "1.4.0",
-    "scripts": "1.15.0"
+    "scripts": "1.16.0"
   },
   "indexSchemaVersion": 2,
   "regimes": {

--- a/maintainers/plans/ACTIVE.md
+++ b/maintainers/plans/ACTIVE.md
@@ -9,15 +9,18 @@ No memory lookup, no ROADMAP scan, no grep. Sub-plans are reached **through** it
 
 ## The active plan
 
-- **Subject:** the restart nudge loops forever, and obeying it is what keeps it alive
-  ([#90](https://github.com/tpierrain/kenjaku/issues/90)) — the owner is blocked by it in real use.
-- **Plan:** [`prospective/restart-nudge-loop-action.md`](prospective/restart-nudge-loop-action.md)
-- **Active since:** 2026-09-07 _(owner's call: "on fait le bug fix ASAP")_
+- **Subject:** a generated brain ships the launcher's CI, so every note saved runs a build matrix in
+  the owner's own GitHub account ([#92](https://github.com/tpierrain/kenjaku/issues/92)) — it bills
+  real money to real people, every day it is not shipped.
+- **Plan:** [`prospective/shipped-ci-workflows-action.md`](prospective/shipped-ci-workflows-action.md)
+- **Active since:** 2026-09-07 _(owner's call: "c'est assez grave")_
 
 ## Open, but NOT active
 
 Links only — each one's own `## 📍 STATE` block says whose it is and where it stands.
 
+- [`prospective/restart-nudge-loop-action.md`](prospective/restart-nudge-loop-action.md) — **was
+  active earlier the same day**; its belt is shipped on a branch, and it resumes at its step 2a.
 - [`prospective/harness-speed-and-test-quality-action.md`](prospective/harness-speed-and-test-quality-action.md)
   — **its speed half is done and shipped**; the quality and record halves are where it resumes.
 - [`prospective/clear-the-tracker-action.md`](prospective/clear-the-tracker-action.md) — **was active

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -23,9 +23,9 @@ The owner gave the go-ahead **including publishing the release**, then went to b
 resuming here finishes alone, in this order, and needs nothing from him.
 
 - **Branch:** `fix/no-ci-in-generated-brains`. **Release to cut:** `v5.1.1` (a fix on `v5.1.0`).
-- **Release title:** `v5.1.1 — The One Where Your Notes Stop Costing You Money` _(the series is
-  Friends-style, `vX.Y.Z — The One …`, and the em dash is the series convention: English title, do
-  not strip it)_. If he answered with another title before clearing, HIS wins.
+- **Release title, HIS pick, 2026-09-07:** `v5.1.1 — The One Where Your Brain Stops Running Builds`
+  _(the series is Friends-style, `vX.Y.Z — The One …`, and the em dash is the series convention:
+  English title, never strip it)_. He was offered three and chose this one; it is settled.
 - **✅ Done and pushed:** the copy fix (`.github/` is dev-only, pinned by a test that asks the real
   tracked listing) and the retreat (`scripts/lib/workflow-retreat.mjs` + 12 tests, wired into
   `reconcile-brain.mjs`, reported to the owner in money rather than filenames, manifest

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -43,13 +43,20 @@ in the owner's own account, and bills it to them.
 - 🚑 **Do not re-propose an emergency kill switch.** There is none, and why is written below, in
   *The emergency question*: we cannot reach anyone's GitHub, and no engine code reaches a brain
   without its owner updating. The `[skip ci]` half-measure was weighed there and left conditional.
-- ⏱️ **What a SHORT sitting buys, measured against the code and not guessed** _(asked 2026-09-07:
-  "is half an hour realistic?")_. **Step 1 is a half-hour piece**: one prefix, one test on the real
-  tracked list, one assertion in the installer's end-to-end check. **Step 2 is not**: it is the first
-  thing in this product to delete a file outside `.claude/skills/`, it needs its own module, its own
-  refusals and its own tests, and it only reaches anyone through a release. Treat them as two
-  sittings, and do not let the second be rushed because the first was quick — the plan already says
-  a deletion inside someone's brain is pinned by tests before it ships.
+- ⏱️ **SHIP TONIGHT, at a deliberately reduced ceremony** _(owner's call, 2026-09-07: "c'est un cas
+  majeur… je veux un truc rapide, très localisé, ce soir")_. The scope is cut to the two changes that
+  stop the bleeding, and the ceremony is cut to the two checks that actually prove they work. See
+  *The tonight cut* below for what is kept, what is dropped, and why the dropped half is affordable
+  **here specifically** rather than in general.
+- 🔎 **Three findings from reading the delivery path, and all three say the plan is smaller than it
+  looked** _(verified 2026-09-07, not assumed)_:
+  - `scripts/lib/**` is already in the manifest's `replace` regime, so **a new module under it ships
+    into every updating brain with no manifest edit at all**, and so does the reconcile that calls it.
+  - `commitEngineUpdate` stages with `git add -A`, so **the deletion is committed by the update
+    itself** and pushed by the end-of-turn hook. Without that it would vanish locally and GitHub
+    would keep running the workflows: this was the second way the fix could have been a no-op.
+  - A brain sees an update because of a **semver git tag** (`resolveLatestTag`). So the fix travels
+    the moment a tag exists, and not before — the tag IS the delivery.
 - **A session may, alone:** work test-first on a branch off `main`, push every green commit and read
   its CI. **Not:** touch either of the owner's two real brains, tag, or push to `main`.
 
@@ -90,6 +97,30 @@ condition is the owner's to evaluate, and it is recorded here rather than re-der
 **What DOES land immediately:** step 1 needs no release at all. A brain is installed from a clone of
 the launcher's default branch, so the moment step 1 is merged to `main`, **every brain created from
 then on is clean**. That is the one half with no delivery problem, and it is why it goes first.
+
+## ⚡ The tonight cut — what ceremony is dropped, and what may never be
+
+Decided 2026-09-07 with the owner, who asked for a fast, very localized hotfix and explicitly waived
+re-running the full suites and the mutation runs.
+
+**Dropped, and affordable HERE:** the mutation run, the whole-repo suite, and waiting on the full
+cross-platform matrix. The argument is not "we are in a hurry" — it is that this change has **no
+input**. The deletion takes no glob, no manifest entry, no user data: it names **two literal paths**,
+both anchored under `.github/workflows/`. There is no space of values for a mutation run to explore,
+so the checks being skipped are the ones with the least to say about this particular diff.
+
+**Kept, because these two are what "it really works" means:**
+
+- the focused unit test on the new module, run directly (seconds, not a suite);
+- **the field rehearsal** — `node maintainers/qa/field-rehearsal/rehearse.mjs --brain <a real brain>`.
+  Non-negotiable and it is CONVENTIONS §10ter: this release changes the update path, and no test in
+  this repo can see the path the fleet runs (in the field, the OLD engine drives the new one). The
+  last release that skipped this landed **nothing** on two brains while telling their owners they
+  were up to date. It reads the originals only, and copies without `.git`.
+
+**And two things the hurry may never touch:** the deletion still refuses anything outside
+`.github/workflows/`, and it still runs at update time only. Those are not ceremony, they are the
+blast radius.
 
 ## What this plan is NOT allowed to become
 

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -40,6 +40,9 @@ in the owner's own account, and bills it to them.
   only reaches an existing brain when its owner **updates**. Step 1 alone saves nobody who already
   has a brain. **Step 2 is the one that stops the bleeding**, and step 3 is what makes step 2 arrive.
 - **Blocked on:** nothing. A session may start step 1 immediately.
+- 🚑 **Do not re-propose an emergency kill switch.** There is none, and why is written below, in
+  *The emergency question*: we cannot reach anyone's GitHub, and no engine code reaches a brain
+  without its owner updating. The `[skip ci]` half-measure was weighed there and left conditional.
 - ⏱️ **What a SHORT sitting buys, measured against the code and not guessed** _(asked 2026-09-07:
   "is half an hour realistic?")_. **Step 1 is a half-hour piece**: one prefix, one test on the real
   tracked list, one assertion in the installer's end-to-end check. **Step 2 is not**: it is the first
@@ -49,6 +52,44 @@ in the owner's own account, and bills it to them.
   a deletion inside someone's brain is pinned by tests before it ships.
 - **A session may, alone:** work test-first on a branch off `main`, push every green commit and read
   its CI. **Not:** touch either of the owner's two real brains, tag, or push to `main`.
+
+## 🚑 The emergency question, asked and answered — 2026-09-07
+
+> *"Can't we urgently disable the ability to run actions in all the second brains?"*
+
+**There is no fast lane, and the reason is worth stating once so it is never re-hoped for.**
+
+- **We cannot reach anyone's GitHub.** Each brain lives in its owner's own account. There is no list
+  of them, no credential, no fleet control. Nothing we write can turn Actions off over there.
+- **And nothing arrives in a brain by itself.** Checked in the code rather than assumed: the only
+  automatic mechanism a brain runs at session start is the self-heal, and it re-converges the brain
+  **from its own on-disk files, with no network** (`sourceDir === brainDir`). New engine code reaches
+  a brain **only** when its owner runs an update. By design (updates are opt-in), and that design is
+  not being re-opened over this.
+- **So every candidate fix reaches the same person, at the same moment, through the same door.**
+  "Urgent" therefore cannot mean *reach people sooner*; it can only mean *be publishable sooner*.
+
+**The cheap candidate, considered seriously and NOT retained by default.** Mark the brain's automatic
+commits with `[skip ci]` (one constant, `COMMIT_MESSAGE` in `scripts/lib/vault-commit.mjs`, already
+in the `merge` regime so it already travels). GitHub starts no run on a commit carrying that mark.
+
+- ✅ It would kill the ~19 push-triggered matrix runs a day, which is nearly the whole bill, for one
+  line and no new deletion machinery at all.
+- ❌ It does **not** stop `mutation-nightly.yml`: that one is on a schedule and fires with no push.
+  The failure mail keeps arriving, nightly, from the repository holding someone's notes.
+- ❌ It brands **every** note commit in **every** brain, forever, with a CI marker that describes a
+  problem those brains will no longer have.
+- ❌ And it spends the one thing that is actually scarce: **a release**. Both halves travel only in a
+  published engine version, so shipping the half-measure first means the real fix waits for the
+  release after it.
+
+**Decision:** the deletion (step 2) stays the fix. `[skip ci]` becomes worth its cost **only if step
+2 cannot be done within a few days** — a longer wait is what would buy back its downsides. That
+condition is the owner's to evaluate, and it is recorded here rather than re-derived.
+
+**What DOES land immediately:** step 1 needs no release at all. A brain is installed from a clone of
+the launcher's default branch, so the moment step 1 is merged to `main`, **every brain created from
+then on is clean**. That is the one half with no delivery problem, and it is why it goes first.
 
 ## What this plan is NOT allowed to become
 

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -17,6 +17,38 @@
 and `mutation-nightly.yml`; the auto-push hook then starts a full build matrix on every note saved,
 in the owner's own account, and bills it to them.
 
+## 🌙 HAND-OFF — written to survive a cleared context, 2026-09-07 evening
+
+The owner gave the go-ahead **including publishing the release**, then went to bed. A session
+resuming here finishes alone, in this order, and needs nothing from him.
+
+- **Branch:** `fix/no-ci-in-generated-brains`. **Release to cut:** `v5.1.1` (a fix on `v5.1.0`).
+- **Release title:** `v5.1.1 — The One Where Your Notes Stop Costing You Money` _(the series is
+  Friends-style, `vX.Y.Z — The One …`, and the em dash is the series convention: English title, do
+  not strip it)_. If he answered with another title before clearing, HIS wins.
+- **✅ Done and pushed:** the copy fix (`.github/` is dev-only, pinned by a test that asks the real
+  tracked listing) and the retreat (`scripts/lib/workflow-retreat.mjs` + 12 tests, wired into
+  `reconcile-brain.mjs`, reported to the owner in money rather than filenames, manifest
+  `engineVersion.scripts` → `1.16.0`). Every test touching this ran green: 185 + 121 + 39.
+- **▶️ Remaining, in order:**
+  1. Step 4 — one sentence in SETUP §7 and the duo doc: a brain's repository stores and syncs, it
+     never builds.
+  2. The field rehearsal, CONVENTIONS §10ter, **the one check that may not be skipped**:
+     `node maintainers/qa/field-rehearsal/rehearse.mjs --brain ~/mind-palace`. He named that brain
+     himself for this. It **reads the original only** (the copy is taken without `.git`, every write
+     goes to a temp dir) — verified in the code, and it is why he agreed. Exit `0`, and the report
+     must show the two workflow files GONE from the copy.
+  3. PR → merge to `main`. From that moment every newly created brain is clean, with no release.
+  4. Tag `v5.1.1` + `gh release create`, note written for a non-developer first (CONVENTIONS §11):
+     the cost, in plain words, on the owner's own account. **The tag IS the delivery** — nothing
+     reaches an installed brain before it exists.
+  5. CONVENTIONS §10 (re-read the marketing surface) and §10bis (sweep the open issues), kept light
+     per the tonight cut.
+  6. Comment on [#92](https://github.com/tpierrain/kenjaku/issues/92) — **and do NOT close it**: step
+     6 below closes it only on field evidence, and that is unchanged by the hurry.
+- **⚠️ Do not, alone:** modify `~/mind-palace` or his other brain (the rehearsal's read-only copy is
+  the one sanctioned contact), or re-open any decision recorded above.
+
 ## 📍 STATE — the only perishable block in this file · opened 2026-09-07
 
 - 🔥 **THIS IS THE ACTIVE PLAN.** The owner's words: *"c'est assez grave"*. It costs real money to
@@ -133,14 +165,17 @@ blast radius.
 
 ## Tracking
 
-- [ ] **1. A newly created brain carries no CI at all.**
-  - [ ] `.github/` joins `DEV_ONLY_PREFIXES` in `scripts/lib/tracked-files.mjs`, the way
+- [x] **1. A newly created brain carries no CI at all.** _(2026-09-07 · `fix/no-ci-in-generated-brains`)_
+  - [x] `.github/` joins `DEV_ONLY_PREFIXES` in `scripts/lib/tracked-files.mjs`, the way
         `maintainers/` already does.
-  - [ ] Test-first in `tracked-files.test.mjs`: `filterCopyable` keeps no `.github/` path. Assert on
-        the real tracked list, not a fixture, so a workflow added later is caught too.
-  - [ ] The installer's end-to-end check asserts the generated brain has **no `.github/` directory**.
+  - [x] Test-first in `tracked-files.test.mjs`: `filterCopyable` keeps no `.github/` path. Asserted on
+        the real tracked list, not a fixture, so a workflow added later is caught too. It first
+        asserts the repo really tracks `.github/` files, so an empty listing cannot pass for a clean
+        one.
+  - [ ] _(deferred past the tonight cut, and it is the one deferral: the real-listing test above
+        covers the same defect without a Windows install run.)_ The installer's end-to-end check asserts the generated brain has **no `.github/` directory**.
         That is the assertion that would have caught this, and it is the one that must exist after.
-- [ ] **2. A brain already installed loses them at its next engine update** _(the step that actually
+- [x] **2. A brain already installed loses them at its next engine update** _(2026-09-07 · same branch)_ _(the step that actually
       stops the bleeding)_.
   - **The proof rule, decided 2026-09-07 after the trap above.** The retirement is **by declared
     path**, not by proven authorship: a deployed brain cannot prove authorship of a file that was
@@ -149,17 +184,18 @@ blast radius.
     `.github/workflows/ci.yml` and `.github/workflows/mutation-nightly.yml` — and nothing else. A
     workflow the OWNER wrote is a different filename and is never touched; the deletion lands in the
     brain's own git history, so it is recoverable by the owner in one command.
-  - [ ] Its own narrow module, on the shape of `status-line-retreat.mjs` (the product's other
+  - [x] Its own narrow module, on the shape of `status-line-retreat.mjs` (the product's other
         targeted retreat) rather than a widening of `retireSkills` — a bucket whose guard is
         provenance must not gain entries that can never satisfy it.
-  - [ ] It keeps the guards that are still meaningful: **declared** in the manifest (never inferred
+  - [x] It keeps the guards that are still meaningful: **declared** in the manifest (never inferred
         from an absence), `climbsOut` refused, and it runs at **update time only** (never at the
         SessionStart self-heal, whose output goes nowhere).
-  - [ ] A hard refusal, tested: a tombstone that names anything under `vault/` is rejected, loudly.
+  - [x] A hard refusal, tested: anything not anchored under `.github/workflows/` is refused, and a
+        path that begins there and climbs back out to `vault/` with it.
         The owner's notes are never reachable by this mechanism, whatever a manifest says.
-  - [ ] The removal is **idempotent and silent when there is nothing to remove**: the overwhelming
+  - [x] The removal is **idempotent and silent when there is nothing to remove**: the overwhelming
         majority of updates must not pay for this, and must say nothing about it.
-  - [ ] When it DOES remove, it says so in one plain sentence: the brain no longer runs a build, and
+  - [x] When it DOES remove, it says so in one plain sentence: the brain no longer runs a build, and
         that is why the failure mail stops.
 - [ ] **3. An owner who never opens an update prompt still gets there.** Check what the session-start
       divergence nudge already says when a newer engine exists, and whether it is enough to make

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -21,7 +21,17 @@ in the owner's own account, and bills it to them.
 
 - 🔥 **THIS IS THE ACTIVE PLAN.** The owner's words: *"c'est assez grave"*. It costs real money to
   real people **every day it is not shipped**, and they are the ones who followed the documentation.
-- **Next:** step 1. Nothing is started, no code is written, no branch exists yet.
+- **Next:** step 1, on the branch `fix/no-ci-in-generated-brains` (it exists, and carries this plan
+  and nothing else). No engine code is written yet.
+- 🪤 **A TRAP FOUND BY READING THE CODE, 2026-09-07, and it invalidates step 2 as it was first
+  written.** The existing tombstone bucket cannot be merely *widened* to cover a workflow file: it
+  deletes only what it can **prove** it delivered, byte for byte, from the brain's recorded
+  provenance (`decideSkillRetirement` → `verifyBase`). A brain in the field records **no provenance
+  at all** for `.github/workflows/**` — those files were in no regime, so nothing ever recorded them
+  — and `engine-fingerprints.json` (the disk-heal table, 15 files) does not carry them either. Every
+  such file would therefore return `preserve / no-provenance` and **step 2 would ship a silent
+  no-op**: the exact failure the whole step exists to avoid. Step 2 below is rewritten for a proof
+  rule that a deployed brain can actually satisfy.
 - ❌ **Warning them by hand is OFF THE TABLE** _(owner's call, 2026-09-07)_. There is no list of
   installed brains, and he judged the human route not workable. **So the fix has to travel by
   itself, through the engine update, and the plan is written for that.** Do not re-propose a Slack
@@ -30,6 +40,13 @@ in the owner's own account, and bills it to them.
   only reaches an existing brain when its owner **updates**. Step 1 alone saves nobody who already
   has a brain. **Step 2 is the one that stops the bleeding**, and step 3 is what makes step 2 arrive.
 - **Blocked on:** nothing. A session may start step 1 immediately.
+- ⏱️ **What a SHORT sitting buys, measured against the code and not guessed** _(asked 2026-09-07:
+  "is half an hour realistic?")_. **Step 1 is a half-hour piece**: one prefix, one test on the real
+  tracked list, one assertion in the installer's end-to-end check. **Step 2 is not**: it is the first
+  thing in this product to delete a file outside `.claude/skills/`, it needs its own module, its own
+  refusals and its own tests, and it only reaches anyone through a release. Treat them as two
+  sittings, and do not let the second be rushed because the first was quick — the plan already says
+  a deletion inside someone's brain is pinned by tests before it ships.
 - **A session may, alone:** work test-first on a branch off `main`, push every green commit and read
   its CI. **Not:** touch either of the owner's two real brains, tag, or push to `main`.
 
@@ -53,16 +70,25 @@ in the owner's own account, and bills it to them.
         That is the assertion that would have caught this, and it is the one that must exist after.
 - [ ] **2. A brain already installed loses them at its next engine update** _(the step that actually
       stops the bleeding)_.
-  - [ ] Today the update has exactly ONE subtractive bucket, `retireSkills` in
-        `scripts/lib/engine-apply-plan.mjs`, and it is scoped to `.claude/skills/`. Widen the
-        tombstone so it can retire a **shipped file outside the skills tree**, keeping every guard
-        that bucket already earned (declared in the manifest, never inferred from an absence,
-        `climbsOut` refused).
+  - **The proof rule, decided 2026-09-07 after the trap above.** The retirement is **by declared
+    path**, not by proven authorship: a deployed brain cannot prove authorship of a file that was
+    never in a regime, so demanding that proof is the same as never deleting. What replaces it is a
+    tombstone that names **exactly the two files the launcher has ever shipped** —
+    `.github/workflows/ci.yml` and `.github/workflows/mutation-nightly.yml` — and nothing else. A
+    workflow the OWNER wrote is a different filename and is never touched; the deletion lands in the
+    brain's own git history, so it is recoverable by the owner in one command.
+  - [ ] Its own narrow module, on the shape of `status-line-retreat.mjs` (the product's other
+        targeted retreat) rather than a widening of `retireSkills` — a bucket whose guard is
+        provenance must not gain entries that can never satisfy it.
+  - [ ] It keeps the guards that are still meaningful: **declared** in the manifest (never inferred
+        from an absence), `climbsOut` refused, and it runs at **update time only** (never at the
+        SessionStart self-heal, whose output goes nowhere).
   - [ ] A hard refusal, tested: a tombstone that names anything under `vault/` is rejected, loudly.
         The owner's notes are never reachable by this mechanism, whatever a manifest says.
-  - [ ] `engine-manifest.json` declares `.github/workflows/**` retired.
   - [ ] The removal is **idempotent and silent when there is nothing to remove**: the overwhelming
         majority of updates must not pay for this, and must say nothing about it.
+  - [ ] When it DOES remove, it says so in one plain sentence: the brain no longer runs a build, and
+        that is why the failure mail stops.
 - [ ] **3. An owner who never opens an update prompt still gets there.** Check what the session-start
       divergence nudge already says when a newer engine exists, and whether it is enough to make
       someone act. If it is, say so here and tick; if it is not, this is where it gets loud, **once**.

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -53,8 +53,9 @@ resuming here finishes alone, in this order, and needs nothing from him.
 
 - 🔥 **THIS IS THE ACTIVE PLAN.** The owner's words: *"c'est assez grave"*. It costs real money to
   real people **every day it is not shipped**, and they are the ones who followed the documentation.
-- **Next:** step 1, on the branch `fix/no-ci-in-generated-brains` (it exists, and carries this plan
-  and nothing else). No engine code is written yet.
+- **Next:** 👉 **read the HAND-OFF block above, not this line.** Steps 1 and 2 are DONE and pushed on
+  `fix/no-ci-in-generated-brains`; what remains is the doc sentence, the rehearsal, the merge and the
+  release.
 - 🪤 **A TRAP FOUND BY READING THE CODE, 2026-09-07, and it invalidates step 2 as it was first
   written.** The existing tombstone bucket cannot be merely *widened* to cover a workflow file: it
   deletes only what it can **prove** it delivered, byte for byte, from the brain's recorded
@@ -89,8 +90,10 @@ resuming here finishes alone, in this order, and needs nothing from him.
     would keep running the workflows: this was the second way the fix could have been a no-op.
   - A brain sees an update because of a **semver git tag** (`resolveLatestTag`). So the fix travels
     the moment a tag exists, and not before — the tag IS the delivery.
-- **A session may, alone:** work test-first on a branch off `main`, push every green commit and read
-  its CI. **Not:** touch either of the owner's two real brains, tag, or push to `main`.
+- **A session may, alone:** everything through to the published release — the owner gave that
+  go-ahead explicitly on 2026-09-07 before going to bed, and the hand-off block carries its terms.
+  **Still not:** modify either of his real brains (the rehearsal's read-only copy of `~/mind-palace`
+  is the one sanctioned contact), or close #92 on the merge.
 
 ## 🚑 The emergency question, asked and answered — 2026-09-07
 

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -1,0 +1,76 @@
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- THE canonical plan for issue #92 — a generated brain ships the         -->
+<!-- launcher's CI, so every note saved runs a build matrix in the owner's  -->
+<!-- own GitHub account. The DETAIL (symptom, mechanism, evidence, the      -->
+<!-- three directions) lives in the issue and is deliberately NOT copied    -->
+<!-- here. This file owns only decisions taken, what is done, and where to  -->
+<!-- resume.                                                                -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+
+# Action plan — a brain must never run a build, and the ones already out there must stop
+
+**The issue, and the single source for the analysis:**
+[#92](https://github.com/tpierrain/kenjaku/issues/92) — reported from a real brain in the field,
+2026-09-07, after a few days of ordinary note-taking.
+
+**In one line**: `.github/` is not excluded from the install copy, so every brain carries `ci.yml`
+and `mutation-nightly.yml`; the auto-push hook then starts a full build matrix on every note saved,
+in the owner's own account, and bills it to them.
+
+## 📍 STATE — the only perishable block in this file · opened 2026-09-07
+
+- 🔥 **THIS IS THE ACTIVE PLAN.** The owner's words: *"c'est assez grave"*. It costs real money to
+  real people **every day it is not shipped**, and they are the ones who followed the documentation.
+- **Next:** step 1. Nothing is started, no code is written, no branch exists yet.
+- ❌ **Warning them by hand is OFF THE TABLE** _(owner's call, 2026-09-07)_. There is no list of
+  installed brains, and he judged the human route not workable. **So the fix has to travel by
+  itself, through the engine update, and the plan is written for that.** Do not re-propose a Slack
+  message.
+- ⚠️ **The hard constraint, and it shapes everything below:** any fix is engine code, and engine code
+  only reaches an existing brain when its owner **updates**. Step 1 alone saves nobody who already
+  has a brain. **Step 2 is the one that stops the bleeding**, and step 3 is what makes step 2 arrive.
+- **Blocked on:** nothing. A session may start step 1 immediately.
+- **A session may, alone:** work test-first on a branch off `main`, push every green commit and read
+  its CI. **Not:** touch either of the owner's two real brains, tag, or push to `main`.
+
+## What this plan is NOT allowed to become
+
+- **A brain never runs a build.** The fix is to stop shipping the workflows, never to make them
+  cheaper, quieter, or conditional. A brain is data; there is nothing for a CI to protect.
+- **Deleting files inside someone's brain is a destructive act**, and step 2 is the first thing in
+  this product that does it outside `.claude/skills/`. It is declared, never inferred; it can never
+  name `vault/`; and it is pinned by tests before it ships. An absent or unparseable manifest must
+  delete **nothing**.
+
+## Tracking
+
+- [ ] **1. A newly created brain carries no CI at all.**
+  - [ ] `.github/` joins `DEV_ONLY_PREFIXES` in `scripts/lib/tracked-files.mjs`, the way
+        `maintainers/` already does.
+  - [ ] Test-first in `tracked-files.test.mjs`: `filterCopyable` keeps no `.github/` path. Assert on
+        the real tracked list, not a fixture, so a workflow added later is caught too.
+  - [ ] The installer's end-to-end check asserts the generated brain has **no `.github/` directory**.
+        That is the assertion that would have caught this, and it is the one that must exist after.
+- [ ] **2. A brain already installed loses them at its next engine update** _(the step that actually
+      stops the bleeding)_.
+  - [ ] Today the update has exactly ONE subtractive bucket, `retireSkills` in
+        `scripts/lib/engine-apply-plan.mjs`, and it is scoped to `.claude/skills/`. Widen the
+        tombstone so it can retire a **shipped file outside the skills tree**, keeping every guard
+        that bucket already earned (declared in the manifest, never inferred from an absence,
+        `climbsOut` refused).
+  - [ ] A hard refusal, tested: a tombstone that names anything under `vault/` is rejected, loudly.
+        The owner's notes are never reachable by this mechanism, whatever a manifest says.
+  - [ ] `engine-manifest.json` declares `.github/workflows/**` retired.
+  - [ ] The removal is **idempotent and silent when there is nothing to remove**: the overwhelming
+        majority of updates must not pay for this, and must say nothing about it.
+- [ ] **3. An owner who never opens an update prompt still gets there.** Check what the session-start
+      divergence nudge already says when a newer engine exists, and whether it is enough to make
+      someone act. If it is, say so here and tick; if it is not, this is where it gets loud, **once**.
+- [ ] **4. Setting up a remote says what the repository will and will not do.** One sentence in
+      SETUP §7 and in the duo doc: a brain's repository stores and syncs, it never builds. Cheap, and
+      it is the sentence whose absence let this run for days without anyone suspecting the product.
+- [ ] **5. Release it, and treat it as the reason for the release.** The release note names the cost
+      in plain words (money, on the owner's account) rather than filing it as a fix among others.
+- [ ] **6. Close [#92](https://github.com/tpierrain/kenjaku/issues/92) only when a real brain that had
+      the workflows has been seen losing them on update** — not on the merge. The issue's evidence is
+      field evidence, and so is its closure.

--- a/maintainers/plans/prospective/shipped-ci-workflows-action.md
+++ b/maintainers/plans/prospective/shipped-ci-workflows-action.md
@@ -30,22 +30,43 @@ resuming here finishes alone, in this order, and needs nothing from him.
   tracked listing) and the retreat (`scripts/lib/workflow-retreat.mjs` + 12 tests, wired into
   `reconcile-brain.mjs`, reported to the owner in money rather than filenames, manifest
   `engineVersion.scripts` → `1.16.0`). Every test touching this ran green: 185 + 121 + 39.
+- **✅ Also done, 2026-09-07 night:** step 4's sentence (SETUP §7 + duo mode §2), the field rehearsal
+  (below), the marketing re-read (below), and the defect the rehearsal found — the owner never HEARD
+  the rescue.
 - **▶️ Remaining, in order:**
-  1. Step 4 — one sentence in SETUP §7 and the duo doc: a brain's repository stores and syncs, it
-     never builds.
-  2. The field rehearsal, CONVENTIONS §10ter, **the one check that may not be skipped**:
-     `node maintainers/qa/field-rehearsal/rehearse.mjs --brain ~/mind-palace`. He named that brain
-     himself for this. It **reads the original only** (the copy is taken without `.git`, every write
-     goes to a temp dir) — verified in the code, and it is why he agreed. Exit `0`, and the report
-     must show the two workflow files GONE from the copy.
-  3. PR → merge to `main`. From that moment every newly created brain is clean, with no release.
-  4. Tag `v5.1.1` + `gh release create`, note written for a non-developer first (CONVENTIONS §11):
+  1. PR → merge to `main`. From that moment every newly created brain is clean, with no release.
+  2. Tag `v5.1.1` + `gh release create`, note written for a non-developer first (CONVENTIONS §11):
      the cost, in plain words, on the owner's own account. **The tag IS the delivery** — nothing
      reaches an installed brain before it exists.
-  5. CONVENTIONS §10 (re-read the marketing surface) and §10bis (sweep the open issues), kept light
-     per the tonight cut.
-  6. Comment on [#92](https://github.com/tpierrain/kenjaku/issues/92) — **and do NOT close it**: step
+  3. Comment on [#92](https://github.com/tpierrain/kenjaku/issues/92) — **and do NOT close it**: step
      6 below closes it only on field evidence, and that is unchanged by the hurry.
+
+### 🔬 The rehearsal, and the defect it found — 2026-09-07 night
+
+Run twice, `--tag v5.1.1` (the first run, at the default `--tag v5.0.0`, proved nothing: the copy is
+installed at **v5.1.0**, so `resolveLatestTag` picked the published v5.1.0 over the forced tag and the
+trial updated the brain to the code it already had. **A rehearsal must force a tag ABOVE the copy's
+installed version, or it silently rehearses nothing** — worth knowing before the next one).
+
+- ✅ **Exit `0`. Both workflow files GONE from the copy**, and the deletion is inside the update's own
+  commit (`engine: update to v5.1.1`, 217 deletions) — so it survives, and GitHub stops running them.
+- ✅ **The owner's territory byte-identical.** The update touched nothing he owns.
+- 🚨 **And the report said NOTHING about it** — the one thing no unit test could see. The recap an
+  owner reads is printed by the engine that RAN the update, the **old** one, which has never heard of
+  this release's sentence; by the next update there is nothing left to remove, so the sentence would
+  have landed **never**. The rescue would have been a silent deletion of two files inside someone's
+  repository. Fixed where the codebase already solved this exact problem: the reconcile child's
+  stdout is inherited by the old parent, and `announceWhatTheOldRecapCannot` exists for precisely
+  that moment. Four tests, red first; the wording moved to `BUILDS_STOPPED` beside the deletion so
+  the two voices cannot drift. Re-rehearsed: the sentence is on screen.
+
+### 📣 CONVENTIONS §10 — the marketing surface, re-read 2026-09-07 night
+
+**Verdict: nothing to change, and no board to re-render.** README, EN-QUOI-C-EST-DIFFERENT, SETUP,
+CONNECTORS and the board copy were swept for every claim about builds, CI, Actions and workflows: the
+only hits are *"builds your brain"* (the installer) and *"the index rebuilds itself"*. Neither is
+about this. Nothing became false, and there is nothing new to sell — a defect removed is not a
+capability. Recorded per §10 because *"checked"* and *"not looked at"* must be distinguishable.
 - **⚠️ Do not, alone:** modify `~/mind-palace` or his other brain (the rehearsal's read-only copy is
   the one sanctioned contact), or re-open any decision recorded above.
 
@@ -53,9 +74,9 @@ resuming here finishes alone, in this order, and needs nothing from him.
 
 - 🔥 **THIS IS THE ACTIVE PLAN.** The owner's words: *"c'est assez grave"*. It costs real money to
   real people **every day it is not shipped**, and they are the ones who followed the documentation.
-- **Next:** 👉 **read the HAND-OFF block above, not this line.** Steps 1 and 2 are DONE and pushed on
-  `fix/no-ci-in-generated-brains`; what remains is the doc sentence, the rehearsal, the merge and the
-  release.
+- **Next:** 👉 **read the HAND-OFF block above, not this line.** Steps 1, 2 and 4 are DONE and pushed
+  on `fix/no-ci-in-generated-brains`, the rehearsal passed and the marketing re-read is recorded;
+  what remains is the merge, the tag, the release note and the comment on #92.
 - 🪤 **A TRAP FOUND BY READING THE CODE, 2026-09-07, and it invalidates step 2 as it was first
   written.** The existing tombstone bucket cannot be merely *widened* to cover a workflow file: it
   deletes only what it can **prove** it delivered, byte for byte, from the brain's recorded
@@ -203,9 +224,16 @@ blast radius.
 - [ ] **3. An owner who never opens an update prompt still gets there.** Check what the session-start
       divergence nudge already says when a newer engine exists, and whether it is enough to make
       someone act. If it is, say so here and tick; if it is not, this is where it gets loud, **once**.
-- [ ] **4. Setting up a remote says what the repository will and will not do.** One sentence in
-      SETUP §7 and in the duo doc: a brain's repository stores and syncs, it never builds. Cheap, and
-      it is the sentence whose absence let this run for days without anyone suspecting the product.
+  - ⏸️ **NOT in the tonight cut, and deliberately** _(2026-09-07 night)_. It is the one step that
+    changes a **standing** surface — a line every owner reads at every session start — so it is the
+    one place a hurried judgement would cost the most, and it stops nobody's bleeding tonight: an
+    owner who does update gets the fix regardless. It waits for a session with room to read what the
+    nudge says today before making it louder. **The release ships without it.**
+- [x] **4. Setting up a remote says what the repository will and will not do.** _(2026-09-07 · `fix/no-ci-in-generated-brains`)_
+      One sentence in SETUP §7 and in the duo doc: a brain's repository stores and syncs, it never
+      builds. Cheap, and it is the sentence whose absence let this run for days without anyone
+      suspecting the product. Said in the owner's own terms (cost, failure mail) and paired with what
+      to do about it — updating the engine — so it reads as a defect to fix, never as a fact of life.
 - [ ] **5. Release it, and treat it as the reason for the release.** The release note names the cost
       in plain words (money, on the owner's account) rather than filing it as a fix among others.
 - [ ] **6. Close [#92](https://github.com/tpierrain/kenjaku/issues/92) only when a real brain that had

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -27,7 +27,7 @@ import { matchesAny } from "./glob-match.mjs";
 import { installStagedSkills, readStagedProvenance } from "./staged-skills.mjs";
 import { refreshUntouchedSkills } from "./engine-skill-refresh.mjs";
 import { retireDeclaredSkills } from "./skill-retirement-fs.mjs";
-import { retireShippedWorkflows } from "./workflow-retreat.mjs";
+import { retireShippedWorkflows, BUILDS_STOPPED } from "./workflow-retreat.mjs";
 import { refreshEngineScripts } from "./engine-script-refresh.mjs";
 import { refreshEngineDoctrine } from "./engine-doctrine-refresh.mjs";
 import { seedHealthNote } from "./staged-health-note.mjs";
@@ -805,6 +805,16 @@ export function announceWhatTheOldRecapCannot({ brainDir, sourceDir, delivered, 
   // comparison, and a misspelled self-heal would tell a converged brain it was "catching
   // up" every single morning. Not a deletion, but the same defect and the same fix.
   if (isSelfHeal({ brainDir, sourceDir })) return;
+
+  // #92 — AND IT LEADS, because on the release that performs this rescue the catch-up half
+  // below is silent: nothing else arrives, so an owner whose brain just stopped being billed
+  // would hear nothing at all. Its own line rather than a third clause of the sentence
+  // below: what it says is not "you caught up", it is "you have stopped being billed", and
+  // the wording is `BUILDS_STOPPED` so this voice and the update recap's cannot drift.
+  // Silent from the second update on, when there is nothing left to remove — which is the
+  // same silence every other clause here keeps.
+  if ((report.workflowsRetired ?? []).length > 0) emit(`🏗️ ${BUILDS_STOPPED}\n`);
+
   const arrived = Object.keys(delivered).sort();
   const gone = report.skillsRetired ?? [];
   if (arrived.length === 0 && gone.length === 0) return;

--- a/scripts/lib/reconcile-brain.mjs
+++ b/scripts/lib/reconcile-brain.mjs
@@ -27,6 +27,7 @@ import { matchesAny } from "./glob-match.mjs";
 import { installStagedSkills, readStagedProvenance } from "./staged-skills.mjs";
 import { refreshUntouchedSkills } from "./engine-skill-refresh.mjs";
 import { retireDeclaredSkills } from "./skill-retirement-fs.mjs";
+import { retireShippedWorkflows } from "./workflow-retreat.mjs";
 import { refreshEngineScripts } from "./engine-script-refresh.mjs";
 import { refreshEngineDoctrine } from "./engine-doctrine-refresh.mjs";
 import { seedHealthNote } from "./staged-health-note.mjs";
@@ -237,6 +238,16 @@ export async function reconcileBrain({
     plan,
     provenance: local?.provenance,
   });
+
+  // 2.bis-workflows THE BRAIN STOPS RUNNING A BUILD (issue #92). The launcher used to
+  //    ship its own CI into every brain, so a brain wired to a remote started a full
+  //    build matrix in the OWNER'S GitHub account on every note saved, and was billed
+  //    for it. Beside the skills retirement because it is the same kind of act, and
+  //    NOT through it because it cannot be: that door removes only what the brain's
+  //    provenance proves we delivered, and no brain in the field records any for these
+  //    files. See workflow-retreat.mjs — the proof rule there is by NAME, and narrow.
+  //    Same `sourceDir` gate, enforced inside the module at the line that deletes.
+  const { removed: workflowsRetired } = retireShippedWorkflows({ brainDir, sourceDir });
 
   // 2.bis Install engine-declared skills the brain is MISSING (ADR 0025): additive,
   //    install-if-absent at the SKILL-DIR level. A skill dir that already exists
@@ -564,6 +575,10 @@ export async function reconcileBrain({
     // and a skill preserved from a RETIREMENT is one the engine has stopped shipping.
     skillsRetired,
     skillsRetirePreserved,
+    // #92: the OTHER subtractive door. Named here for the same reason as the two above —
+    // a field this object does not carry is a verdict the owner never hears, and "your
+    // brain has stopped running builds in your GitHub account" is news worth a sentence.
+    workflowsRetired,
     installedFileMap,
     skillsRefreshed,
     skillsPreserved,

--- a/scripts/lib/reconcile-brain.test.mjs
+++ b/scripts/lib/reconcile-brain.test.mjs
@@ -779,6 +779,63 @@ test("T8 — a launcher path that merely starts with the brain's still announces
   );
 });
 
+// ── #92: THE BUILDS SENTENCE, and why it can only be said HERE ───────────────
+//
+// The rescue itself is proven elsewhere (workflow-retreat.test.mjs, and the field
+// rehearsal): the two workflow files are deleted and the deletion is committed. What is
+// proven here is that the owner HEARS it — and the field rehearsal on a real brain is
+// what showed that they did not. `update-engine.mjs` carries the sentence, but the engine
+// that RUNS this update is the old one, which does not have it; the sentence would land
+// only on a second update, where there is nothing left to remove. So it never lands at
+// all. This child's stdout is inherited by that old parent: the same one voice the
+// catch-up line already uses, for the same one reason.
+//
+// It is a SEPARATE line, not a third clause of the catch-up sentence, because on this
+// release the catch-up half is silent — nothing else arrives — and because what it says
+// is not "you caught up", it is "you have stopped being billed".
+
+test("#92 — the builds sentence is said even when nothing else arrived", async () => {
+  const said = await catchUp({ report: { workflowsRetired: [".github/workflows/ci.yml", ".github/workflows/mutation-nightly.yml"] } });
+  assert.deepEqual(said, [
+    "🏗️ Your brain has stopped running builds in your GitHub account: it used to carry the " +
+      "launcher's own automated checks, so every note you saved started one (and made it fail). " +
+      "A brain stores and syncs your notes, it never builds anything. The failure mail stops, " +
+      "and so does the cost.\n",
+  ]);
+});
+
+test("#92 — the builds sentence leads, and the catch-up line follows it", async () => {
+  // Order is the contract, not an accident: this is the headline of the release the owner
+  // just installed, and a line about refreshed engine files is not.
+  const said = await catchUp({
+    delivered: { "CLAUDE.engine.md": "a1" },
+    report: { skillsRetired: [], workflowsRetired: [".github/workflows/ci.yml"] },
+  });
+  assert.equal(said.length, 2);
+  assert.ok(said[0].startsWith("🏗️ Your brain has stopped running builds"), said[0]);
+  assert.deepEqual(said[1], [
+    "🔓 Catching up: your brain just received 1 engine file it had stopped getting updates for " +
+      "(CLAUDE.engine.md). Your own edits were kept.\n",
+  ][0]);
+});
+
+test("#92 — an update that removed no workflow says nothing about builds", async () => {
+  // The overwhelming majority of updates, forever after this one. An owner must not be
+  // told about a rescue that did not happen.
+  assert.deepEqual(await catchUp({ report: { skillsRetired: [], workflowsRetired: [] } }), []);
+});
+
+test("#92 — a self-heal never says it, whatever it thinks it removed", async () => {
+  assert.deepEqual(
+    await catchUp({
+      brainDir: "/brain",
+      sourceDir: "/brain",
+      report: { workflowsRetired: [".github/workflows/ci.yml"] },
+    }),
+    [],
+  );
+});
+
 // The negative pole, and it is the load-bearing one: this line may never appear on the
 // steady state. A converged brain re-opened every day would otherwise be told, at every
 // session start, about an update that happened once.

--- a/scripts/lib/tracked-files.mjs
+++ b/scripts/lib/tracked-files.mjs
@@ -97,6 +97,18 @@ export function deliversAsLf(info) {
 const DEV_ONLY_FILES = new Set(["DEVELOPING.md", "EN-QUOI-C-EST-DIFFERENT.md"]);
 const DEV_ONLY_PREFIXES = [
   "maintainers/",
+  // 🔥 .github/ — the launcher's OWN continuous integration, and issue #92 is what its
+  // absence from this list cost. A brain is DATA: there is no build to run and no test
+  // to gate. But a brain wired to a remote pushes once per turn, so every note saved
+  // started a full build matrix in the OWNER'S GitHub account — measured in the field at
+  // 19 runs a day and ~720 Actions minutes billed, against a free allowance of 2,000, to
+  // someone who had only written notes. The scheduled nightly ran on top, forever, and
+  // every run was red because a brain is not the launcher.
+  // The whole directory, not the two workflow files: an issue template or a funding file
+  // has no more business in a brain, and naming the tree means the next thing added under
+  // it is covered without anyone remembering this. Pinned by a test that asks the REAL
+  // tracked listing rather than a fixture.
+  ".github/",
   "scripts/run-eval.mjs",
   "scripts/lib/eval-",
   "scripts/lib/mcp-search",

--- a/scripts/lib/tracked-files.test.mjs
+++ b/scripts/lib/tracked-files.test.mjs
@@ -1,6 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseLsFilesZ, filterCopyable, parseLsFilesEolZ, deliversAsLf } from "./tracked-files.mjs";
+
+// The launcher's root, from this file rather than from the runner's cwd: `node --test`
+// is invoked from several places in this repo and a relative root would make the one
+// test that reads the real listing pass or fail on who ran it.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 // ═══════════════════════════════════════════════════════════════════════════
 // W2 — the installer delivers WHAT THE OBJECT STORE HOLDS, not what the
@@ -299,6 +307,36 @@ test("filterCopyable — excludes the eval-set tooling (dev-only: used to choose
     ]),
     ["scripts/verify-rag.mjs", "rag/src/index.ts"],
   );
+});
+
+test("filterCopyable — excludes .github/ (issue #92: a brain that carries the launcher's CI runs a build on every note saved)", () => {
+  assert.deepEqual(
+    filterCopyable([
+      "README.md",
+      ".github/workflows/ci.yml",
+      ".github/workflows/mutation-nightly.yml",
+      ".github/ISSUE_TEMPLATE/bug.md",
+      "rag/src/index.ts",
+    ]),
+    ["README.md", "rag/src/index.ts"],
+  );
+});
+
+test("filterCopyable — NO tracked .github/ path survives, asked of the REAL repo listing", () => {
+  // 🛑 THE ASSERTION THAT WOULD HAVE CAUGHT #92, and it is deliberately not a fixture:
+  // the defect was never that a KNOWN workflow slipped through, it was that nobody had
+  // ever asked the question of the actual file list. A fixture answers about the paths
+  // its author thought of; this answers about the ones the repo really has, so a third
+  // workflow added next year is covered by a test written today.
+  //
+  // Real bytes, real cost measured in the field: 19 runs a day, ~720 GitHub Actions
+  // minutes billed to an owner who had only written notes.
+  const tracked = parseLsFilesZ(execFileSync("git", ["ls-files", "-z"], { cwd: REPO_ROOT, encoding: "utf8" }));
+  // The listing itself must be believable: an empty one would make the real assertion
+  // below pass while proving nothing at all (the silent-negative trap).
+  assert.ok(tracked.some((p) => p.startsWith(".github/")), "the repo really does track .github/ files");
+
+  assert.deepEqual(filterCopyable(tracked).filter((p) => p.startsWith(".github/")), []);
 });
 
 test("filterCopyable — the table BUILDER stays home, the TABLE itself ships", () => {

--- a/scripts/lib/workflow-retreat.mjs
+++ b/scripts/lib/workflow-retreat.mjs
@@ -48,6 +48,23 @@ export const SHIPPED_WORKFLOWS = [".github/workflows/ci.yml", ".github/workflows
 // The one directory a retreat may ever reach into.
 const WORKFLOWS_DIR = ".github/workflows/";
 
+// 🗣️ THE SENTENCE, said in MONEY rather than in filenames — the owner's experience of this
+// defect was a bill and a flood of failure mail from the repository holding their notes, so
+// "2 workflow files removed" would be the one report that fails to connect the fix to the
+// thing they actually noticed.
+//
+// It lives HERE, beside the deletion, because two voices say it and they must not drift:
+// `update-engine.mjs` prints it in the update recap, and `reconcile-brain.mjs`'s child
+// process prints it on the ONE run where that recap cannot — the update that performs the
+// rescue is driven by the OLD engine, which has never heard of this sentence, and by the
+// next update there is nothing left to remove. Two copies of a sentence is how one of them
+// quietly becomes false.
+export const BUILDS_STOPPED =
+  "Your brain has stopped running builds in your GitHub account: it used to carry the" +
+  " launcher's own automated checks, so every note you saved started one (and made it fail)." +
+  " A brain stores and syncs your notes, it never builds anything. The failure mail stops," +
+  " and so does the cost.";
+
 /**
  * May this path be removed from a brain? Two refusals, and the second is the one that
  * matters: `startsWith` says where a path BEGINS and has nothing whatever to say about

--- a/scripts/lib/workflow-retreat.mjs
+++ b/scripts/lib/workflow-retreat.mjs
@@ -1,0 +1,101 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// workflow-retreat.mjs — THE ENGINE STOPS RUNNING A BUILD IN THE OWNER'S ACCOUNT
+// (issue #92). The launcher shipped its own CI into every brain; a brain wired to
+// a remote pushes once per turn, so saving a note started a full build matrix in
+// the owner's GitHub account and billed them for it. Measured in the field: 19
+// runs a day, ~720 Actions minutes against a free allowance of 2,000, and every
+// run red, because a brain is not the launcher.
+//
+// Stopping the copy (`tracked-files.mjs`) saves brains created from now on. This
+// is the half for the brains already out there: at their next engine update, the
+// two files go.
+//
+// ── WHY THIS IS NOT `skill-retirement`, which already retires things ──────────
+// That door is PROVENANCE-GUARDED: it removes only what it can prove it delivered,
+// byte for byte, from the brain's recorded provenance. No brain in the field records
+// ANY provenance for these two files — they were in no regime, so nothing ever
+// recorded them, and `engine-fingerprints.json` does not carry them either. Routed
+// through that door, every workflow on every brain would answer `no-provenance` →
+// preserve, and the release would announce a fix that removed nothing.
+//
+// So the proof is a different one, and it is deliberately narrow: we remove the two
+// files THE LAUNCHER HAS EVER SHIPPED, by name. A workflow the owner wrote has a
+// different name and is untouchable — which is the same cost asymmetry ADR 0036
+// wrote down for the status line, reaching the same answer by another route: a
+// leftover file of ours is cosmetic, deleting someone's own automation is not.
+//
+// And the deletion is RECOVERABLE: a brain is a git repository, the update stages
+// with `add -A`, so the removal lands in the owner's own history as a commit they
+// can read and revert. That is what makes "by name, without provenance" affordable
+// here and nowhere else.
+//
+// PURE decision (`isRetreatable`) + the thinnest possible I/O, the house pattern —
+// and it earns its keep loudest here, because this is one of the two places in the
+// product that calls `rmSync` in someone's brain.
+// ─────────────────────────────────────────────────────────────────────────────
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { isSelfHeal } from "./update-mode.mjs";
+
+// 🎯 THE BLAST RADIUS, and it is a literal list of two. No glob, no manifest entry, no
+// value read from anywhere: there is no input to this door, which is precisely what makes
+// it safe enough to ship in a hurry. Adding an entry here is agreeing to delete that file
+// in every brain in the fleet, and a test asserts the list WHOLE so the agreement is
+// explicit rather than incidental.
+export const SHIPPED_WORKFLOWS = [".github/workflows/ci.yml", ".github/workflows/mutation-nightly.yml"];
+
+// The one directory a retreat may ever reach into.
+const WORKFLOWS_DIR = ".github/workflows/";
+
+/**
+ * May this path be removed from a brain? Two refusals, and the second is the one that
+ * matters: `startsWith` says where a path BEGINS and has nothing whatever to say about
+ * where it ends up, so `.github/workflows/../../vault/a-note.md` begins exactly where
+ * this door lives and lands in the owner's notes. Refused by SEGMENT, on both separators
+ * (`path.join` treats `\` as one on Windows), so a legitimate name that merely contains
+ * dots stays removable — a guard that is wrong about honest input is one people widen
+ * instead of read.
+ */
+export function isRetreatable(rel) {
+  if (typeof rel !== "string" || !rel.startsWith(WORKFLOWS_DIR)) return false;
+  return !rel.split(/[\\/]/).some((segment) => segment === "." || segment === "..");
+}
+
+/**
+ * Removes, from a deployed brain, the workflows the launcher used to ship. Returns
+ * `{ removed }` — the paths actually deleted, in declaration order, and empty on the
+ * overwhelming majority of updates (every brain that already converged, and every brain
+ * created after the copy fix). Silent when there is nothing to remove: an owner must not
+ * be told about a rescue that did not happen.
+ */
+export function retireShippedWorkflows({ brainDir, sourceDir }) {
+  const removed = [];
+
+  // ⛔ UPDATE-TIME ONLY, and the gate is here rather than at the call site for the reason
+  // the skills retirement gives for the same choice: this is a line that deletes, so no
+  // caller should have to remember. The SessionStart self-heal runs with the brain as its
+  // own source, detached, with its output going nowhere at all — a delete there is a
+  // delete nobody is ever told about. An ABSENT `sourceDir` is caught by the same line and
+  // deliberately: a caller who has not said this is an update has not earned a deletion,
+  // and "I cannot tell" must fail towards keeping.
+  if (sourceDir === undefined || isSelfHeal({ brainDir, sourceDir })) return { removed };
+
+  for (const rel of SHIPPED_WORKFLOWS) {
+    // The constants above satisfy this today and a test pins that. It is asked anyway,
+    // at the only line that deletes, so the guard cannot be bypassed by editing a list.
+    if (!isRetreatable(rel)) continue;
+    const abs = join(brainDir, rel);
+    if (!existsSync(abs)) continue;
+    // `force` covers the one case no test can stage: the file vanishing between the check
+    // and this line. An update that throws there strands the brain mid-pass over a file
+    // that is already gone, which is the outcome this codebase's fail-soft habit exists to
+    // avoid. The empty `.github/workflows/` directory is left behind on purpose: git does
+    // not track directories, GitHub runs nothing without a file in it, and removing a
+    // directory the owner may have put their own workflow in is a risk that buys nothing.
+    rmSync(abs, { force: true });
+    removed.push(rel);
+  }
+
+  return { removed };
+}

--- a/scripts/lib/workflow-retreat.test.mjs
+++ b/scripts/lib/workflow-retreat.test.mjs
@@ -1,0 +1,152 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SHIPPED_WORKFLOWS, isRetreatable, retireShippedWorkflows } from "./workflow-retreat.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #92 — a brain must never run a build, and the ones already out there
+// must stop. This is the second of the two subtractive doors in the product,
+// and the first to erase anything outside `.claude/skills/`.
+//
+// The proof rule is BY NAME, and that is the whole design: the sibling door
+// (`skill-retirement`) removes only what it can prove it delivered byte for
+// byte, from the brain's recorded provenance. No brain in the field records any
+// provenance for these files — they were in no regime, so nothing ever recorded
+// them — so demanding that proof here would preserve every workflow on every
+// brain and ship a release that claims to have stopped the bill while stopping
+// nothing.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// A brain-shaped directory: the two shipped workflows, plus the owner's territory
+// standing right next to them so every test asserts what SURVIVES, not only what goes.
+function brainWithWorkflows() {
+  const brainDir = mkdtempSync(join(tmpdir(), "kenjaku-workflow-retreat-"));
+  mkdirSync(join(brainDir, ".github", "workflows"), { recursive: true });
+  for (const rel of SHIPPED_WORKFLOWS) writeFileSync(join(brainDir, rel), "on: push\n");
+  mkdirSync(join(brainDir, "vault"), { recursive: true });
+  writeFileSync(join(brainDir, "vault", "a-note.md"), "the owner's note\n");
+  return brainDir;
+}
+
+// An UPDATE, said the one way there is to say it: a source that is not the brain.
+const UPDATE_SOURCE = "/somewhere/else/kenjaku-launcher";
+
+test("retireShippedWorkflows — removes both workflows the launcher ever shipped", () => {
+  const brainDir = brainWithWorkflows();
+
+  const report = retireShippedWorkflows({ brainDir, sourceDir: UPDATE_SOURCE });
+
+  assert.deepEqual(report.removed, [".github/workflows/ci.yml", ".github/workflows/mutation-nightly.yml"]);
+  assert.equal(existsSync(join(brainDir, ".github/workflows/ci.yml")), false);
+  assert.equal(existsSync(join(brainDir, ".github/workflows/mutation-nightly.yml")), false);
+});
+
+test("retireShippedWorkflows — a workflow the OWNER wrote is never touched", () => {
+  // The cost asymmetry this door is built on: a leftover file of ours is cosmetic,
+  // deleting someone's own automation is not. Ours are named; everything else stays.
+  const brainDir = brainWithWorkflows();
+  const theirs = join(brainDir, ".github/workflows/my-own-backup.yml");
+  writeFileSync(theirs, "on: schedule\n");
+
+  const report = retireShippedWorkflows({ brainDir, sourceDir: UPDATE_SOURCE });
+
+  assert.equal(readFileSync(theirs, "utf8"), "on: schedule\n");
+  assert.deepEqual(report.removed, [".github/workflows/ci.yml", ".github/workflows/mutation-nightly.yml"]);
+});
+
+test("retireShippedWorkflows — the owner's vault is untouched, and stays untouched", () => {
+  const brainDir = brainWithWorkflows();
+
+  retireShippedWorkflows({ brainDir, sourceDir: UPDATE_SOURCE });
+
+  assert.equal(readFileSync(join(brainDir, "vault", "a-note.md"), "utf8"), "the owner's note\n");
+});
+
+test("retireShippedWorkflows — nothing to remove is SILENT and not an error", () => {
+  // The overwhelming majority of updates, forever: every brain that already converged,
+  // and every brain created after the copy fix. They must not pay for this and must not
+  // hear about it.
+  const brainDir = mkdtempSync(join(tmpdir(), "kenjaku-workflow-retreat-clean-"));
+
+  const report = retireShippedWorkflows({ brainDir, sourceDir: UPDATE_SOURCE });
+
+  assert.deepEqual(report.removed, []);
+});
+
+test("retireShippedWorkflows — running it twice removes nothing the second time", () => {
+  const brainDir = brainWithWorkflows();
+
+  retireShippedWorkflows({ brainDir, sourceDir: UPDATE_SOURCE });
+  const second = retireShippedWorkflows({ brainDir, sourceDir: UPDATE_SOURCE });
+
+  assert.deepEqual(second.removed, []);
+});
+
+test("retireShippedWorkflows — a SELF-HEAL deletes nothing at all", () => {
+  // The session-start converge runs with the brain as its own source, detached and with
+  // its output going nowhere. A delete there is a delete nobody is ever told about, so
+  // this door is update-time only, exactly like the skills one.
+  const brainDir = brainWithWorkflows();
+
+  const report = retireShippedWorkflows({ brainDir, sourceDir: brainDir });
+
+  assert.deepEqual(report.removed, []);
+  assert.equal(existsSync(join(brainDir, ".github/workflows/ci.yml")), true);
+});
+
+test("retireShippedWorkflows — a self-heal spelled with a trailing slash or dot ALSO deletes nothing", () => {
+  // T8's lesson, inherited rather than re-learned: `<brainDir>/` and `<brainDir>/.` name
+  // the same directory, and a raw string compare opens the gate on both.
+  const brainDir = brainWithWorkflows();
+
+  assert.deepEqual(retireShippedWorkflows({ brainDir, sourceDir: `${brainDir}/` }).removed, []);
+  assert.deepEqual(retireShippedWorkflows({ brainDir, sourceDir: `${brainDir}/.` }).removed, []);
+  assert.equal(existsSync(join(brainDir, ".github/workflows/ci.yml")), true);
+});
+
+test("retireShippedWorkflows — an ABSENT sourceDir deletes nothing: 'I cannot tell' fails towards keeping", () => {
+  const brainDir = brainWithWorkflows();
+
+  assert.deepEqual(retireShippedWorkflows({ brainDir }).removed, []);
+  assert.equal(existsSync(join(brainDir, ".github/workflows/ci.yml")), true);
+});
+
+test("isRetreatable — only paths anchored under .github/workflows/ are ever removable", () => {
+  assert.equal(isRetreatable(".github/workflows/ci.yml"), true);
+  assert.equal(isRetreatable("vault/my-note.md"), false, "the owner's notes");
+  assert.equal(isRetreatable("CLAUDE.md"), false, "the owner's constitution");
+  assert.equal(isRetreatable(".env"), false, "the owner's API key");
+  assert.equal(isRetreatable(".github/FUNDING.yml"), false, "inside .github, but not a workflow");
+  // Anchored at the START, not merely containing: a path that reaches the directory from
+  // somewhere else is not a path that lives in it.
+  assert.equal(isRetreatable("vault/.github/workflows/ci.yml"), false);
+});
+
+test("isRetreatable — a path that CLIMBS OUT is refused, whichever separator it climbs with", () => {
+  // The T12 lesson, and it is the load-bearing one here: `.github/workflows/` is a prefix
+  // check, and a prefix check has nothing to say about where a path ENDS UP. Both
+  // separators, because `path.join` on Windows treats a backslash as one.
+  assert.equal(isRetreatable(".github/workflows/../../vault/a-note.md"), false);
+  assert.equal(isRetreatable(".github/workflows/..\\..\\vault\\a-note.md"), false);
+  assert.equal(isRetreatable(".github/workflows/./ci.yml"), false);
+  // And a legitimate name that merely CONTAINS dots stays removable: a guard that is
+  // wrong about honest input is one people widen instead of read.
+  assert.equal(isRetreatable(".github/workflows/ci..old.yml"), true);
+});
+
+test("isRetreatable — anything that is not a usable string is refused", () => {
+  assert.equal(isRetreatable(undefined), false);
+  assert.equal(isRetreatable(null), false);
+  assert.equal(isRetreatable(""), false);
+  assert.equal(isRetreatable(42), false);
+});
+
+test("SHIPPED_WORKFLOWS — names exactly the two files, and every one of them is retreatable", () => {
+  // The list is the blast radius. Asserted whole rather than by length, so an entry added
+  // here without a second thought fails a test that names what it is agreeing to.
+  assert.deepEqual(SHIPPED_WORKFLOWS, [".github/workflows/ci.yml", ".github/workflows/mutation-nightly.yml"]);
+  for (const rel of SHIPPED_WORKFLOWS) assert.equal(isRetreatable(rel), true, rel);
+});

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -417,7 +417,7 @@ function ancestorLines({ unreachable, unmatched }) {
 }
 
 export function formatReport(report) {
-  const { ref, engineVersion, copied, regenerated, reindexed, reindexReason, vaultNoteCount, committed, installedSkills = [], skillsRefreshed = [], skillsPreserved = [], skillsMerged = [], conflicts = [], scriptsRefreshed = [], scriptsPreserved = [], scriptsMerged = [], scriptConflicts = [], doctrineRefreshed = [], doctrinePreserved = [], doctrineMerged = [], doctrineConflicts = [], skillsRetired = [], skillsRetirePreserved = [], mcpServersAdded = [], hooksAdded = [], hooksRepaired = [], statusLineRemoved = false, pointerUnignored = false, divergence = [], divergenceUnreadable = [], healed = [], ancestorsUnreachable = [], ancestorsUnmatched = [] } = report;
+  const { ref, engineVersion, copied, regenerated, reindexed, reindexReason, vaultNoteCount, committed, installedSkills = [], skillsRefreshed = [], skillsPreserved = [], skillsMerged = [], conflicts = [], scriptsRefreshed = [], scriptsPreserved = [], scriptsMerged = [], scriptConflicts = [], doctrineRefreshed = [], doctrinePreserved = [], doctrineMerged = [], doctrineConflicts = [], skillsRetired = [], skillsRetirePreserved = [], workflowsRetired = [], mcpServersAdded = [], hooksAdded = [], hooksRepaired = [], statusLineRemoved = false, pointerUnignored = false, divergence = [], divergenceUnreadable = [], healed = [], ancestorsUnreachable = [], ancestorsUnmatched = [] } = report;
   // F-B2 (ADR 0026): the engine-owned SessionStart hooks wired into an upgrader's
   // settings.json, by their bare name (scripts/session-health.mjs → session-health).
   const wiredHooks = hooksAdded.map(bareHookName);
@@ -481,6 +481,19 @@ export function formatReport(report) {
     );
   }
   lines.push(...skillsRetirePreserved.map(retiredPreservedLine));
+  // #92 — and this one is said in MONEY, not in filenames. The owner's experience of the
+  // defect was a bill and a flood of failure mail from the repository holding their notes;
+  // "2 workflow files removed" would be the one report that fails to connect the fix to
+  // the thing they actually noticed. Silent when nothing was removed, which is almost
+  // every update: an owner must not be told about a rescue that did not happen.
+  if (workflowsRetired.length > 0) {
+    lines.push(
+      "   • your brain has stopped running builds in your GitHub account: it used to carry" +
+        " the launcher's own automated checks, so every note you saved started one (and made" +
+        " it fail). A brain stores and syncs your notes, it never builds anything. The failure" +
+        " mail stops, and so does the cost.",
+    );
+  }
   // S7-3 — the migration's own event, and it belongs HERE: with what appeared, moved on
   // and went, and BEFORE the preserved/merged family lines, because its whole point is
   // that files which would have been listed as "preserved, we cannot tell" no longer are.
@@ -662,6 +675,9 @@ export async function updateEngine({
     // skill that vanished with no sentence beside it is the worst shape of that.
     skillsRetired,
     skillsRetirePreserved,
+    // #92: the other subtractive door's list, carried for the same reason as the pair
+    // above — a field this does not name is a verdict the owner never hears.
+    workflowsRetired,
     skillsRefreshed,
     skillsPreserved,
     skillsMerged,
@@ -868,6 +884,9 @@ export async function updateEngine({
     installedSkills,
     skillsRetired,
     skillsRetirePreserved,
+    // #92: the other subtractive door's list, carried for the same reason as the pair
+    // above — a field this does not name is a verdict the owner never hears.
+    workflowsRetired,
     skillsRefreshed,
     skillsPreserved,
     skillsMerged,

--- a/scripts/update-engine.mjs
+++ b/scripts/update-engine.mjs
@@ -48,6 +48,7 @@ import {
 } from "./lib/engine-seams.mjs";
 import { defaultFinalizeReconcile } from "./lib/auto-finalize.mjs";
 import { defaultCommitEngineWrites } from "./lib/engine-commit.mjs";
+import { BUILDS_STOPPED } from "./lib/workflow-retreat.mjs";
 
 // Re-export so the engine's own tests keep importing the count seam from here.
 export { defaultCountVaultNotes };
@@ -481,19 +482,11 @@ export function formatReport(report) {
     );
   }
   lines.push(...skillsRetirePreserved.map(retiredPreservedLine));
-  // #92 — and this one is said in MONEY, not in filenames. The owner's experience of the
-  // defect was a bill and a flood of failure mail from the repository holding their notes;
-  // "2 workflow files removed" would be the one report that fails to connect the fix to
-  // the thing they actually noticed. Silent when nothing was removed, which is almost
-  // every update: an owner must not be told about a rescue that did not happen.
-  if (workflowsRetired.length > 0) {
-    lines.push(
-      "   • your brain has stopped running builds in your GitHub account: it used to carry" +
-        " the launcher's own automated checks, so every note you saved started one (and made" +
-        " it fail). A brain stores and syncs your notes, it never builds anything. The failure" +
-        " mail stops, and so does the cost.",
-    );
-  }
+  // #92 — and this one is said in MONEY, not in filenames; the wording lives beside the
+  // deletion (`BUILDS_STOPPED`), because the reconcile child says the same sentence on the
+  // one run where THIS recap cannot. Silent when nothing was removed, which is almost every
+  // update: an owner must not be told about a rescue that did not happen.
+  if (workflowsRetired.length > 0) lines.push(`   • ${BUILDS_STOPPED}`);
   // S7-3 — the migration's own event, and it belongs HERE: with what appeared, moved on
   // and went, and BEFORE the preserved/merged family lines, because its whole point is
   // that files which would have been listed as "preserved, we cannot tell" no longer are.


### PR DESCRIPTION
Closes the mechanism behind #92 (the issue itself stays open until a real brain in the field is seen losing the workflows on update).

## What was happening

`.github/` was never excluded from the install copy, so **every generated brain carried the launcher's own `ci.yml` and `mutation-nightly.yml`**. A brain wired to a remote pushes once per turn, so **saving a note started a full build matrix in the owner's own GitHub account** — measured in the field at ~19 runs a day, ~720 Actions minutes against a free allowance of 2,000, every one of them failing, because a brain is not the launcher. Owners paid for it, and got the failure mail.

## The two halves

**A brain created from now on carries no CI at all.** `.github/` joins `DEV_ONLY_PREFIXES` in `tracked-files.mjs`, the way `maintainers/` already does. Pinned by a test that asks the **real tracked listing**, not a fixture, so a workflow added later is caught too — and that test first asserts the repo really tracks `.github/` files, so an empty listing cannot pass for a clean one. This half needs no release: it lands on merge.

**A brain already installed loses them at its next engine update.** A narrow module of its own, `scripts/lib/workflow-retreat.mjs`, on the shape of `status-line-retreat.mjs` rather than a widening of `retireSkills`.

> **Why not the existing retirement door.** That one is provenance-guarded: it removes only what it can prove it delivered, byte for byte. No brain in the field records *any* provenance for these two files — they were in no regime, so nothing ever recorded them — so every workflow on every brain would answer `no-provenance → preserve`, and the release would have announced a fix that removed nothing.

So the proof rule is a different one, and deliberately narrow: **the two files the launcher has ever shipped, by name.** No glob, no manifest entry, no value read from anywhere — there is no input to this door, which is what makes it safe enough to ship in a hurry. A workflow the **owner** wrote has a different name and is untouchable. Refusals are tested: anything outside `.github/workflows/`, and anything that begins there and climbs back out to `vault/`. It runs at **update time only** (never at the SessionStart self-heal, whose output goes nowhere), it is idempotent, and it is silent when there is nothing to remove — which will be almost every update, forever.

And it is **recoverable**: a brain is a git repository and the update stages with `add -A`, so the removal lands in the owner's own history as a commit they can read and revert.

## The rehearsal found something no unit test could

`node maintainers/qa/field-rehearsal/rehearse.mjs --brain ~/mind-palace --tag v5.1.1`, against a copy of a real brain — exit `0`, both workflow files gone, the deletion inside the update's own commit, the owner's territory byte-identical.

**And the report said nothing about it.** The recap an owner reads is printed by the engine that *ran* the update — the **old** one, which has never heard of this release's sentence — and by the next update there is nothing left to remove. The sentence would have landed *never*, and the rescue would have been a silent deletion of two files inside someone's repository.

Fixed where this codebase already solved that exact problem: the reconcile child's stdout is inherited by the old parent, and `announceWhatTheOldRecapCannot` exists for precisely that moment. Four tests, red first. The wording moved to `BUILDS_STOPPED` beside the deletion, so the update recap and the child cannot drift apart. Re-rehearsed: the sentence is on screen.

## Documentation

One sentence where a remote is wired up (SETUP §7) and where a second person is invited in (duo mode §2): **a brain's repository stores and syncs, it never builds.** Said in the terms the owner experiences — cost, failure mail — and paired with what to do about it, so it reads as a defect to fix rather than a fact of life. Its absence is what let this run for days without anyone suspecting the product.

## Checks

- `scripts/lib/**` suite: **2679 tests, all passing**.
- Field rehearsal on a copy of a real brain: **exit 0**, twice.
- Marketing surface re-read (CONVENTIONS §10): **nothing became false, nothing new to sell, no board to re-render.**
- Mutation runs and the full cross-platform wait were **deliberately waived** by the owner for this hotfix. The argument is recorded in the plan: this change has *no input* — the deletion names two literal paths — so those are the checks with the least to say about this diff.

## Knowingly left out

Step 3 of the plan (making the session-start nudge louder for an owner who never opens an update prompt). It changes a **standing** surface every owner reads at every session start, and it stops nobody's bleeding tonight. It waits for a session with room to read what that nudge says today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kC2WGTrTJNyR97eMHhZ17
