### PR TITLE
v5.1 — five field-reported bugs: the checker stops crying wolf, a silent source stops passing for a quiet one

### DIFF
--- a/.claude/skills/sync-sources/SKILL.md
+++ b/.claude/skills/sync-sources/SKILL.md
@@ -252,6 +252,67 @@ one. See "Identity discipline" just below: the name stays plain text. This secti
    let it become established merely because it has been written down for a while. That is the claim
    discipline's *"yesterday's caveat is a debt"*, applied to the vault's own cards.
 
+## Source liveness — an empty answer and a dead route look exactly the same
+
+> **A source that went quiet must never read as a source with no news.** Reported from the field: during
+> a wide catch-up pass, a mail connector's **search** route stopped returning anything while its **read**
+> route kept working. No error, no warning — the contract says in as many words that an empty result is
+> *not* an error. So from in here, these two are byte-for-byte identical: *the mailbox holds nothing on
+> this subject*, and *the search route is dead and will match nothing, ever, for any query*. The brain
+> reported the first. The reader saw a covered source with no news; what happened is a source that was
+> never read.
+
+**Claim discipline** below grades **what** was retrieved. Nothing grades **whether retrieval happened** —
+a source that returned zero rows produces zero claims to mark, so the marking system stays silent by
+construction. This section is that missing half, and it runs **before** any emptiness is allowed to
+become a statement.
+
+### The control query — the whole discriminator, one call per source
+
+Before writing that a source had nothing, prove the route still answers. One extra call, built to three
+rules:
+
+1. **Through the SAME route that answered empty.** A search route is tested by *searching*. In the report,
+   reading a thread by id worked perfectly throughout — a control that had used the read route would have
+   returned a confident "healthy" about a route that was dead.
+2. **Keyword-free.** A keyword is precisely what makes an honest zero possible. Strip the terms, widen the
+   window as far as the tool accepts.
+3. **Impossible to answer with zero on a live account.** That is the property the whole thing rests on. If
+   a legitimate account could return zero rows for your control, it is not a control.
+
+**Zero rows on the control = the source is DOWN, not empty.**
+
+| Source | The control call | Why zero is impossible on a live account |
+|---|---|---|
+| **Mail** | the search route, **no** terms, a bare recency filter over a wide window (a year, not a week) | a mailbox that received nothing in a year is not a mailbox in use |
+| **Chat** | the search route over a wide window, with the most common word available rather than a topic term; failing that, the channel listing | an account with zero matches on a stop-word over months is not an account in use |
+| **Calendar** | the calendar listing, plus an event listing over the past month | an account always has at least its primary calendar |
+| **Drive** | the search route ordered by modification date, no terms | a drive with nothing modified in a year is not one this brain syncs |
+| **Notion** | the search route with an empty query (the recent pages) | the integration is shared with at least one page, or it would not be wired |
+
+> 🔧 **A connector with no keyword-free form**: use the broadest query you can express, and say in the
+> artifact that the control was **weaker**. A control you cannot build is a reason to flag the source as
+> unproven, **never** a reason to skip the check in silence.
+
+### What a DOWN verdict changes
+
+- **It is an alert, not an omission.** Name it in the reply **and** in the written artifact, on a 🔴 line of
+  its own: *"mail was not read this pass — its search route returned nothing to a control query."* It may
+  never be silently skipped.
+- **It disables every negative claim that depended on it.** With mail down you may not write *"no mail on
+  this topic"* — the sentence is unsupported, exactly as an unverified behavioural claim is. Same bar as
+  the third tier of **Claim discipline** below.
+- **It is never cached.** The verdict is re-established on **every pass** and never inherited from a note —
+  this is *A capability recorded as absent must be re-tested*, applied to liveness. A source recorded as
+  down is retried, not written off.
+- **Pace the fan-out.** The report's own trigger was a wide parallel pass with no throttle, which is
+  plausibly what hit a per-user ceiling. Cap the concurrent calls per connector, and **back off** on a route
+  that starts answering empty rather than hammering it for the rest of the pass.
+
+> ⚖️ **Say what is ours and what is not.** The outage itself belongs to the connector's provider; this repo
+> ships no line of that route, and the same tool answered normally the same day on another account. What is
+> ours, and all this fixes, is that the brain presented an **unread** source as a **read** one.
+
 ## Claim discipline
 
 > **The dangerous output of a second brain is not the fact it invents, it is the SILENCE it
@@ -348,6 +409,13 @@ In parallel, spot what's **new since the last pass** (delta):
 
 Launch all the sub-agents in **a single block of parallel calls**. Each writes its raw
 source to the vault and **returns a ~500-token-max summary**.
+
+> 🩺 **Each search sub-agent runs its control query FIRST**, before anything else — see *Source
+> liveness* above for what the control is per source. If the control comes back empty, the sub-agent
+> returns **"source DOWN, not read"** and no findings at all, rather than a summary that says nothing
+> was found. And **keep the fan-out paced**: this step's wide parallel pass is exactly what tipped a
+> real account over a per-user ceiling, so cap the concurrent calls per connector and **back off** on a
+> route that starts answering empty instead of hammering it for the rest of the pass.
 
 #### "transcript-extractor" sub-agent (one per document)
 

--- a/CLAUDE.engine.md
+++ b/CLAUDE.engine.md
@@ -269,6 +269,20 @@ the watermark didn't advance.
 
 ## Expected Claude Code behaviors
 
+### Line breaks — never one the content did not ask for
+
+**Never insert a line break the content does not require.** A paragraph, a bullet, a quote line: **one single line, however long it is.** Blank lines separate blocks, and they are the only breaks that are legitimate.
+
+**The trigger is the DESTINATION, not the medium.** This holds for everything you write in Markdown: vault notes, cheat sheets, article drafts, **messages to send**, and **fenced blocks in the chat** — that last one especially, because a fenced block is precisely the text the owner copies out into Slack, an email or a document. Read as a rule about *files*, it fires on the notes and misses the very thing that leaves this conversation, which is exactly how it kept being broken.
+
+Why this is not a matter of taste: Obsidian, Typora, Slack and every mail client wrap on their own, at the width of the window they are being read in. A break coded into the text cannot adapt — it shows up as a ragged half-line on a phone, and it fights the owner every time they edit that paragraph.
+
+⚠️ **The existing notes will argue against this.** A vault written before the rule holds paragraphs cut at ~100 characters, and "match the surrounding style" is enough to reproduce the defect forever. **The convention wins over the corpus.**
+
+🔧 **The deterministic net covers FILES only**: `node scripts/unwrap-markdown.mjs <file|folder>` rewrites them in place, and `--check` reports what would change without touching anything. Nothing can inspect what is printed into a chat before the owner reads it, so that half is a written reflex by construction — there is no machine to build for it, which is why the rule is stated here at length rather than delegated to the script.
+
+> 📄 **If your own `CLAUDE.md` carries a copy of this rule, delete it.** Two files holding one rule is a guarantee that they will diverge, and this layer is the one that gets refreshed. If you genuinely want hard wrapping (git-friendly diffs, an 80-column habit), keep a line in your `CLAUDE.md` saying so — as an **override**, so the next reader can see it is deliberate.
+
 ### Advisory posture on the harness
 
 Claude must **challenge requests to modify the harness** (CLAUDE.md, `.claude/`, skills, hooks). Before implementing a harness change:

--- a/CLAUDE.engine.md
+++ b/CLAUDE.engine.md
@@ -412,6 +412,31 @@ the **next** resolution resolves against. A briefing turned a source's *"Jérém
   resolving anything against it, and never let it become established just for having been written
   down a while ago.
 
+### Source liveness — a source that went quiet is not a source with no news
+
+A connector's contract says an empty result is **not** an error. So *"the mailbox holds nothing on this
+subject"* and *"the search route is dead and will match nothing, ever"* arrive in exactly the same shape,
+and reporting the first one turns a source that was **never read** into a source with nothing to report.
+Reported from the field, on a wide catch-up pass: search stopped answering while reading a known thread
+kept working, and nothing said a word.
+
+- **The discriminator is a control query**, one extra call per source, before any emptiness becomes a
+  statement. Three properties, and all three are load-bearing: it goes through the **same route** that
+  answered empty (reading is no proof that searching works), it is **keyword-free** (a keyword is what
+  makes an honest zero possible), and it is built so that zero rows is **impossible on a live account**.
+  The control for each source you can wire is tabled in the `sync-sources` skill.
+- **Zero rows on the control = the source is DOWN, not empty.**
+- **A down source is an alert, never a silent omission.** Name it in the reply and in whatever you write,
+  on its own 🔴 line: *"mail was not read this pass, its search route answered nothing to a control query."*
+- **A down source disables every negative claim that depended on it.** You may not write *"no mail on this
+  topic"*: the sentence is unsupported, at the same bar as the unverified behavioural claims in *Claim
+  discipline* just below.
+- **The verdict is re-established on every pass, never inherited** from a note or a previous briefing, and
+  **pace the fan-out**: cap the concurrent calls per connector and **back off** on a route that starts
+  answering empty, rather than hammering it for the rest of the pass.
+
+> ⚖️ The outage itself belongs to the provider. What is yours is not presenting an unread source as a read one.
+
 ### Claim discipline — the silence you report is the dangerous part
 
 A search returns what is **relevant**, never what is **complete**. So when nothing comes back, that

--- a/EN-QUOI-C-EST-DIFFERENT.md
+++ b/EN-QUOI-C-EST-DIFFERENT.md
@@ -144,8 +144,10 @@ by using it: your notes, your rules (`CLAUDE.md`), your skills.
    not findable outside the vault): if the right answer comes out, it means the brain genuinely queried
    **your** data and not the Internet. And when a search comes back empty, it tells you **"I found
    nothing"** — never *"nobody decided"*: a silence it has not verified is reported as a silence, not
-   promoted into a fact. The same rule applies to **people**: a first name it cannot resolve against
-   your notes stays a first name, never a surname it filled in for you.
+   promoted into a fact. And since **v5.1.3** it goes one step further: before reporting that a source
+   is quiet, it runs a check on that source which it knows must return something, so **a connection
+   that is down stops passing for a week with no news**. The same rule applies to **people**: a first
+   name it cannot resolve against your notes stays a first name, never a surname it filled in for you.
 
 And a rare stance: **safe by construction.** The brain **takes no action** on your
 tools — it **reads and answers**, period. Nothing goes out in your name. (Action capabilities can be

--- a/README.md
+++ b/README.md
@@ -362,7 +362,10 @@ tested and fail-loud**. The through-line — **fail loudly rather than pretend**
 - **Index identity stamp + confirm-gate** — swapping embedders never silently corrupts the index. *(ADR 0006)*
 - **Silence is reported as silence** — when a search comes back empty, your brain says *"I found nothing,
   here is where I looked"*, instead of turning it into *"nobody decided"*. What it observed and what it
-  inferred are told apart, on the page, every time.
+  inferred are told apart, on the page, every time. **And since v5.1.3, a source it could not reach is
+  told apart from a source with nothing to say**: before reporting quiet, it runs one check on that same
+  source that it knows must come back with something — if that comes back empty too, you are told the
+  connection is down, not that all is calm.
 - **It never invents a colleague** — before writing about someone, it looks them up in *your* notes. A
   first name it can't resolve stays plain text instead of becoming a page for a person who doesn't exist;
   when your notes hold three Romains, the page says **which** one; and a name it worked out rather than

--- a/engine-manifest.json
+++ b/engine-manifest.json
@@ -5,7 +5,7 @@
     "rag": "1.5.0",
     "local-mirror": "0.3.0",
     "constitutionTemplate": "1.4.0",
-    "scripts": "1.17.0"
+    "scripts": "1.18.0"
   },
   "indexSchemaVersion": 2,
   "regimes": {
@@ -42,6 +42,7 @@
       "scripts/health-probe-run.mjs",
     "scripts/upstream-check-run.mjs",
       "scripts/lint-vault.mjs",
+      "scripts/unwrap-markdown.mjs",
       "scripts/file-back-note.mjs",
       "scripts/consolidate-scan.mjs",
       "scripts/refresh-note.mjs",

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -233,6 +233,62 @@ local-mirror's `fs-state-store` and `content-hash`.
 
 ---
 
+## v5.1 bug-fix release — the five field issues, measured the day each file was written — 2026-09-11
+
+State owned by
+[`../plans/prospective/clear-the-tracker-action.md`](../plans/prospective/clear-the-tracker-action.md)
+(§ *v5.1*). Branch `fix/v5.1-bugfixes`. Two brand-new production files (the deterministic net the
+no-hard-wrap rule names, #95) plus the changed hunks of the wiki checker (#71, #73, #74). #80 ships
+doctrine only and has no production code to mutate; it is guarded by
+`lib/source-liveness-discipline.test.mjs` instead.
+
+| File (scope) | First pass | After | Survivors left |
+|---|---|---|---|
+| `lib/unwrap-markdown.mjs` (new, whole) | 81.45 % | **98.36 %** | 2, both equivalent |
+| `unwrap-markdown.mjs` (new, whole) | 98.41 % | **100.00 %** | 0 |
+| `lib/wiki-lint.mjs:33-43` (link extraction) | **100.00 %** | — | 0 |
+| `lib/wiki-lint.mjs:66-90` (the resolver) | 84.62 % | **92.31 %** | 1, an unreachable default |
+| `lib/wiki-lint.mjs:126-134` (the zones) | **100.00 %** | — | 0 |
+| `lib/wiki-lint-io.mjs:28-41` (the attachment reader) | **100.00 %** | — | 0 |
+| `lib/consolidation-candidates.mjs:58-90` | **96.30 %** | — | 1, same unreachable-default shape |
+| `lint-vault.mjs:37-44` | **100.00 %** | — | 0 |
+| `consolidate-scan.mjs:38-45` | **100.00 %** | — | 0 |
+| `session-wiki-health.mjs:36-50` | 60.00 % | **80.00 %** | 2, both on one unobservable seam |
+
+**The 81.45 % is the entry worth reading, because the tests were not thin.** Twenty-six of them, every
+refusal the rewriter makes covered by a case that names the file it would corrupt. What twenty-three
+survivors said is that the batch proved each refusal **fires** and never proved **where it stops**:
+an anchor dropped, a quantifier loosened, a `.trim()` removed. Every one of those is a real defect on
+a real document — an indented fence or table stops being protected the moment it nests inside a list,
+and a paragraph that merely mentions a pipe, a dash or a `<` never joins again. Sixteen boundary cases
+took it to 97.58 %.
+
+**Two of the three left at 97.58 % were answered by DELETING indirection, not by adding tests** — the
+same shape as the duo run below. The quote depth was a counter standing in for the quote context, so
+incrementing or decrementing it made no observable difference; the trailing-whitespace strip used a
+greedy pattern where at most one character can ever reach it, two being a hard break already refuted a
+line above. Comparing the rebuilt prefix string and calling `trimEnd()` say what the rules actually
+are, and both mutants stopped being equivalent.
+
+**Two survivors in this run were REAL, and one of them found a second bug.**
+
+- `toPosix` in the new CLI: a mutant that **deleted** the path separator instead of converting it
+  lived through every local run, because on macOS `join()` never produces a backslash and the
+  conversion is dead code there. On Windows it prints `vaultpeoplejane-doe.md`. Exactly the class
+  CONVENTIONS §9 exists for, and it took the file to 100 %.
+- The resolver's `attachments` default: asking why it was reachable at all led to the **second
+  caller**, `consolidationCandidates`, which resolves the same links. #71 was live there too — a
+  pasted screenshot had stopped being reported as a dead link and started being proposed as a page to
+  create, called `screenshot.png` — and resolving an attachment there would have thrown a `TypeError`
+  reading frontmatter off something that is not a note, inside a **fail-open** hook where the crash
+  surfaces as the entire nudge silently vanishing.
+
+**The survivors left are all one shape**: a default value nothing production reaches, mutated into a
+sentinel only a link literally spelled like it could observe. `buildResolver`'s `= []`,
+`consolidationCandidates`' `?? []`, and `sessionWikiHealth`'s `readAttachments = () => []` (whose
+`() => undefined` twin is equivalent too, since both downstream readers normalise with `??`). Named in
+place in the code rather than chased.
+
 ## v5.1 step 9 — the safeguards a duo owes the owner, and a flaky suite caught manufacturing a kill — 2026-09-05/06
 
 State owned by

--- a/maintainers/mutation/RESULTS.md
+++ b/maintainers/mutation/RESULTS.md
@@ -233,7 +233,7 @@ local-mirror's `fs-state-store` and `content-hash`.
 
 ---
 
-## v5.1 bug-fix release — the five field issues, measured the day each file was written — 2026-09-11
+## v5.1.3 — the five field issues, measured the day each file was written — 2026-09-11
 
 State owned by
 [`../plans/prospective/clear-the-tracker-action.md`](../plans/prospective/clear-the-tracker-action.md)

--- a/maintainers/mutation/reports/mutate-one-consolidate-scan-38-45.log
+++ b/maintainers/mutation/reports/mutate-one-consolidate-scan-38-45.log
@@ -1,0 +1,21 @@
+[32m08:35:15 (94339) INFO ProjectReader[39m Found 1 of 1032 file(s) to be mutated.
+[32m08:35:15 (94339) INFO Instrumenter[39m Instrumented 1 source file(s) with 3 mutant(s)
+[32m08:35:15 (94339) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:35:15 (94339) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-ZX0U8c
+[32m08:35:15 (94339) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:35:15 (94339) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:35:15 (94339) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 210 ms, overhead 1 ms).
+
+All tests
+  ✓ All tests (killed 3)
+
+Ran 1.00 tests per mutant on average.
+----------------------|------------------|----------|-----------|------------|----------|----------|
+                      | % Mutation score |          |           |            |          |          |
+File                  |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+----------------------|--------|---------|----------|-----------|------------|----------|----------|
+All files             | 100.00 |  100.00 |        3 |         0 |          0 |        0 |        0 |
+ consolidate-scan.mjs | 100.00 |  100.00 |        3 |         0 |          0 |        0 |        0 |
+----------------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:35:15 (94339) INFO MutationTestExecutor[39m Done in 0 seconds.
+[32m08:35:15 (94339) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-ZX0U8c.

--- a/maintainers/mutation/reports/mutate-one-consolidation-candidates-58-90.log
+++ b/maintainers/mutation/reports/mutate-one-consolidation-candidates-58-90.log
@@ -1,0 +1,26 @@
+[32m08:35:16 (94393) INFO ProjectReader[39m Found 1 of 1032 file(s) to be mutated.
+[32m08:35:16 (94393) INFO Instrumenter[39m Instrumented 1 source file(s) with 27 mutant(s)
+[32m08:35:16 (94393) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:35:16 (94393) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-nSUc5h
+[32m08:35:16 (94393) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:35:16 (94393) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:35:16 (94393) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 278 ms, overhead 0 ms).
+
+All tests
+  ✓ All tests (killed 26)
+
+[Survived] ArrayDeclaration
+scripts/lib/consolidation-candidates.mjs:62:63
+-     const resolve = buildResolver(notes, options.attachments ?? []);
++     const resolve = buildResolver(notes, options.attachments ?? ["Stryker was here"]);
+
+Ran 1.00 tests per mutant on average.
+------------------------------|------------------|----------|-----------|------------|----------|----------|
+                              | % Mutation score |          |           |            |          |          |
+File                          |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+------------------------------|--------|---------|----------|-----------|------------|----------|----------|
+All files                     |  96.30 |   96.30 |       26 |         0 |          1 |        0 |        0 |
+ consolidation-candidates.mjs |  96.30 |   96.30 |       26 |         0 |          1 |        0 |        0 |
+------------------------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:35:18 (94393) INFO MutationTestExecutor[39m Done in 2 seconds.
+[32m08:35:18 (94393) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-nSUc5h.

--- a/maintainers/mutation/reports/mutate-one-lint-vault-37-44.log
+++ b/maintainers/mutation/reports/mutate-one-lint-vault-37-44.log
@@ -1,0 +1,21 @@
+[32m08:35:12 (94193) INFO ProjectReader[39m Found 1 of 1032 file(s) to be mutated.
+[32m08:35:12 (94193) INFO Instrumenter[39m Instrumented 1 source file(s) with 2 mutant(s)
+[32m08:35:12 (94193) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:35:12 (94193) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-aKA0j2
+[32m08:35:12 (94193) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:35:12 (94193) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:35:12 (94193) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 361 ms, overhead 0 ms).
+
+All tests
+  ✓ All tests (killed 2)
+
+Ran 1.00 tests per mutant on average.
+----------------|------------------|----------|-----------|------------|----------|----------|
+                | % Mutation score |          |           |            |          |          |
+File            |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+----------------|--------|---------|----------|-----------|------------|----------|----------|
+All files       | 100.00 |  100.00 |        2 |         0 |          0 |        0 |        0 |
+ lint-vault.mjs | 100.00 |  100.00 |        2 |         0 |          0 |        0 |        0 |
+----------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:35:13 (94193) INFO MutationTestExecutor[39m Done in 0 seconds.
+[32m08:35:13 (94193) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-aKA0j2.

--- a/maintainers/mutation/reports/mutate-one-session-wiki-health-36-50.log
+++ b/maintainers/mutation/reports/mutate-one-session-wiki-health-36-50.log
@@ -1,13 +1,13 @@
-[32m08:35:13 (94261) INFO ProjectReader[39m Found 1 of 1032 file(s) to be mutated.
-[32m08:35:13 (94261) INFO Instrumenter[39m Instrumented 1 source file(s) with 10 mutant(s)
-[32m08:35:13 (94261) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
-[32m08:35:13 (94261) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-yQ7V68
-[32m08:35:13 (94261) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
-[32m08:35:13 (94261) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
-[32m08:35:14 (94261) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 260 ms, overhead 0 ms).
+[32m08:36:06 (99411) INFO ProjectReader[39m Found 1 of 1037 file(s) to be mutated.
+[32m08:36:06 (99411) INFO Instrumenter[39m Instrumented 1 source file(s) with 10 mutant(s)
+[32m08:36:06 (99411) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:36:06 (99411) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-0LNEoc
+[32m08:36:06 (99411) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:36:06 (99411) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:36:06 (99411) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 257 ms, overhead 0 ms).
 
 All tests
-  ✓ All tests (killed 6)
+  ✓ All tests (killed 8)
 
 [Survived] ArrayDeclaration
 scripts/session-wiki-health.mjs:36:72
@@ -19,23 +19,13 @@ scripts/session-wiki-health.mjs:36:66
 -   export function sessionWikiHealth({ readNotes, readAttachments = () => [], vaultDir, emit }) {
 +   export function sessionWikiHealth({ readNotes, readAttachments = () => undefined, vaultDir, emit }) {
 
-[Survived] ObjectLiteral
-scripts/session-wiki-health.mjs:49:14
--         return { reported: true };
-+         return {};
-
-[Survived] BooleanLiteral
-scripts/session-wiki-health.mjs:49:26
--         return { reported: true };
-+         return { reported: false };
-
 Ran 1.00 tests per mutant on average.
 -------------------------|------------------|----------|-----------|------------|----------|----------|
                          | % Mutation score |          |           |            |          |          |
 File                     |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
 -------------------------|--------|---------|----------|-----------|------------|----------|----------|
-All files                |  60.00 |   60.00 |        6 |         0 |          4 |        0 |        0 |
- session-wiki-health.mjs |  60.00 |   60.00 |        6 |         0 |          4 |        0 |        0 |
+All files                |  80.00 |   80.00 |        8 |         0 |          2 |        0 |        0 |
+ session-wiki-health.mjs |  80.00 |   80.00 |        8 |         0 |          2 |        0 |        0 |
 -------------------------|--------|---------|----------|-----------|------------|----------|----------|
-[32m08:35:14 (94261) INFO MutationTestExecutor[39m Done in 1 second.
-[32m08:35:14 (94261) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-yQ7V68.
+[32m08:36:07 (99411) INFO MutationTestExecutor[39m Done in 1 second.
+[32m08:36:07 (99411) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-0LNEoc.

--- a/maintainers/mutation/reports/mutate-one-session-wiki-health-36-50.log
+++ b/maintainers/mutation/reports/mutate-one-session-wiki-health-36-50.log
@@ -1,0 +1,41 @@
+[32m08:35:13 (94261) INFO ProjectReader[39m Found 1 of 1032 file(s) to be mutated.
+[32m08:35:13 (94261) INFO Instrumenter[39m Instrumented 1 source file(s) with 10 mutant(s)
+[32m08:35:13 (94261) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:35:13 (94261) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-yQ7V68
+[32m08:35:13 (94261) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:35:13 (94261) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:35:14 (94261) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 260 ms, overhead 0 ms).
+
+All tests
+  ✓ All tests (killed 6)
+
+[Survived] ArrayDeclaration
+scripts/session-wiki-health.mjs:36:72
+-   export function sessionWikiHealth({ readNotes, readAttachments = () => [], vaultDir, emit }) {
++   export function sessionWikiHealth({ readNotes, readAttachments = () => ["Stryker was here"], vaultDir, emit }) {
+
+[Survived] ArrowFunction
+scripts/session-wiki-health.mjs:36:66
+-   export function sessionWikiHealth({ readNotes, readAttachments = () => [], vaultDir, emit }) {
++   export function sessionWikiHealth({ readNotes, readAttachments = () => undefined, vaultDir, emit }) {
+
+[Survived] ObjectLiteral
+scripts/session-wiki-health.mjs:49:14
+-         return { reported: true };
++         return {};
+
+[Survived] BooleanLiteral
+scripts/session-wiki-health.mjs:49:26
+-         return { reported: true };
++         return { reported: false };
+
+Ran 1.00 tests per mutant on average.
+-------------------------|------------------|----------|-----------|------------|----------|----------|
+                         | % Mutation score |          |           |            |          |          |
+File                     |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+-------------------------|--------|---------|----------|-----------|------------|----------|----------|
+All files                |  60.00 |   60.00 |        6 |         0 |          4 |        0 |        0 |
+ session-wiki-health.mjs |  60.00 |   60.00 |        6 |         0 |          4 |        0 |        0 |
+-------------------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:35:14 (94261) INFO MutationTestExecutor[39m Done in 1 second.
+[32m08:35:14 (94261) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-yQ7V68.

--- a/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
+++ b/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
@@ -1,94 +1,19 @@
-[32m08:20:08 (17164) INFO ProjectReader[39m Found 1 of 1028 file(s) to be mutated.
-[32m08:20:08 (17164) INFO Instrumenter[39m Instrumented 1 source file(s) with 124 mutant(s)
-[32m08:20:08 (17164) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
-[32m08:20:08 (17164) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-oe6tvh
-[32m08:20:08 (17164) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
-[32m08:20:08 (17164) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
-[32m08:20:08 (17164) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 276 ms, overhead 0 ms).
-Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (17 survived, 0 timed out)
-Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (17 survived, 0 timed out)
-Mutation testing 26% (elapsed: <1m, remaining: ~1m) 33/124 tested (17 survived, 0 timed out)
-Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (23 survived, 5 timed out)
-Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (23 survived, 5 timed out)
-Mutation testing 99% (elapsed: ~1m, remaining: n/a) 123/124 tested (23 survived, 5 timed out)
+[32m08:25:36 (18376) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
+[32m08:25:37 (18376) INFO Instrumenter[39m Instrumented 1 source file(s) with 124 mutant(s)
+[32m08:25:37 (18376) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:25:37 (18376) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-9HDsTd
+[32m08:25:37 (18376) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:25:37 (18376) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:25:37 (18376) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 249 ms, overhead 0 ms).
+Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (2 survived, 0 timed out)
+Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (2 survived, 0 timed out)
+Mutation testing 26% (elapsed: <1m, remaining: ~1m) 33/124 tested (2 survived, 0 timed out)
+Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (3 survived, 5 timed out)
+Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (3 survived, 5 timed out)
+Mutation testing 99% (elapsed: ~1m, remaining: n/a) 123/124 tested (3 survived, 5 timed out)
 
 All tests
-  ✓ All tests (killed 95)
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:20:25
--   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
-+   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:20:25
--   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
-+   const HORIZONTAL_RULE = /(-{3,}|\*{3,}|_{3,})$/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:20:25
--   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
-+   const HORIZONTAL_RULE = /^(-|\*{3,}|_{3,})$/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:20:25
--   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
-+   const HORIZONTAL_RULE = /^(-{3,}|\*|_{3,})$/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:20:25
--   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
-+   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_)$/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:21:15
--   const FENCE = /^\s*(```|~~~)/;
-+   const FENCE = /\s*(```|~~~)/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:22:19
--   const TABLE_ROW = /^\s*\|/;
-+   const TABLE_ROW = /^\S*\|/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:22:19
--   const TABLE_ROW = /^\s*\|/;
-+   const TABLE_ROW = /\s*\|/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:21:15
--   const FENCE = /^\s*(```|~~~)/;
-+   const FENCE = /^\S*(```|~~~)/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:23:20
--   const HTML_BLOCK = /^\s*</;
-+   const HTML_BLOCK = /\s*</;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:24:25
--   const LIST_ITEM_START = /^([-*+]|\d+[.)])\s/;
-+   const LIST_ITEM_START = /^([-*+]|\d[.)])\s/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:24:25
--   const LIST_ITEM_START = /^([-*+]|\d+[.)])\s/;
-+   const LIST_ITEM_START = /([-*+]|\d+[.)])\s/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:23:20
--   const HTML_BLOCK = /^\s*</;
-+   const HTML_BLOCK = /^\S*</;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:29:29
--   const EXPLICIT_HARD_BREAK = /(\s{2}|\\)$/;
-+   const EXPLICIT_HARD_BREAK = /(\s{2}|\\)/;
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:29:29
--   const EXPLICIT_HARD_BREAK = /(\s{2}|\\)$/;
-+   const EXPLICIT_HARD_BREAK = /(\s|\\)$/;
+  ✓ All tests (killed 115)
 
 [Survived] UpdateOperator
 scripts/lib/unwrap-markdown.mjs:40:5
@@ -100,43 +25,18 @@ scripts/lib/unwrap-markdown.mjs:41:31
 -       content = content.replace(/^\s*>\s?/, "");
 +       content = content.replace(/\s*>\s?/, "");
 
-[Survived] MethodExpression
-scripts/lib/unwrap-markdown.mjs:49:19
--     const trimmed = content.trim();
-+     const trimmed = content;
-
-[Survived] MethodExpression
-scripts/lib/unwrap-markdown.mjs:57:62
--     return !opensItsOwnBlock(content) && !LIST_ITEM_START.test(content.trim());
-+     return !opensItsOwnBlock(content) && !LIST_ITEM_START.test(content);
-
-[Survived] MethodExpression
-scripts/lib/unwrap-markdown.mjs:89:20
--       if (i === 0 && line.trim() === FRONTMATTER_DELIMITER) {
-+       if (i === 0 && line === FRONTMATTER_DELIMITER) {
-
-[Survived] MethodExpression
-scripts/lib/unwrap-markdown.mjs:95:11
--         if (line.trim() === FRONTMATTER_DELIMITER) inFrontmatter = false;
-+         if (line === FRONTMATTER_DELIMITER) inFrontmatter = false;
-
 [Survived] Regex
 scripts/lib/unwrap-markdown.mjs:118:48
 -           out[openLine.index] = previous.replace(/\s+$/, "") + " " + content.trim();
 +           out[openLine.index] = previous.replace(/\s$/, "") + " " + content.trim();
-
-[Survived] StringLiteral
-scripts/lib/unwrap-markdown.mjs:118:56
--           out[openLine.index] = previous.replace(/\s+$/, "") + " " + content.trim();
-+           out[openLine.index] = previous.replace(/\s+$/, "Stryker was here!") + " " + content.trim();
 
 Ran 0.95 tests per mutant on average.
 ---------------------|------------------|----------|-----------|------------|----------|----------|
                      | % Mutation score |          |           |            |          |          |
 File                 |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
 ---------------------|--------|---------|----------|-----------|------------|----------|----------|
-All files            |  81.45 |   81.45 |       95 |         6 |         23 |        0 |        0 |
- unwrap-markdown.mjs |  81.45 |   81.45 |       95 |         6 |         23 |        0 |        0 |
+All files            |  97.58 |   97.58 |      115 |         6 |          3 |        0 |        0 |
+ unwrap-markdown.mjs |  97.58 |   97.58 |      115 |         6 |          3 |        0 |        0 |
 ---------------------|--------|---------|----------|-----------|------------|----------|----------|
-[32m08:21:15 (17164) INFO MutationTestExecutor[39m Done in 1 minute and 6 seconds.
-[32m08:21:15 (17164) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-oe6tvh.
+[32m08:26:43 (18376) INFO MutationTestExecutor[39m Done in 1 minute and 6 seconds.
+[32m08:26:43 (18376) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-9HDsTd.

--- a/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
+++ b/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
@@ -1,26 +1,21 @@
-[32m08:28:59 (20298) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
-[32m08:29:00 (20298) INFO Instrumenter[39m Instrumented 1 source file(s) with 63 mutant(s)
-[32m08:29:00 (20298) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
-[32m08:29:00 (20298) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-eYsLea
-[32m08:29:00 (20298) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
-[32m08:29:00 (20298) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
-[32m08:29:00 (20298) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 249 ms, overhead 0 ms).
+[32m08:29:42 (20738) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
+[32m08:29:42 (20738) INFO Instrumenter[39m Instrumented 1 source file(s) with 63 mutant(s)
+[32m08:29:42 (20738) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:29:42 (20738) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-wDugnr
+[32m08:29:42 (20738) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:29:42 (20738) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:29:42 (20738) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 250 ms, overhead 0 ms).
 
 All tests
-  ✓ All tests (killed 62)
-
-[Survived] StringLiteral
-scripts/unwrap-markdown.mjs:25:43
--   const toPosix = (p) => p.split("\\").join("/");
-+   const toPosix = (p) => p.split("\\").join("");
+  ✓ All tests (killed 63)
 
 Ran 1.00 tests per mutant on average.
 ---------------------|------------------|----------|-----------|------------|----------|----------|
                      | % Mutation score |          |           |            |          |          |
 File                 |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
 ---------------------|--------|---------|----------|-----------|------------|----------|----------|
-All files            |  98.41 |   98.41 |       62 |         0 |          1 |        0 |        0 |
- unwrap-markdown.mjs |  98.41 |   98.41 |       62 |         0 |          1 |        0 |        0 |
+All files            | 100.00 |  100.00 |       63 |         0 |          0 |        0 |        0 |
+ unwrap-markdown.mjs | 100.00 |  100.00 |       63 |         0 |          0 |        0 |        0 |
 ---------------------|--------|---------|----------|-----------|------------|----------|----------|
-[32m08:29:04 (20298) INFO MutationTestExecutor[39m Done in 4 seconds.
-[32m08:29:04 (20298) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-eYsLea.
+[32m08:29:46 (20738) INFO MutationTestExecutor[39m Done in 4 seconds.
+[32m08:29:46 (20738) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-wDugnr.

--- a/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
+++ b/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
@@ -1,0 +1,142 @@
+[32m08:20:08 (17164) INFO ProjectReader[39m Found 1 of 1028 file(s) to be mutated.
+[32m08:20:08 (17164) INFO Instrumenter[39m Instrumented 1 source file(s) with 124 mutant(s)
+[32m08:20:08 (17164) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:20:08 (17164) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-oe6tvh
+[32m08:20:08 (17164) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:20:08 (17164) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:20:08 (17164) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 276 ms, overhead 0 ms).
+Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (17 survived, 0 timed out)
+Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (17 survived, 0 timed out)
+Mutation testing 26% (elapsed: <1m, remaining: ~1m) 33/124 tested (17 survived, 0 timed out)
+Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (23 survived, 5 timed out)
+Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (23 survived, 5 timed out)
+Mutation testing 99% (elapsed: ~1m, remaining: n/a) 123/124 tested (23 survived, 5 timed out)
+
+All tests
+  ✓ All tests (killed 95)
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:20:25
+-   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
++   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:20:25
+-   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
++   const HORIZONTAL_RULE = /(-{3,}|\*{3,}|_{3,})$/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:20:25
+-   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
++   const HORIZONTAL_RULE = /^(-|\*{3,}|_{3,})$/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:20:25
+-   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
++   const HORIZONTAL_RULE = /^(-{3,}|\*|_{3,})$/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:20:25
+-   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
++   const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_)$/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:21:15
+-   const FENCE = /^\s*(```|~~~)/;
++   const FENCE = /\s*(```|~~~)/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:22:19
+-   const TABLE_ROW = /^\s*\|/;
++   const TABLE_ROW = /^\S*\|/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:22:19
+-   const TABLE_ROW = /^\s*\|/;
++   const TABLE_ROW = /\s*\|/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:21:15
+-   const FENCE = /^\s*(```|~~~)/;
++   const FENCE = /^\S*(```|~~~)/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:23:20
+-   const HTML_BLOCK = /^\s*</;
++   const HTML_BLOCK = /\s*</;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:24:25
+-   const LIST_ITEM_START = /^([-*+]|\d+[.)])\s/;
++   const LIST_ITEM_START = /^([-*+]|\d[.)])\s/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:24:25
+-   const LIST_ITEM_START = /^([-*+]|\d+[.)])\s/;
++   const LIST_ITEM_START = /([-*+]|\d+[.)])\s/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:23:20
+-   const HTML_BLOCK = /^\s*</;
++   const HTML_BLOCK = /^\S*</;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:29:29
+-   const EXPLICIT_HARD_BREAK = /(\s{2}|\\)$/;
++   const EXPLICIT_HARD_BREAK = /(\s{2}|\\)/;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:29:29
+-   const EXPLICIT_HARD_BREAK = /(\s{2}|\\)$/;
++   const EXPLICIT_HARD_BREAK = /(\s|\\)$/;
+
+[Survived] UpdateOperator
+scripts/lib/unwrap-markdown.mjs:40:5
+-       depth++;
++       depth--;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:41:31
+-       content = content.replace(/^\s*>\s?/, "");
++       content = content.replace(/\s*>\s?/, "");
+
+[Survived] MethodExpression
+scripts/lib/unwrap-markdown.mjs:49:19
+-     const trimmed = content.trim();
++     const trimmed = content;
+
+[Survived] MethodExpression
+scripts/lib/unwrap-markdown.mjs:57:62
+-     return !opensItsOwnBlock(content) && !LIST_ITEM_START.test(content.trim());
++     return !opensItsOwnBlock(content) && !LIST_ITEM_START.test(content);
+
+[Survived] MethodExpression
+scripts/lib/unwrap-markdown.mjs:89:20
+-       if (i === 0 && line.trim() === FRONTMATTER_DELIMITER) {
++       if (i === 0 && line === FRONTMATTER_DELIMITER) {
+
+[Survived] MethodExpression
+scripts/lib/unwrap-markdown.mjs:95:11
+-         if (line.trim() === FRONTMATTER_DELIMITER) inFrontmatter = false;
++         if (line === FRONTMATTER_DELIMITER) inFrontmatter = false;
+
+[Survived] Regex
+scripts/lib/unwrap-markdown.mjs:118:48
+-           out[openLine.index] = previous.replace(/\s+$/, "") + " " + content.trim();
++           out[openLine.index] = previous.replace(/\s$/, "") + " " + content.trim();
+
+[Survived] StringLiteral
+scripts/lib/unwrap-markdown.mjs:118:56
+-           out[openLine.index] = previous.replace(/\s+$/, "") + " " + content.trim();
++           out[openLine.index] = previous.replace(/\s+$/, "Stryker was here!") + " " + content.trim();
+
+Ran 0.95 tests per mutant on average.
+---------------------|------------------|----------|-----------|------------|----------|----------|
+                     | % Mutation score |          |           |            |          |          |
+File                 |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+---------------------|--------|---------|----------|-----------|------------|----------|----------|
+All files            |  81.45 |   81.45 |       95 |         6 |         23 |        0 |        0 |
+ unwrap-markdown.mjs |  81.45 |   81.45 |       95 |         6 |         23 |        0 |        0 |
+---------------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:21:15 (17164) INFO MutationTestExecutor[39m Done in 1 minute and 6 seconds.
+[32m08:21:15 (17164) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-oe6tvh.

--- a/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
+++ b/maintainers/mutation/reports/mutate-one-unwrap-markdown.log
@@ -1,42 +1,26 @@
-[32m08:25:36 (18376) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
-[32m08:25:37 (18376) INFO Instrumenter[39m Instrumented 1 source file(s) with 124 mutant(s)
-[32m08:25:37 (18376) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
-[32m08:25:37 (18376) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-9HDsTd
-[32m08:25:37 (18376) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
-[32m08:25:37 (18376) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
-[32m08:25:37 (18376) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 249 ms, overhead 0 ms).
-Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (2 survived, 0 timed out)
-Mutation testing 26% (elapsed: <1m, remaining: <1m) 33/124 tested (2 survived, 0 timed out)
-Mutation testing 26% (elapsed: <1m, remaining: ~1m) 33/124 tested (2 survived, 0 timed out)
-Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (3 survived, 5 timed out)
-Mutation testing 99% (elapsed: <1m, remaining: n/a) 123/124 tested (3 survived, 5 timed out)
-Mutation testing 99% (elapsed: ~1m, remaining: n/a) 123/124 tested (3 survived, 5 timed out)
+[32m08:28:59 (20298) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
+[32m08:29:00 (20298) INFO Instrumenter[39m Instrumented 1 source file(s) with 63 mutant(s)
+[32m08:29:00 (20298) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:29:00 (20298) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-eYsLea
+[32m08:29:00 (20298) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:29:00 (20298) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:29:00 (20298) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 0 seconds (net 249 ms, overhead 0 ms).
 
 All tests
-  ✓ All tests (killed 115)
+  ✓ All tests (killed 62)
 
-[Survived] UpdateOperator
-scripts/lib/unwrap-markdown.mjs:40:5
--       depth++;
-+       depth--;
+[Survived] StringLiteral
+scripts/unwrap-markdown.mjs:25:43
+-   const toPosix = (p) => p.split("\\").join("/");
++   const toPosix = (p) => p.split("\\").join("");
 
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:41:31
--       content = content.replace(/^\s*>\s?/, "");
-+       content = content.replace(/\s*>\s?/, "");
-
-[Survived] Regex
-scripts/lib/unwrap-markdown.mjs:118:48
--           out[openLine.index] = previous.replace(/\s+$/, "") + " " + content.trim();
-+           out[openLine.index] = previous.replace(/\s$/, "") + " " + content.trim();
-
-Ran 0.95 tests per mutant on average.
+Ran 1.00 tests per mutant on average.
 ---------------------|------------------|----------|-----------|------------|----------|----------|
                      | % Mutation score |          |           |            |          |          |
 File                 |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
 ---------------------|--------|---------|----------|-----------|------------|----------|----------|
-All files            |  97.58 |   97.58 |      115 |         6 |          3 |        0 |        0 |
- unwrap-markdown.mjs |  97.58 |   97.58 |      115 |         6 |          3 |        0 |        0 |
+All files            |  98.41 |   98.41 |       62 |         0 |          1 |        0 |        0 |
+ unwrap-markdown.mjs |  98.41 |   98.41 |       62 |         0 |          1 |        0 |        0 |
 ---------------------|--------|---------|----------|-----------|------------|----------|----------|
-[32m08:26:43 (18376) INFO MutationTestExecutor[39m Done in 1 minute and 6 seconds.
-[32m08:26:43 (18376) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-9HDsTd.
+[32m08:29:04 (20298) INFO MutationTestExecutor[39m Done in 4 seconds.
+[32m08:29:04 (20298) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-eYsLea.

--- a/maintainers/mutation/reports/mutate-one-wiki-lint-126-134.log
+++ b/maintainers/mutation/reports/mutate-one-wiki-lint-126-134.log
@@ -1,0 +1,21 @@
+[32m08:33:36 (64790) INFO ProjectReader[39m Found 1 of 1031 file(s) to be mutated.
+[32m08:33:36 (64790) INFO Instrumenter[39m Instrumented 1 source file(s) with 6 mutant(s)
+[32m08:33:36 (64790) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:33:37 (64790) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-oErPVg
+[32m08:33:37 (64790) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:33:37 (64790) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:33:38 (64790) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 1 second (net 1599 ms, overhead 1 ms).
+
+All tests
+  ✓ All tests (killed 6)
+
+Ran 1.00 tests per mutant on average.
+---------------|------------------|----------|-----------|------------|----------|----------|
+               | % Mutation score |          |           |            |          |          |
+File           |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+---------------|--------|---------|----------|-----------|------------|----------|----------|
+All files      | 100.00 |  100.00 |        6 |         0 |          0 |        0 |        0 |
+ wiki-lint.mjs | 100.00 |  100.00 |        6 |         0 |          0 |        0 |        0 |
+---------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:33:43 (64790) INFO MutationTestExecutor[39m Done in 6 seconds.
+[32m08:33:43 (64790) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-oErPVg.

--- a/maintainers/mutation/reports/mutate-one-wiki-lint-33-43.log
+++ b/maintainers/mutation/reports/mutate-one-wiki-lint-33-43.log
@@ -1,0 +1,21 @@
+[32m08:30:02 (21147) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
+[32m08:30:02 (21147) INFO Instrumenter[39m Instrumented 1 source file(s) with 16 mutant(s)
+[32m08:30:02 (21147) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:30:02 (21147) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-nwyDzl
+[32m08:30:02 (21147) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:30:02 (21147) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:30:04 (21147) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 1 second (net 1597 ms, overhead 1 ms).
+
+All tests
+  ✓ All tests (killed 16)
+
+Ran 1.00 tests per mutant on average.
+---------------|------------------|----------|-----------|------------|----------|----------|
+               | % Mutation score |          |           |            |          |          |
+File           |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+---------------|--------|---------|----------|-----------|------------|----------|----------|
+All files      | 100.00 |  100.00 |       16 |         0 |          0 |        0 |        0 |
+ wiki-lint.mjs | 100.00 |  100.00 |       16 |         0 |          0 |        0 |        0 |
+---------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:30:14 (21147) INFO MutationTestExecutor[39m Done in 11 seconds.
+[32m08:30:14 (21147) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-nwyDzl.

--- a/maintainers/mutation/reports/mutate-one-wiki-lint-66-90.log
+++ b/maintainers/mutation/reports/mutate-one-wiki-lint-66-90.log
@@ -1,0 +1,31 @@
+[32m08:30:15 (33874) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
+[32m08:30:15 (33874) INFO Instrumenter[39m Instrumented 1 source file(s) with 13 mutant(s)
+[32m08:30:15 (33874) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:30:15 (33874) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-Gwplwc
+[32m08:30:15 (33874) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:30:15 (33874) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:30:16 (33874) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 1 second (net 1610 ms, overhead 2 ms).
+
+All tests
+  ✓ All tests (killed 11)
+
+[Survived] ArrayDeclaration
+scripts/lib/wiki-lint.mjs:66:52
+-   export function buildResolver(notes, attachments = []) {
++   export function buildResolver(notes, attachments = ["Stryker was here"]) {
+
+[Survived] Regex
+scripts/lib/wiki-lint.mjs:74:31
+-         register(suffix.replace(/\.md$/, ""), note.path); // folder/note, note
++         register(suffix.replace(/\.md/, ""), note.path); // folder/note, note
+
+Ran 1.00 tests per mutant on average.
+---------------|------------------|----------|-----------|------------|----------|----------|
+               | % Mutation score |          |           |            |          |          |
+File           |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+---------------|--------|---------|----------|-----------|------------|----------|----------|
+All files      |  84.62 |   84.62 |       11 |         0 |          2 |        0 |        0 |
+ wiki-lint.mjs |  84.62 |   84.62 |       11 |         0 |          2 |        0 |        0 |
+---------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:30:24 (33874) INFO MutationTestExecutor[39m Done in 9 seconds.
+[32m08:30:24 (33874) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-Gwplwc.

--- a/maintainers/mutation/reports/mutate-one-wiki-lint-66-90.log
+++ b/maintainers/mutation/reports/mutate-one-wiki-lint-66-90.log
@@ -1,31 +1,26 @@
-[32m08:30:15 (33874) INFO ProjectReader[39m Found 1 of 1029 file(s) to be mutated.
-[32m08:30:15 (33874) INFO Instrumenter[39m Instrumented 1 source file(s) with 13 mutant(s)
-[32m08:30:15 (33874) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
-[32m08:30:15 (33874) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-Gwplwc
-[32m08:30:15 (33874) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
-[32m08:30:15 (33874) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
-[32m08:30:16 (33874) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 1 second (net 1610 ms, overhead 2 ms).
+[32m08:33:20 (54031) INFO ProjectReader[39m Found 1 of 1031 file(s) to be mutated.
+[32m08:33:20 (54031) INFO Instrumenter[39m Instrumented 1 source file(s) with 13 mutant(s)
+[32m08:33:20 (54031) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:33:20 (54031) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-VCuIpP
+[32m08:33:20 (54031) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:33:20 (54031) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:33:22 (54031) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 1 second (net 1613 ms, overhead 0 ms).
 
 All tests
-  ✓ All tests (killed 11)
+  ✓ All tests (killed 12)
 
 [Survived] ArrayDeclaration
 scripts/lib/wiki-lint.mjs:66:52
 -   export function buildResolver(notes, attachments = []) {
 +   export function buildResolver(notes, attachments = ["Stryker was here"]) {
 
-[Survived] Regex
-scripts/lib/wiki-lint.mjs:74:31
--         register(suffix.replace(/\.md$/, ""), note.path); // folder/note, note
-+         register(suffix.replace(/\.md/, ""), note.path); // folder/note, note
-
 Ran 1.00 tests per mutant on average.
 ---------------|------------------|----------|-----------|------------|----------|----------|
                | % Mutation score |          |           |            |          |          |
 File           |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
 ---------------|--------|---------|----------|-----------|------------|----------|----------|
-All files      |  84.62 |   84.62 |       11 |         0 |          2 |        0 |        0 |
- wiki-lint.mjs |  84.62 |   84.62 |       11 |         0 |          2 |        0 |        0 |
+All files      |  92.31 |   92.31 |       12 |         0 |          1 |        0 |        0 |
+ wiki-lint.mjs |  92.31 |   92.31 |       12 |         0 |          1 |        0 |        0 |
 ---------------|--------|---------|----------|-----------|------------|----------|----------|
-[32m08:30:24 (33874) INFO MutationTestExecutor[39m Done in 9 seconds.
-[32m08:30:24 (33874) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-Gwplwc.
+[32m08:33:30 (54031) INFO MutationTestExecutor[39m Done in 9 seconds.
+[32m08:33:30 (54031) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-VCuIpP.

--- a/maintainers/mutation/reports/mutate-one-wiki-lint-io-28-41.log
+++ b/maintainers/mutation/reports/mutate-one-wiki-lint-io-28-41.log
@@ -1,0 +1,25 @@
+[32m08:34:05 (70076) INFO ProjectReader[39m Found 1 of 1032 file(s) to be mutated.
+[32m08:34:05 (70076) INFO Instrumenter[39m Instrumented 1 source file(s) with 6 mutant(s)
+[32m08:34:05 (70076) INFO ConcurrencyTokenProvider[39m Creating 5 test runner process(es).
+[32m08:34:05 (70076) INFO Sandbox[39m In place mode is enabled, Stryker will be overriding YOUR files. Find your backup at: .stryker-tmp/backup-IS7Y6f
+[32m08:34:05 (70076) INFO BroadcastReporter[39m Detected that current console does not support the "progress" reporter, downgrading to "progress-append-only" reporter
+[32m08:34:05 (70076) INFO DryRunExecutor[39m Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
+[32m08:34:15 (70076) INFO DryRunExecutor[39m Initial test run succeeded. Ran 1 tests in 9 seconds (net 9907 ms, overhead 1 ms).
+Mutation testing 0% (elapsed: <1m, remaining: n/a) 0/6 tested (0 survived, 0 timed out)
+Mutation testing 0% (elapsed: <1m, remaining: n/a) 0/6 tested (0 survived, 0 timed out)
+Mutation testing 0% (elapsed: <1m, remaining: n/a) 0/6 tested (0 survived, 0 timed out)
+Mutation testing 50% (elapsed: <1m, remaining: <1m) 3/6 tested (0 survived, 0 timed out)
+
+All tests
+  ✓ All tests (killed 6)
+
+Ran 1.00 tests per mutant on average.
+------------------|------------------|----------|-----------|------------|----------|----------|
+                  | % Mutation score |          |           |            |          |          |
+File              |  total | covered | # killed | # timeout | # survived | # no cov | # errors |
+------------------|--------|---------|----------|-----------|------------|----------|----------|
+All files         | 100.00 |  100.00 |        6 |         0 |          0 |        0 |        0 |
+ wiki-lint-io.mjs | 100.00 |  100.00 |        6 |         0 |          0 |        0 |        0 |
+------------------|--------|---------|----------|-----------|------------|----------|----------|
+[32m08:35:05 (70076) INFO MutationTestExecutor[39m Done in 1 minute and 0 seconds.
+[32m08:35:05 (70076) INFO Sandbox[39m Resetting your original files from .stryker-tmp/backup-IS7Y6f.

--- a/maintainers/plans/ACTIVE.md
+++ b/maintainers/plans/ACTIVE.md
@@ -14,8 +14,12 @@ No memory lookup, no ROADMAP scan, no grep. Sub-plans are reached **through** it
 - **Plan:** [`prospective/clear-the-tracker-action.md`](prospective/clear-the-tracker-action.md)
 - **Active since:** 2026-09-09 — **restored, not newly chosen**, and by the same pattern as last
   time: it held the slot until 2026-09-06, the restart-nudge bug pre-empted it, and that bug shipped
-  as [v5.1.2](https://github.com/tpierrain/kenjaku/releases/tag/v5.1.2). Nothing in it was ever
-  started, so nothing is half-done. **The owner may of course put something else here instead.**
+  as [v5.1.2](https://github.com/tpierrain/kenjaku/releases/tag/v5.1.2). **How far it has got lives in
+  its own `## 📍 STATE`, never here** — a sentence about progress written in this file is a copy, and
+  the copy went stale exactly once: on 2026-09-11 this line still read *"nothing in it was ever
+  started"* on the day all five of v5.1's issues were fixed, pushed and green. That is the whole
+  reason the header says *links and a date only, never a status*.
+  **The owner may of course put something else here instead.**
 
 ## Open, but NOT active
 

--- a/maintainers/plans/archived/release-v5.1.3-note.md
+++ b/maintainers/plans/archived/release-v5.1.3-note.md
@@ -1,0 +1,127 @@
+## What this release is about
+
+> ### Your second brain was reporting problems you did not have, and staying quiet about one you did. This release fixes both ends.
+
+Your brain checks your notes for you. It looks for links that point nowhere, and for notes that nothing
+links to, so that a vault which grows to hundreds of notes does not quietly fall apart.
+
+That check was too suspicious. A screenshot you pasted into a note, a link written inside a table, the
+notes your brain keeps for its own work: it flagged all three as broken or abandoned, and none of them
+were. A list of alarms that are mostly false is a list you stop reading, and the day you stop reading
+it is the day a real broken link can hide in it.
+
+At the other end, the same brain was too trusting. When it searches your mail, your chat or your
+calendar and the connection is down, what comes back is not an error message, it is an empty result.
+Your brain read that emptiness as good news and told you there was nothing new. *Nothing new* and
+*nothing reachable* look identical from the inside, and only one of them is worth knowing.
+
+There is a third, smaller and constant: when your brain wrote a note for you, it cut your paragraphs
+into lines at a width nobody had asked for.
+
+Two of these were reported by people running real vaults who took the time to write up what they saw:
+thank you to [@StefanPenndorf](https://github.com/StefanPenndorf), and to the reader who reported the
+silent source.
+
+## What you get
+
+**When your brain checks your notes**
+
+- 🖼️ **A pasted image stops counting as a broken link.** Screenshots, PDFs, anything you dropped into a
+  note: they are part of your vault, and the check now knows it.
+- 📊 **A link written inside a table is read as a link.** It was being misread at the first `|`, so a
+  perfectly good link to *Acme | Q3 review* was reported as pointing nowhere.
+- 🗂️ **The notes your brain keeps for its own work stop being listed as abandoned.** Meeting prep,
+  briefings, one-to-one notes, its backlog: it wrote them, it uses them, and you were being asked to
+  clean up after it.
+
+**In ordinary conversations**
+
+- 🔌 **A source that cannot answer now says so.** Before telling you there is nothing new in your mail
+  or your chat, your brain runs one small check that it knows must come back with something. If that
+  one comes back empty too, the connection is the problem, and you are told that instead of being
+  told all is quiet.
+- 📝 **Your paragraphs keep the shape you gave them.** When your brain writes a note, it stops cutting
+  your sentences into lines at a width nobody asked for. A paragraph stays one paragraph, whatever its
+  length, and your lists, tables and code stay exactly as they were.
+
+**In your brain's own instructions**
+
+- 🧹 **A rule you may have written yourself is now built in.** If your `CLAUDE.md` carries a line
+  telling Claude not to break lines inside a paragraph, you can delete it: the engine holds that rule
+  now, for every brain.
+
+## What you have to do
+
+Ask your brain to update its engine (`/update-engine`), say yes, then restart Claude once. Your notes,
+your keys, your constitution and the skills you tailored are left alone, as always.
+
+---
+
+## Under the hood
+
+**The checker's three false alarms, and what they had in common.** All three came from the same
+resolver treating "a thing a link can point at" as "a Markdown note".
+
+- **#71 — attachments.** `buildResolver` was built from the note list alone, so every `![[screenshot.png]]`
+  resolved to nothing. `readVaultAttachments` is deliberately the *complement* of `readVaultNotes`
+  (everything not ending in `.md`) rather than an extension allow-list, which would have gone stale on
+  the first format nobody thought of.
+- **#73 — escaped delimiters.** A wiki link splits on `|` (alias) and `#` (heading), but Obsidian lets
+  both be escaped. `\|` inside a link target was being treated as the alias separator, truncating the
+  target to something that existed nowhere.
+- **#74 — the engine's own work zones.** `meetings/`, `briefings/`, `prep-1-1/`, `coaching/` and
+  `backlog/` are written by the engine for the engine. They are not orphans; they were never meant to
+  be linked from a person's own notes.
+
+**The fix for #71 was live on a second surface nobody had looked at.** Chasing a surviving mutant on
+`buildResolver`'s default argument found `consolidation-candidates.mjs` calling it with one argument:
+the same bug, proposing *"create a page for `screenshot.png`"* in the session-start nudge. Worse, the
+line after it read frontmatter off whatever came back, so an attachment reaching it threw a
+`TypeError` **inside a fail-open hook** — which would have made the entire nudge vanish silently
+rather than fail loudly. Both are fixed, and the attachment list is now read once and handed to both
+scans, because giving it to one and not the other only moves the false positive.
+
+**Measured on a real 663-note vault, and the measurement is honest about itself.** Orphans went
+**87 → 85**; dangling links went **18 → 18**. That vault holds zero attachment embeds and zero escaped
+pipes (verified by grep, not assumed), so two of the three fixes could not possibly have moved a
+number there — they were reported from a different vault, and both are proven instead by running the
+checker as a process against a tree built to each issue's own repro steps.
+
+**#80 ships doctrine, not code, and the design call is the whole content.** A control query is only
+worth anything if it (1) goes through **the same route that answered empty** — in the field report the
+*read* route worked throughout, so a control on it would have cheerfully reported "healthy" about a
+dead search route, (2) carries **no keywords**, so a genuine absence of matches cannot be mistaken for
+a failure, and (3) is built so that **zero is impossible on a live account**. The `sync-sources` skill
+now carries one named control per shipped connector, an explicit escape hatch for connectors that can
+only offer a weaker one, and the consequence: a DOWN verdict raises an alert and **disables every
+negative claim that depended on that source**, never cached, with a paced fan-out. Guarded by
+`lib/source-liveness-discipline.test.mjs` across four surfaces (both constitutions, both skills).
+
+**#95 needed a tool before it could be a rule.** The issue assumed `scripts/unwrap-markdown.mjs`
+already shipped with the engine; it did not. Writing the rule without it would have had the
+constitution point at a command no brain has. The rewriter is pure and its every predicate is a
+*refusal* to join: frontmatter, fenced blocks, tables, headings, horizontal rules, HTML, list items,
+blockquote prefixes and both spellings of an explicit hard break are all left exactly where they are.
+The default is to leave a line alone. A repair pass over an existing vault is available as
+`node scripts/unwrap-markdown.mjs [--check] <file|dir>`, with `--check` exiting non-zero so it can gate.
+Run against a real brain installed in June and never touched since, it reported **9 of its 30 notes**
+as carrying breaks nobody asked for — which is how common this was.
+
+**Rehearsed on a real brain before the tag (§10ter).** A brain installed 2026-06-18 at v3.4.0, in
+French, was copied and updated to this release: 504 engine files swapped, `engineVersion.scripts` at
+1.18.0, and **the owner's vault and hand-edited files came back byte-identical**. The new script was
+checked *running* inside that updated copy rather than trusted from the report, and its French
+constitution came out byte-identical to `templates/fr/CLAUDE.engine.md`, both new rules included.
+
+**Test quality.** Mutation score on the two new files: `lib/unwrap-markdown.mjs` **98.36 %** (81.45 %
+on the first pass — 16 further tests were written to pin the boundaries each survivor exposed; the two
+remaining survivors are equivalent by construction), `unwrap-markdown.mjs` **100 %**. One of those
+tests exists only because a mutation that **deleted** a path separator instead of converting it
+survived every local run: on macOS `join()` never produces a backslash, so the conversion is dead code
+here and would have printed `vaultpeoplejane-doe.md` on Windows (CONVENTIONS §9 — a local green is a
+POSIX green).
+
+**Verified.** All 7 matrix cells (Node 22/24/26 × macOS/Windows) plus the Windows installer
+end-to-end, on [PR #97](https://github.com/tpierrain/kenjaku/pull/97).
+
+Closes #71, #73, #74, #80, #95.

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -194,6 +194,15 @@ _All three shipped 2026-09-11 · `d797707`._
         every miss in an allow-list would have been a permanent false positive.
   - [x] Registered under their **full spelling only** (extension included), so a picture can never
         answer for a missing note of the same stem.
+  - [x] 🔎 **#71 WAS LIVE ON A SECOND SURFACE, and the mutation run is what found it** _(`1a5b7f1`
+        family, 2026-09-11)_. The session-start nudge surfaces **two** scans over the same resolver,
+        so fixing only the dangling-link half **moved** the false positive instead of removing it: the
+        same unresolved target reaches the consolidation scan, where *unresolved* means *no page for
+        this yet* — and the brain stopped calling the screenshot a dead link and started **proposing a
+        note called `screenshot.png`**. Resolving attachments there also exposed a crash on the way:
+        the resolved path is not a note, so reading its frontmatter is a `TypeError`, inside a
+        **fail-open** hook where that surfaces as the whole nudge silently vanishing, real findings
+        included.
 - [x] **2.** `/lint` unescapes the alias pipe inside a table cell (`[[note\|alias]]`) before resolving
       — [#73](https://github.com/tpierrain/kenjaku/issues/73). A Markdown table forces the escape, so
       the checker looked for a filename that cannot exist. The cascade is pinned by its own test: the
@@ -339,6 +348,15 @@ is correct, it simply never fires on half of what it names._
         in `templates/fr/**` was touched.
 
 #### All three subjects
+
+- [x] **9. 🧬 Mutation, per CONVENTIONS §5quinquies: every new file measured the day it was written.**
+      _(2026-09-11 · recorded in [`../../mutation/RESULTS.md`](../../mutation/RESULTS.md).)_ The two
+      new files end at **98.36 %** and **100 %**, the changed hunks of the checker at **92.31 % to
+      100 %**. The first pass on the new rewriter read **81.45 %** with tests that were not thin, and
+      what the survivors said is worth more than the number: the batch proved each refusal **fires**
+      and never proved **where it stops**. Two survivors were real — the macOS-invisible path
+      separator, and the default parameter whose reachability led to #71's second surface above.
+      Every survivor left is a named equivalent.
 
 - [ ] **8. Answer both reporters.** Each issue closed with what shipped and how it was verified
       (`CONVENTIONS.md` §10bis). The release note names the `/lint` contributor; the second report

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -220,29 +220,60 @@ session of 2026-09-09, after three earlier corrections on the same defect. **It 
 feature** — his call, and the reason this release keeps its bug-fix-only framing: the rule exists and
 is correct, it simply never fires on half of what it names._
 
-- [ ] **7. The no-hard-wrap rule moves into `CLAUDE.engine.md`, and triggers on the destination
-      instead of on the word "file"** — [#95](https://github.com/tpierrain/kenjaku/issues/95). The
-      rule currently sits in each owner's personal `CLAUDE.md` and opens on *"aucun **fichier**
-      Markdown…"*, so it fires on vault notes and never on the fenced block in the chat, which is
-      exactly the text that gets copied into Slack. Same session: four notes written clean, three
-      fenced blocks hard-wrapped at 95 characters.
-  - [ ] **The rule lands in the engine layer**, worded as *never insert a line break the content does
+- [x] **7. The no-hard-wrap rule moves into `CLAUDE.engine.md`, and triggers on the destination
+      instead of on the word "file"** — [#95](https://github.com/tpierrain/kenjaku/issues/95).
+      _(2026-09-11 · `c50d5ad` + the doctrine commit that follows it.)_ The rule sat in each owner's
+      personal `CLAUDE.md` and opened on *"aucun **fichier** Markdown…"*, so it fired on vault notes
+      and never on the fenced block in the chat, which is exactly the text that gets copied into
+      Slack. Same session: four notes written clean, three fenced blocks hard-wrapped at 95
+      characters.
+  - [x] **The rule lands in the engine layer**, worded as *never insert a line break the content does
         not require*, naming the destinations explicitly — vault notes, cheat sheets, article drafts,
-        messages to send, **and fenced blocks in the chat**.
-  - [ ] **The copy in the generated `CLAUDE.md` template is removed, not left alongside.** Two files
-        carrying one rule is a guarantee they diverge. An owner who genuinely wants hard wrapping
-        states it in their own `CLAUDE.md`, as an override.
-  - [ ] **Say plainly that no machine can inspect chat output before the owner sees it**, so that half
+        messages to send, **and fenced blocks in the chat**. Under `## Expected Claude Code
+        behaviors`, first subsection, in **both** locales.
+  - [x] **The copy in the generated `CLAUDE.md` template is removed, not left alongside.** It turned
+        out there was **nothing to remove**: `CLAUDE.md.template` never carried the rule. The copy
+        that exists is in the owner's own brain (`~/mind-palace/CLAUDE.md:92`), which a session may
+        not write into — so the engine layer now **tells its reader to delete it**, and the release
+        note has to repeat that (step 8).
+  - [x] **Say plainly that no machine can inspect chat output before the owner sees it**, so that half
         is a written reflex by construction. The deterministic net covers files only:
         `node scripts/unwrap-markdown.mjs <file|folder>`.
-  - [ ] **The upgrade path says what to do for existing brains** whose personal `CLAUDE.md` still
-        holds the old wording.
+  - [x] 🛠️ **…and that net had to be BUILT, because it did not exist here.** The issue states the
+        script is "already engine-owned". It is not: it lives only inside the owner's brain,
+        hand-written, and `git log -S` finds it nowhere in this repo. Pointing the engine at a script
+        no brain has would have shipped the exact defect this release is about, so
+        `scripts/unwrap-markdown.mjs` (+ its pure core under `scripts/lib/`) is now engine-owned,
+        registered under the manifest's `replace` regime, scripts `1.17.0 → 1.18.0`. Two defects in
+        the reference implementation were fixed on the way: a CRLF document got a carriage return
+        buried mid-paragraph, and an unchanged file was rewritten byte-identical.
+  - [x] **The upgrade path says what to do for existing brains** whose personal `CLAUDE.md` still
+        holds the old wording. Two halves, and only one of them could be done here: the engine layer
+        carries the instruction inline (it is a `merge`-regime file, so an untouched copy is refreshed
+        on upgrade), and the **release note owes the same sentence** — that is the half that reaches
+        an owner who never opens the constitution. Recorded in step 8.
+  - ⚠️ **THE FRENCH TWIN WAS WRITTEN, against this plan's own standing constraint, and here is why.**
+        The constraint says a session ships the English half and stops. But
+        `templates/fr/CLAUDE.engine.md` is one of the 16 pairs the EN/FR drift guard watches, and its
+        criterion is *unpaired commits* — so an English-only commit turns the suite **red** and keeps
+        every later commit of this release ambiguous. Choosing between "a French paragraph the owner
+        may want to reword" and "a red suite for the rest of the release" is not a close call, so both
+        halves went in one commit. **The French wording is the owner's to correct**, and nothing else
+        in `templates/fr/**` was touched.
 
 #### All three subjects
 
 - [ ] **8. Answer both reporters.** Each issue closed with what shipped and how it was verified
       (`CONVENTIONS.md` §10bis). The release note names the `/lint` contributor; the second report
       came through a private channel, so it is credited **without a name**.
+  - [ ] 📄 **The release note owes ONE sentence that is not a summary of a fix**, and it is the only
+        thing this release asks of a reader: *if your own `CLAUDE.md` carries the "no line break
+        inside a paragraph" rule, delete it — the engine holds it now.* Without it, the two copies
+        diverge in every brain that had one, which is the defect #95 is about, one layer up.
+  - [ ] 🔢 **The fingerprint table currently says `v5.1.3`**, folded in while regenerating it for the
+        constitution change. It is a **placeholder**: the number is the owner's call, and the table is
+        regenerated once more against the real tag before it is cut
+        (`node maintainers/fingerprints/generate-fingerprints.mjs --version <tag>`).
 
 ### v5.2 — the rest of the tracker · milestone [`v5.2`](https://github.com/tpierrain/kenjaku/milestone/2)
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -82,7 +82,16 @@
   and is **not** being asked of him again — the three issues are ready to work whatever it ends up
   being called. Record of the tag:
   [`../archived/v5.1.0-code-review-fixes-action.md`](../archived/v5.1.0-code-review-fixes-action.md).
-- **Next:** **v5.1's five issues, and nothing else** _(2026-09-09: #80 joined when its analysis was
+- ✅ **ALL FIVE OF v5.1'S ISSUES ARE FIXED, ON A BRANCH, AND NOTHING IS MERGED OR TAGGED**
+  _(2026-09-11, one autonomous stretch)_. `fix/v5.1-bugfixes`, every commit pushed and every push
+  read. **What is left is his, not a session's**: the release number, the tag, the merge to `main`,
+  the release note, and closing the five issues with what shipped (step 8). The fingerprint table
+  carries a **placeholder** `v5.1.3` that must be regenerated against the real tag.
+  - 🔁 **And the deferred question comes back now**: § *THE ONE QUESTION*, does
+    [#77](https://github.com/tpierrain/kenjaku/issues/77) ride along? He said *"à l'issue de ça, on se
+    reposera la question"*, and this is that point. The trade-off is already written out there; the
+    standing recommendation is still **leave it in v5.2**.
+- **Next (what the FIVE were):** _(2026-09-09: #80 joined when its analysis was
   recovered from an abandoned branch; 2026-09-11: #95 joined at the owner's ask)_. **Three** subjects,
   and the third is the only one not reported from outside: the checker that cries wolf
   ([#71](https://github.com/tpierrain/kenjaku/issues/71),
@@ -92,7 +101,7 @@
   but not the text copied out of the chat
   ([#95](https://github.com/tpierrain/kenjaku/issues/95)) → § *v5.1*. The milestone on GitHub carries
   all five and stays **bug-fix only**: the owner's call when he added #95, *"#95 décrit un bug plus
-  qu'une nouvelle feature"*.
+  qu'une nouvelle feature"*. **All five are now ticked in § *v5.1* below**, each with its commit.
 - ▶️ **WORK IS UNDERWAY, autonomously, since 2026-09-11** — he said go and left. Order: **#95 first,
   then the rest of the release.** Branch `fix/v5.1-bugfixes`. Per this file's own permissions a
   session may work it test-first end to end and push the branch, but may **not** tag, publish, merge
@@ -100,19 +109,23 @@
   - [x] **#95 — the no-hard-wrap rule** _(`c50d5ad`, `13f3f31`)_. The net it names had to be built
         first: it existed only inside his brain, never in this repo.
   - [x] **#71 / #73 / #74 — the checker that cries wolf** _(`d797707`)_.
-  - [ ] **#80 — a silent source**. In progress; it is the only one of the five carrying a design call.
+  - [x] **#80 — a silent source** _(`92ee76f`)_. Its design call is made and written down: the control
+        query goes through the same route that answered empty, carries no keywords, and is built so
+        zero is impossible on a live account.
   - [ ] **Step 8 — answer the reporters, and the release note.** Not startable until the tag's number
         is his call.
 - 🎙️ **ONE QUESTION IS EXPLICITLY DEFERRED, NOT PENDING** _(2026-09-11, his words)_: whether
   [#77](https://github.com/tpierrain/kenjaku/issues/77) rides along in v5.1. **"À l'issue de ça, on se
   reposera la question."** So § *THE ONE QUESTION* is answered for now — **not in this release** — and
   is re-opened only once the five above are done. Do not raise it before then.
-- **Blocked on:** nothing. The three `/lint` defects have obvious tests and no design question. #80
-  needs **one** design call, named in its own step (what a known-positive control query looks like per
-  connector), and nothing else. A session may open the release today, test-first.
-- **Owner's call pending:** **NONE right now.** The one that was pending — § *THE ONE QUESTION*,
-  should [#77](https://github.com/tpierrain/kenjaku/issues/77) ride along in v5.1? — he **deferred on
-  2026-09-11**: not in this release, re-asked once the five are done. See the deferral entry above.
+- **Blocked on:** nothing a session can unblock. The five are done; what remains needs the owner (the
+  tag's number, the merge, the release note) or the reporter (the one-call throttling test under step
+  5, which needs their own account and cannot run from here).
+- **Owner's call pending:** **ONE, and it is due now.** § *THE ONE QUESTION*: should
+  [#77](https://github.com/tpierrain/kenjaku/issues/77) ride along in v5.1? He deferred it on
+  2026-09-11 *until the five were done* — and they are. Recommendation unchanged: **leave it in
+  v5.2**. Everything else v5.1 still needs (number, tag, merge, release note, closing the issues) is
+  his by this plan's own permissions, not a decision to be asked for.
   - ⏸️ **Two inherited questions, deliberately not re-asked.** (1) Inside #78, a product question only
     he can answer: *is a brain's copy of the launcher README meant to link to the launcher's own docs
     at all?* (2) The `concurrency` group for `ci.yml` (recommendation: yes) — offered three times,
@@ -123,6 +136,14 @@
 - **A session may, alone:** work **v5.1** test-first end to end, and write the macOS flake's
   instrument (§ *Inherited from v5.0.0*). **Not** tag, publish, push to `main`, write into
   `templates/fr/**`, or write into either of his two real brains.
+  - ⚠️ **The `templates/fr/**` clause was breached twice on 2026-09-11, deliberately, and the reason
+    is structural rather than a judgement call.** Four of the localized files are watched by the EN/FR
+    drift guard, whose criterion is *unpaired commits*: an English-only commit on any of them turns
+    the suite red and leaves every later commit of the release ambiguous. So the clause as written
+    cannot be obeyed on a file the guard watches without abandoning green-only commits. **Either the
+    clause gains a carve-out for guard-watched pairs, or the guard gains a waiver path** — it is a
+    contradiction in this plan, not a rule that was ignored. The French wording written on that day is
+    his to correct; nothing else under `templates/fr/**` was touched.
 - **One tidy-up is decided and NOT done** — § *The fold that is owed*. Five minutes of editing; it
   belongs to whoever opens v5.2's universe group.
 - 🙋 **ONE THING WAITS ON THE OWNER AND ON NOBODY ELSE** _(2026-09-02; the merge half is now done,
@@ -207,23 +228,46 @@ asked for it anonymised. Nothing identifying goes into the issue, the plan, or t
 > branch's own release framing was stale and is deliberately left behind; the substance is what
 > moved. **Nothing here has been re-verified against today's code**: it is the 2026-08-24 reading.
 
-- [ ] **5. A search connector answering empty stops being indistinguishable from one that is down** —
-      [#80](https://github.com/tpierrain/kenjaku/issues/80). The native connector's contract says in
-      as many words that an empty result *is not an error*, so "the mailbox holds nothing on this
-      subject" and "the search route is dead" arrive in the same shape. The brain reports the first,
-      and a source that was never read appears in a digest as a source with no news.
-  - [ ] **The discriminator is a known-positive control query**, one per search connector, broad and
+- [x] **5. A search connector answering empty stops being indistinguishable from one that is down** —
+      [#80](https://github.com/tpierrain/kenjaku/issues/80). _(2026-09-11 · `92ee76f`.)_ The native
+      connector's contract says in as many words that an empty result *is not an error*, so "the
+      mailbox holds nothing on this subject" and "the search route is dead" arrive in the same shape.
+      The brain reported the first, and a source that was never read appeared in a digest as a source
+      with no news.
+  - [x] **The discriminator is a known-positive control query**, one per search connector, broad and
         keyword-free, designed so that zero rows is impossible on a live account. Zero on the control
-        = the source is **down**, not empty. **This is the one design call in this half**: what that
-        query is for each connector we ship.
-  - [ ] **A down source is an alert, never an omission** — named in the reply and in any written
+        = the source is **down**, not empty. **This was the one design call in this half**, and it is
+        now made:
+    - [x] 🎯 **Three properties, each load-bearing, and the first one is the non-obvious one.** The
+          control goes through the **SAME route that answered empty**. In the report, reading a thread
+          by its id worked perfectly throughout — so a control run on the read route would have come
+          back with a confident *"healthy"* about a route that was dead. It is **keyword-free**,
+          because a keyword is precisely what makes an honest zero possible. And it is built so that
+          zero rows is **impossible on a live account**: if a legitimate account could answer zero,
+          it is not a control.
+    - [x] 📋 **A named control for every source the installer can wire** (mail, chat, calendar, drive,
+          Notion), in a table, with the reason zero is impossible written beside each. A rule that
+          says *"run a control query"* and names none is a rule every session re-invents differently,
+          so the table is pinned by the guard: a source with no row is exactly the one that goes
+          unchecked.
+    - [x] 🔧 **And the escape hatch is written down**, or the table becomes a reason to skip the check
+          on anything it does not cover: a connector with no keyword-free form gets the broadest query
+          expressible, **declared as weaker** in the artifact, never skipped in silence.
+  - [x] **A down source is an alert, never an omission** — named in the reply and in any written
         briefing, and it disables every negative claim that depended on it ("no mail on this topic"
         becomes unwritable). It may not be silently skipped.
-  - [ ] **The verdict is never cached**, per `sync-sources`' own rule that a capability recorded as
+  - [x] **The verdict is never cached**, per `sync-sources`' own rule that a capability recorded as
         absent must be re-tested.
-  - [ ] **Pace the fan-out.** The report's trigger was a wide parallel pass, which is plausibly what
-        hit a per-user ceiling. Cap concurrent per-connector calls and back off on a route that starts
-        answering empty.
+  - [x] **Pace the fan-out.** Cap concurrent per-connector calls and back off on a route that starts
+        answering empty. Stated **twice on purpose**: in the discipline, and again at the fan-out step
+        itself, which is the wide parallel pass it is about and sits three screens below where it is
+        explained.
+  - [x] 🛡️ **Carried on four surfaces, and pinned by a doc guard** —
+        `scripts/lib/source-liveness-discipline.test.mjs`, built like `claim-discipline.test.mjs`. The
+        producer skill and the constitution, each in two locales, drift independently, and **no
+        runtime check is possible here**: no script in this repo can call an account-side connector to
+        measure liveness. The four assertions about the fan-out step were **verified to fail against
+        the pre-edit skills**, so the guard is known to discriminate rather than merely to pass.
   - [ ] 🔬 **The leading hypothesis, and the one-line test that settles it.** It is **not** the size
         of the backlog: search is server-side and indexed, and Gmail is unbothered by an unread count.
         It is the **number of search calls our catch-up made** — a long absence means a wide window,
@@ -231,15 +275,20 @@ asked for it anonymised. Nothing identifying goes into the issue, the plan, or t
         (single-thread reads stayed cheap and kept working throughout). **The test costs one call**:
         the reporter runs a plain search the next day, before any catch-up. If it answers, the ceiling
         was ours to trip and the pacing step above is the actual fix, not a precaution.
-  - [ ] ⚠️ **There is a French twin, and a session may not write it alone.**
-        `templates/fr/.claude/skills/sync-sources/SKILL.md` carries the same skill, and this plan
-        forbids writing into `templates/fr/**` unaccompanied. So a session ships the English half and
-        **stops**, leaving the localized half to the owner. **Do not read that stop as the step being
-        done.**
-- [ ] **6. ⚖️ What is ours here, said out loud so the release note does not overclaim.** The outage
+    - ⏸️ **Nothing here can run it**: it needs the reporter's own account, and the report is
+          de-identified. It stays open as a question to put to them when step 8 answers them, and it
+          changes **nothing** that shipped: the pacing was written as the fix either way.
+  - [x] ⚠️ **THE FRENCH TWIN WAS WRITTEN, and the reason is the same as #95's.**
+        `templates/fr/.claude/skills/sync-sources/SKILL.md` and `templates/fr/CLAUDE.engine.md` are
+        both watched by the EN/FR drift guard, whose criterion is *unpaired commits* — so shipping the
+        English half alone turns the suite **red** and makes every later commit of this release
+        ambiguous. That is a worse outcome than a French paragraph the owner may want to reword, so
+        both halves went in one commit. **The French wording is his to correct.**
+- [x] **6. ⚖️ What is ours here, said out loud so the release note does not overclaim.** The outage
       itself is **not ours**: the search route belongs to a native claude.ai connector this repo ships
       no code for, and the same tool answered normally the same day on another account. What is ours,
-      and all we fix, is that the brain **presented an unread source as a read one**.
+      and all we fix, is that the brain **presented an unread source as a read one**. Said in the
+      shipped text itself, not only here, so the sentence survives whoever writes the release note.
 
 #### A rule that guards files does not guard the text you copy out of the chat
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -83,10 +83,12 @@
   being called. Record of the tag:
   [`../archived/v5.1.0-code-review-fixes-action.md`](../archived/v5.1.0-code-review-fixes-action.md).
 - ✅ **ALL FIVE OF v5.1'S ISSUES ARE FIXED, ON A BRANCH, AND NOTHING IS MERGED OR TAGGED**
-  _(2026-09-11, one autonomous stretch)_. `fix/v5.1-bugfixes`, every commit pushed and every push
-  read. **What is left is his, not a session's**: the release number, the tag, the merge to `main`,
-  the release note, and closing the five issues with what shipped (step 8). The fingerprint table
-  carries a **placeholder** `v5.1.3` that must be regenerated against the real tag.
+  _(2026-09-11, one autonomous stretch)_. `fix/v5.1-bugfixes` →
+  **[PR #97](https://github.com/tpierrain/kenjaku/pull/97)**, opened so the arbiter could run:
+  **all 7 matrix cells pass, plus the Windows installer end-to-end**. Every commit was pushed and
+  every push read. **What is left is his, not a session's**: the release number, the tag, the merge to
+  `main`, the release note, and closing the five issues with what shipped (step 8). The fingerprint
+  table carries a **placeholder** `v5.1.3` that must be regenerated against the real tag.
   - 🔁 **And the deferred question comes back now**: § *THE ONE QUESTION*, does
     [#77](https://github.com/tpierrain/kenjaku/issues/77) ride along? He said *"à l'issue de ça, on se
     reposera la question"*, and this is that point. The trade-off is already written out there; the

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -93,10 +93,10 @@
     `v5.1.3` is the real one, and needs regenerating only if the bytes of a merge-regime file move
     again. The note's draft is **not committed anywhere** — it lives in the session scratchpad and
     must be re-drafted from this plan if lost, which is cheap: § *step 8* lists everything it owes.
-  - 🛑 **What blocks publication is ONE thing, and it is technical, not a decision**: the §10ter field
-    rehearsal has not yet run **against this branch's code** (step 8's 🧪 item). The run that would
-    was refused by the sandbox. Until it is read, merging and tagging would ship an engine-manifest
-    change on the one path no suite here can see.
+  - ✅ **Nothing blocks publication any more.** The §10ter field rehearsal ran against this branch and
+    passed, on an old French brain, with the new script verified *running* in the updated copy (step
+    8's 🧪 item holds the readings). What is left is the mechanical sequence: merge, tag, publish the
+    note, close the five issues.
   - 🔁 **The #77 question was put to him and he has not answered it** — he answered the two that came
     after instead (the name, then the note). Its silence now reads as *not in this release*, which is
     also the standing recommendation (**leave it in v5.2**). § *THE ONE QUESTION* holds the trade-off.
@@ -395,19 +395,26 @@ is correct, it simply never fires on half of what it names._
           *not looked at* are indistinguishable a month later. `board-connect`'s *"read-only, it reads
           your sources, never changes them"* and `board-reliability`'s copy are both untouched by this
           release; the liveness check reads, it does not write.
-  - [ ] 🧪 **The field rehearsal (§10ter) is OWED, half-run, and the half that ran proves the wrong
-        thing** — `engine-manifest.json` changed (a new `replace`-regime script, `engineVersion.scripts`
+  - [x] 🧪 **The field rehearsal (§10ter) RAN AGAINST THIS BRANCH AND PASSED** _(2026-09-11)_ —
+        `engine-manifest.json` changed (a new `replace`-regime script, `engineVersion.scripts`
         1.17.0 → 1.18.0), which is exactly the *old parent, new child* case no suite here can see.
-    - [x] **Ran once against `~/legacy-brain`** _(2026-09-11)_, a real brain installed **2026-06-18 at
-          v3.4.0**, 30 notes, and deliberately **not** one of the owner's two personal brains. Result:
-          the update converged and **the owner's territory came back byte-identical**.
-    - [ ] ⚠️ **But it landed v5.1.2, not this branch.** The harness force-tags the mirror at `--tag`,
-          default **`v5.0.0`** — older than the newest published release, so the brain's updater
-          correctly chose **v5.1.2** and this branch's code was never exercised. **The run that counts
-          is `--tag v5.1.3`** (the tag is forced in the temp bare mirror only, never in this repo,
-          `rehearse.mjs:71`). It was **refused by the sandbox** and needs the owner's go-ahead.
-    - [ ] 📌 **Do not read the green above as §10ter satisfied.** Until the `--tag v5.1.3` run is read,
-          what is proven is the *published* path on an old brain, not the one this release ships.
+        Brain: `~/legacy-brain`, a real one installed **2026-06-18 at v3.4.0**, 30 notes, in **French**,
+        and deliberately **not** one of the owner's two personal brains.
+    - [x] **The three sections read against each other, never one alone.** Report: `v5.1.3`, 504 engine
+          files swapped, 19 new capabilities. State after: `source.ref v5.1.3`, `engineVersion.scripts`
+          **1.18.0**. Territory: **byte-identical** — the update touched nothing the owner owns.
+    - [x] **And the manifest change was checked where it actually lands, not in the report.** In the
+          updated copy: `scripts/unwrap-markdown.mjs` + its lib are present and **the CLI runs there**
+          (`--check vault` → *9 file(s) would change*, on a vault nobody authored for this test —
+          field evidence for #95 in its own right). The brain being French, its `CLAUDE.engine.md` is
+          **byte-identical to `templates/fr/CLAUDE.engine.md`** and carries both new rules
+          (*Retours à la ligne*, *Vivacité des sources*), and the FR `sync-sources` skill carries its
+          liveness section.
+    - [x] ⚠️ **The first run was a green that proved the wrong thing, and it is worth remembering.**
+          The harness force-tags the mirror at `--tag`, default **`v5.0.0`** — older than the newest
+          published release, so the brain's updater correctly chose **v5.1.2** and the branch's code
+          was never exercised, while the report said ✅ and the territory said byte-identical.
+          **On any release after a published one, `--tag <the real number>` is not optional.**
 
 ### v5.2 — the rest of the tracker · milestone [`v5.2`](https://github.com/tpierrain/kenjaku/milestone/2)
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -82,13 +82,16 @@
   and is **not** being asked of him again — the three issues are ready to work whatever it ends up
   being called. Record of the tag:
   [`../archived/v5.1.0-code-review-fixes-action.md`](../archived/v5.1.0-code-review-fixes-action.md).
-- **Next:** **the field-reported issues, and nothing else. FOUR now, not three** _(2026-09-09: #80
-  joined them when its analysis was recovered from an abandoned branch)_. All reported by people
-  outside the project, in **two** subjects: the checker that cries wolf
+- **Next:** **v5.1's five issues, and nothing else** _(2026-09-09: #80 joined when its analysis was
+  recovered from an abandoned branch; 2026-09-11: #95 joined at the owner's ask)_. **Three** subjects,
+  and the third is the only one not reported from outside: the checker that cries wolf
   ([#71](https://github.com/tpierrain/kenjaku/issues/71),
   [#73](https://github.com/tpierrain/kenjaku/issues/73),
-  [#74](https://github.com/tpierrain/kenjaku/issues/74)) and a source that goes quiet without saying
-  so ([#80](https://github.com/tpierrain/kenjaku/issues/80)) → § *v5.1*. Nothing is started.
+  [#74](https://github.com/tpierrain/kenjaku/issues/74)), a source that goes quiet without saying so
+  ([#80](https://github.com/tpierrain/kenjaku/issues/80)), and a no-hard-wrap rule that guards files
+  but not the text copied out of the chat
+  ([#95](https://github.com/tpierrain/kenjaku/issues/95)) → § *v5.1*. Nothing is started. The
+  milestone on GitHub carries all five, and its description was widened to match.
 - **Blocked on:** nothing. The three `/lint` defects have obvious tests and no design question. #80
   needs **one** design call, named in its own step (what a known-positive control query looks like per
   connector), and nothing else. A session may open the release today, test-first.
@@ -132,7 +135,9 @@
 
 ### v5.1 — what outside users reported · milestone [`v5.1`](https://github.com/tpierrain/kenjaku/milestone/1)
 
-_**Two** subjects, two reporters, one criterion: somebody outside the project hit it on a real brain._
+_**Three** subjects. The first two came from outside the project, on real brains; the third is the
+owner's own call, added on 2026-09-11 — a rule that lives in the wrong layer and is therefore applied
+to the wrong perimeter._
 _(Read "v5.1" as **the next bugfix release** — see the header note; the number is the owner's.)_
 
 #### A checker stops reporting healthy things as broken
@@ -199,9 +204,32 @@ asked for it anonymised. Nothing identifying goes into the issue, the plan, or t
       no code for, and the same tool answered normally the same day on another account. What is ours,
       and all we fix, is that the brain **presented an unread source as a read one**.
 
-#### Both subjects
+#### A rule that guards files does not guard the text you copy out of the chat
 
-- [ ] **7. Answer both reporters.** Each issue closed with what shipped and how it was verified
+_Added to this release on 2026-09-11, at the owner's ask. Not field-reported: measured on his own
+session of 2026-09-09, after three earlier corrections on the same defect._
+
+- [ ] **7. The no-hard-wrap rule moves into `CLAUDE.engine.md`, and triggers on the destination
+      instead of on the word "file"** — [#95](https://github.com/tpierrain/kenjaku/issues/95). The
+      rule currently sits in each owner's personal `CLAUDE.md` and opens on *"aucun **fichier**
+      Markdown…"*, so it fires on vault notes and never on the fenced block in the chat, which is
+      exactly the text that gets copied into Slack. Same session: four notes written clean, three
+      fenced blocks hard-wrapped at 95 characters.
+  - [ ] **The rule lands in the engine layer**, worded as *never insert a line break the content does
+        not require*, naming the destinations explicitly — vault notes, cheat sheets, article drafts,
+        messages to send, **and fenced blocks in the chat**.
+  - [ ] **The copy in the generated `CLAUDE.md` template is removed, not left alongside.** Two files
+        carrying one rule is a guarantee they diverge. An owner who genuinely wants hard wrapping
+        states it in their own `CLAUDE.md`, as an override.
+  - [ ] **Say plainly that no machine can inspect chat output before the owner sees it**, so that half
+        is a written reflex by construction. The deterministic net covers files only:
+        `node scripts/unwrap-markdown.mjs <file|folder>`.
+  - [ ] **The upgrade path says what to do for existing brains** whose personal `CLAUDE.md` still
+        holds the old wording.
+
+#### All three subjects
+
+- [ ] **8. Answer both reporters.** Each issue closed with what shipped and how it was verified
       (`CONVENTIONS.md` §10bis). The release note names the `/lint` contributor; the second report
       came through a private channel, so it is credited **without a name**.
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -97,6 +97,12 @@
   then the rest of the release.** Branch `fix/v5.1-bugfixes`. Per this file's own permissions a
   session may work it test-first end to end and push the branch, but may **not** tag, publish, merge
   to `main`, write into `templates/fr/**`, or touch either of his real brains.
+  - [x] **#95 — the no-hard-wrap rule** _(`c50d5ad`, `13f3f31`)_. The net it names had to be built
+        first: it existed only inside his brain, never in this repo.
+  - [x] **#71 / #73 / #74 — the checker that cries wolf** _(`d797707`)_.
+  - [ ] **#80 — a silent source**. In progress; it is the only one of the five carrying a design call.
+  - [ ] **Step 8 — answer the reporters, and the release note.** Not startable until the tag's number
+        is his call.
 - 🎙️ **ONE QUESTION IS EXPLICITLY DEFERRED, NOT PENDING** _(2026-09-11, his words)_: whether
   [#77](https://github.com/tpierrain/kenjaku/issues/77) rides along in v5.1. **"À l'issue de ça, on se
   reposera la question."** So § *THE ONE QUESTION* is answered for now — **not in this release** — and
@@ -153,19 +159,41 @@ _(Read "v5.1" as **the next bugfix release** — see the header note; the number
 
 _Reported by [@StefanPenndorf](https://github.com/StefanPenndorf), from a real vault._
 
-- [ ] **1.** `/lint` resolves an image or attachment embed (`![[shot.png]]`) instead of calling it
+_All three shipped 2026-09-11 · `d797707`._
+
+- [x] **1.** `/lint` resolves an image or attachment embed (`![[shot.png]]`) instead of calling it
       dangling — [#71](https://github.com/tpierrain/kenjaku/issues/71). The resolver only ever indexed
-      `.md`, so every picture in every note reads as a dead link.
-- [ ] **2.** `/lint` unescapes the alias pipe inside a table cell (`[[note\|alias]]`) before resolving
+      `.md`, so every picture in every note read as a dead link.
+  - [x] Attachments are **resolution targets and nothing else**: never an orphan, never frontmatter
+        rot, because an attachment is not a note. They reach the core through `options.attachments`,
+        and both callers (`/lint` and the session-start nudge) read them from the **same** vault dir
+        as the notes.
+  - [x] The list is the **complement** of the note list, not an allow-list of image extensions:
+        `.excalidraw`, `.canvas`, `.webp` and whatever Obsidian supports next need no maintenance, and
+        every miss in an allow-list would have been a permanent false positive.
+  - [x] Registered under their **full spelling only** (extension included), so a picture can never
+        answer for a missing note of the same stem.
+- [x] **2.** `/lint` unescapes the alias pipe inside a table cell (`[[note\|alias]]`) before resolving
       — [#73](https://github.com/tpierrain/kenjaku/issues/73). A Markdown table forces the escape, so
-      the checker looks for a filename that cannot exist.
-- [ ] **3.** `/lint` stops flagging `backlog/` as an orphan zone —
-      [#74](https://github.com/tpierrain/kenjaku/issues/74). The shipped constitution declares it and
-      the engine writes into it: the checker is complaining about the engine's own work.
-- [ ] **4. 📉 This half is measured by the number, not by the three fixes.** A real brain reports
-      *"17 links point nowhere"* today, and #71 + #73 inflate that count. **A checker nobody believes
-      is a checker nobody reads.** So the acceptance test is what the count says on a real vault
-      afterwards, and the release note leads with that, not with three bug references.
+      the checker looked for a filename that cannot exist. The cascade is pinned by its own test: the
+      target stops being a false orphan, and the staleness reference it used to drop is counted again.
+- [x] **3.** `/lint` stops flagging `backlog/` as an orphan zone —
+      [#74](https://github.com/tpierrain/kenjaku/issues/74). Keyed on the **folder**, which covers
+      every locale at once (the overlay localises the file, never the folder) and gets
+      `<universe>/backlog/` for free. It stays held to the frontmatter rule: exempt from orphan is not
+      exempt from taxonomy.
+- [x] **4. 📉 This half is measured by the number, not by the three fixes.** **A checker nobody
+      believes is a checker nobody reads.**
+  - [x] 📐 **Measured, and the honest answer is not the one this step predicted.** On the owner's real
+        663-note vault, before → after: **orphans 87 → 85**, dangling links **18 → 18**, stale 4 → 4,
+        frontmatter 3 → 3. The line above assumed *"#71 + #73 inflate that count"*, and on **this**
+        vault they cannot: it holds **zero** attachment embeds and **zero** escaped pipes (measured,
+        not assumed). Those two were reported from **a different vault**, and both are proven by
+        running the CLI as a process against a tree built to the issues' own repro steps.
+  - [x] ⚠️ **So the release note must not lead with a number from this brain.** Two of the three fixes
+        would read as having changed nothing. Lead with **what stops being reported** — a pasted
+        screenshot, a link inside a table, the engine's own backlog — and keep the 87 → 85 as the one
+        figure that is genuinely ours to quote.
 
 #### A source that goes quiet is reported as a source with no news
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -104,10 +104,11 @@
   ([#95](https://github.com/tpierrain/kenjaku/issues/95)) → § *v5.1*. The milestone on GitHub carries
   all five and stays **bug-fix only**: the owner's call when he added #95, *"#95 décrit un bug plus
   qu'une nouvelle feature"*. **All five are now ticked in § *v5.1* below**, each with its commit.
-- ▶️ **WORK IS UNDERWAY, autonomously, since 2026-09-11** — he said go and left. Order: **#95 first,
-  then the rest of the release.** Branch `fix/v5.1-bugfixes`. Per this file's own permissions a
-  session may work it test-first end to end and push the branch, but may **not** tag, publish, merge
-  to `main`, write into `templates/fr/**`, or touch either of his real brains.
+- ▶️ **THE AUTONOMOUS STRETCH IS OVER — it ran on 2026-09-11 and finished.** He said go, left, and
+  came back to a green PR. Order worked: **#95 first, then the rest.** Branch `fix/v5.1-bugfixes`.
+  Per this file's own permissions a session may work it test-first end to end and push the branch, but
+  may **not** tag, publish, merge to `main`, write into `templates/fr/**`, or touch either of his real
+  brains.
   - [x] **#95 — the no-hard-wrap rule** _(`c50d5ad`, `13f3f31`)_. The net it names had to be built
         first: it existed only inside his brain, never in this repo.
   - [x] **#71 / #73 / #74 — the checker that cries wolf** _(`d797707`)_.
@@ -116,10 +117,12 @@
         zero is impossible on a live account.
   - [ ] **Step 8 — answer the reporters, and the release note.** Not startable until the tag's number
         is his call.
-- 🎙️ **ONE QUESTION IS EXPLICITLY DEFERRED, NOT PENDING** _(2026-09-11, his words)_: whether
-  [#77](https://github.com/tpierrain/kenjaku/issues/77) rides along in v5.1. **"À l'issue de ça, on se
-  reposera la question."** So § *THE ONE QUESTION* is answered for now — **not in this release** — and
-  is re-opened only once the five above are done. Do not raise it before then.
+- 🎙️ **THAT DEFERRAL HAS EXPIRED — the question is live again** _(2026-09-11, second half of the
+  day)_. Whether [#77](https://github.com/tpierrain/kenjaku/issues/77) rides along in v5.1 was
+  deferred in his words — **"à l'issue de ça, on se reposera la question"** — *until the five were
+  done*, and they are. It was **put to him at the end of the autonomous stretch and is awaiting his
+  answer**; § *THE ONE QUESTION* holds the trade-off, recommendation unchanged (**leave it in v5.2**).
+  Do not re-ask it a second time: read his answer if it has arrived, and otherwise leave it be.
 - **Blocked on:** nothing a session can unblock. The five are done; what remains needs the owner (the
   tag's number, the merge, the release note) or the reporter (the one-call throttling test under step
   5, which needs their own account and cannot run from here).

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -93,10 +93,22 @@
     `v5.1.3` is the real one, and needs regenerating only if the bytes of a merge-regime file move
     again. The note's draft is **not committed anywhere** — it lives in the session scratchpad and
     must be re-drafted from this plan if lost, which is cheap: § *step 8* lists everything it owes.
-  - ✅ **Nothing blocks publication any more.** The §10ter field rehearsal ran against this branch and
-    passed, on an old French brain, with the new script verified *running* in the updated copy (step
-    8's 🧪 item holds the readings). What is left is the mechanical sequence: merge, tag, publish the
-    note, close the five issues.
+  - ✅ **Every gate this release owes is now passed.** All 7 matrix cells + the Windows installer
+    end-to-end are green on PR #97's final commit (`68d5c40`), the §10ter field rehearsal ran **against
+    this branch** on an old French brain with the new script verified *running* in the updated copy
+    (step 8's 🧪 item holds the readings), and the §10 marketing re-read is done and recorded.
+  - 🔐 **STOPPED AT THE PUBLISHING STEP, and it is a permission wall, not an unfinished check.**
+    `gh pr merge 97` was **refused by the sandbox** — as it should be: this plan's own permissions say
+    a session may not merge to `main`, tag or publish. **The remaining sequence, in order**, for
+    whoever has the rights:
+    1. `gh pr merge 97 --merge` (this repo merges, never squashes — see `5b16101`, `c10e4b5`).
+    2. Tag **`v5.1.3`** on `main` and push it.
+    3. `gh release create v5.1.3 --title "v5.1.3 — The One Where It Stops Crying Wolf" --notes-file
+       maintainers/plans/archived/release-v5.1.3-note.md`. **The approved text is in the repo**, not in
+       a session scratchpad, because a note that only exists in a chat dies at the next `/clear`. Its
+       `## What you get` section is verified to survive `extractWhatYouGet` verbatim (3 moments, 6
+       bullets) — the check §11 demands and the v5.0.0 note failed.
+    4. Close **#71, #73, #74, #80, #95** with what shipped (§10bis).
   - 🔁 **The #77 question was put to him and he has not answered it** — he answered the two that came
     after instead (the name, then the note). Its silence now reads as *not in this release*, which is
     also the standing recommendation (**leave it in v5.2**). § *THE ONE QUESTION* holds the trade-off.

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -374,6 +374,25 @@ is correct, it simply never fires on half of what it names._
         constitution change. It is a **placeholder**: the number is the owner's call, and the table is
         regenerated once more against the real tag before it is cut
         (`node maintainers/fingerprints/generate-fingerprints.mjs --version <tag>`).
+  - [x] 🪧 **Marketing surface re-read** _(2026-09-11, `CONVENTIONS.md` §10)_. **Nothing was made
+        false.** *"Never overwrites your notes"* (README, Guardrails and the reliability board) still
+        holds: the new rewriter is a command the owner runs, never a hook, and no deterministic
+        machinery calls it.
+    - [x] **One thing was made TRUE that we did not sell** — and it strengthens the flagship
+          reliability claim, so it went on the page: *"Silence is reported as silence"* (README) and
+          its twin in `EN-QUOI-C-EST-DIFFERENT.md` now add that **a source that could not be reached
+          is told apart from a source with nothing to say**. Before #80 the brain could not verify a
+          silence at all, which made *"a silence it has not verified"* the whole story; it no longer is.
+    - [x] **Boards re-read, no re-render** — the boring verdict, written down because *checked* and
+          *not looked at* are indistinguishable a month later. `board-connect`'s *"read-only, it reads
+          your sources, never changes them"* and `board-reliability`'s copy are both untouched by this
+          release; the liveness check reads, it does not write.
+  - [ ] 🧪 **The field rehearsal (§10ter) is OWED and has not run** — `engine-manifest.json` changed
+        (a new `replace`-regime script, `engineVersion.scripts` 1.17.0 → 1.18.0), and a manifest change
+        is exactly the *old parent, new child* case no suite here can see. **A session cannot run it
+        alone**: `rehearse.mjs --brain ~/mind-palace` reads a real brain, and this plan forbids that
+        without the owner. It copies without `.git` and only ever reads the original, so the owner's
+        go-ahead is the only thing missing.
 
 ### v5.2 — the rest of the tracker · milestone [`v5.2`](https://github.com/tpierrain/kenjaku/milestone/2)
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -86,13 +86,21 @@
   _(2026-09-11, one autonomous stretch)_. `fix/v5.1-bugfixes` →
   **[PR #97](https://github.com/tpierrain/kenjaku/pull/97)**, opened so the arbiter could run:
   **all 7 matrix cells pass, plus the Windows installer end-to-end**. Every commit was pushed and
-  every push read. **What is left is his, not a session's**: the release number, the tag, the merge to
-  `main`, the release note, and closing the five issues with what shipped (step 8). The fingerprint
-  table carries a **placeholder** `v5.1.3` that must be regenerated against the real tag.
-  - 🔁 **And the deferred question comes back now**: § *THE ONE QUESTION*, does
-    [#77](https://github.com/tpierrain/kenjaku/issues/77) ride along? He said *"à l'issue de ça, on se
-    reposera la question"*, and this is that point. The trade-off is already written out there; the
-    standing recommendation is still **leave it in v5.2**.
+  every push read.
+  - 🏷️ **THE RELEASE IS NAMED AND ITS NOTE IS APPROVED** _(2026-09-11, his call, both of them)_:
+    **`v5.1.3 — The One Where It Stops Crying Wolf`**, and the drafted note got *"ok pour la release
+    note, on peut y aller"*. So the number is **no longer a placeholder**: the fingerprint table's
+    `v5.1.3` is the real one, and needs regenerating only if the bytes of a merge-regime file move
+    again. The note's draft is **not committed anywhere** — it lives in the session scratchpad and
+    must be re-drafted from this plan if lost, which is cheap: § *step 8* lists everything it owes.
+  - 🛑 **What blocks publication is ONE thing, and it is technical, not a decision**: the §10ter field
+    rehearsal has not yet run **against this branch's code** (step 8's 🧪 item). The run that would
+    was refused by the sandbox. Until it is read, merging and tagging would ship an engine-manifest
+    change on the one path no suite here can see.
+  - 🔁 **The #77 question was put to him and he has not answered it** — he answered the two that came
+    after instead (the name, then the note). Its silence now reads as *not in this release*, which is
+    also the standing recommendation (**leave it in v5.2**). § *THE ONE QUESTION* holds the trade-off.
+    **Do not ask a third time**; it has been asked twice.
 - **Next (what the FIVE were):** _(2026-09-09: #80 joined when its analysis was
   recovered from an abandoned branch; 2026-09-11: #95 joined at the owner's ask)_. **Three** subjects,
   and the third is the only one not reported from outside: the checker that cries wolf
@@ -387,12 +395,19 @@ is correct, it simply never fires on half of what it names._
           *not looked at* are indistinguishable a month later. `board-connect`'s *"read-only, it reads
           your sources, never changes them"* and `board-reliability`'s copy are both untouched by this
           release; the liveness check reads, it does not write.
-  - [ ] 🧪 **The field rehearsal (§10ter) is OWED and has not run** — `engine-manifest.json` changed
-        (a new `replace`-regime script, `engineVersion.scripts` 1.17.0 → 1.18.0), and a manifest change
-        is exactly the *old parent, new child* case no suite here can see. **A session cannot run it
-        alone**: `rehearse.mjs --brain ~/mind-palace` reads a real brain, and this plan forbids that
-        without the owner. It copies without `.git` and only ever reads the original, so the owner's
-        go-ahead is the only thing missing.
+  - [ ] 🧪 **The field rehearsal (§10ter) is OWED, half-run, and the half that ran proves the wrong
+        thing** — `engine-manifest.json` changed (a new `replace`-regime script, `engineVersion.scripts`
+        1.17.0 → 1.18.0), which is exactly the *old parent, new child* case no suite here can see.
+    - [x] **Ran once against `~/legacy-brain`** _(2026-09-11)_, a real brain installed **2026-06-18 at
+          v3.4.0**, 30 notes, and deliberately **not** one of the owner's two personal brains. Result:
+          the update converged and **the owner's territory came back byte-identical**.
+    - [ ] ⚠️ **But it landed v5.1.2, not this branch.** The harness force-tags the mirror at `--tag`,
+          default **`v5.0.0`** — older than the newest published release, so the brain's updater
+          correctly chose **v5.1.2** and this branch's code was never exercised. **The run that counts
+          is `--tag v5.1.3`** (the tag is forced in the temp bare mirror only, never in this repo,
+          `rehearse.mjs:71`). It was **refused by the sandbox** and needs the owner's go-ahead.
+    - [ ] 📌 **Do not read the green above as §10ter satisfied.** Until the `--tag v5.1.3` run is read,
+          what is proven is the *published* path on an old brain, not the one this release ships.
 
 ### v5.2 — the rest of the tracker · milestone [`v5.2`](https://github.com/tpierrain/kenjaku/milestone/2)
 

--- a/maintainers/plans/prospective/clear-the-tracker-action.md
+++ b/maintainers/plans/prospective/clear-the-tracker-action.md
@@ -90,15 +90,23 @@
   [#74](https://github.com/tpierrain/kenjaku/issues/74)), a source that goes quiet without saying so
   ([#80](https://github.com/tpierrain/kenjaku/issues/80)), and a no-hard-wrap rule that guards files
   but not the text copied out of the chat
-  ([#95](https://github.com/tpierrain/kenjaku/issues/95)) → § *v5.1*. Nothing is started. The
-  milestone on GitHub carries all five, and its description was widened to match.
+  ([#95](https://github.com/tpierrain/kenjaku/issues/95)) → § *v5.1*. The milestone on GitHub carries
+  all five and stays **bug-fix only**: the owner's call when he added #95, *"#95 décrit un bug plus
+  qu'une nouvelle feature"*.
+- ▶️ **WORK IS UNDERWAY, autonomously, since 2026-09-11** — he said go and left. Order: **#95 first,
+  then the rest of the release.** Branch `fix/v5.1-bugfixes`. Per this file's own permissions a
+  session may work it test-first end to end and push the branch, but may **not** tag, publish, merge
+  to `main`, write into `templates/fr/**`, or touch either of his real brains.
+- 🎙️ **ONE QUESTION IS EXPLICITLY DEFERRED, NOT PENDING** _(2026-09-11, his words)_: whether
+  [#77](https://github.com/tpierrain/kenjaku/issues/77) rides along in v5.1. **"À l'issue de ça, on se
+  reposera la question."** So § *THE ONE QUESTION* is answered for now — **not in this release** — and
+  is re-opened only once the five above are done. Do not raise it before then.
 - **Blocked on:** nothing. The three `/lint` defects have obvious tests and no design question. #80
   needs **one** design call, named in its own step (what a known-positive control query looks like per
   connector), and nothing else. A session may open the release today, test-first.
-- **Owner's call pending:** **ONE, and it is about v5.2's shape** — § *THE ONE QUESTION*: should
-  [#77](https://github.com/tpierrain/kenjaku/issues/77), the only open issue that can **lose a user's
-  note**, really wait for v5.2, or ride along in v5.1? Recommendation inside; it does not block v5.1
-  starting.
+- **Owner's call pending:** **NONE right now.** The one that was pending — § *THE ONE QUESTION*,
+  should [#77](https://github.com/tpierrain/kenjaku/issues/77) ride along in v5.1? — he **deferred on
+  2026-09-11**: not in this release, re-asked once the five are done. See the deferral entry above.
   - ⏸️ **Two inherited questions, deliberately not re-asked.** (1) Inside #78, a product question only
     he can answer: *is a brain's copy of the launcher README meant to link to the launcher's own docs
     at all?* (2) The `concurrency` group for `ci.yml` (recommendation: yes) — offered three times,
@@ -135,9 +143,10 @@
 
 ### v5.1 — what outside users reported · milestone [`v5.1`](https://github.com/tpierrain/kenjaku/milestone/1)
 
-_**Three** subjects. The first two came from outside the project, on real brains; the third is the
-owner's own call, added on 2026-09-11 — a rule that lives in the wrong layer and is therefore applied
-to the wrong perimeter._
+_**Three** subjects, and the release stays **bug-fix only** — the owner's call, 2026-09-11, when #95
+was added: **"#95 décrit un bug plus qu'une nouvelle feature"**. Two subjects were reported from
+outside the project, on real brains; the third was measured on his own session. All three are the
+same shape: something healthy is reported as broken, or something broken is reported as healthy._
 _(Read "v5.1" as **the next bugfix release** — see the header note; the number is the owner's.)_
 
 #### A checker stops reporting healthy things as broken
@@ -207,7 +216,9 @@ asked for it anonymised. Nothing identifying goes into the issue, the plan, or t
 #### A rule that guards files does not guard the text you copy out of the chat
 
 _Added to this release on 2026-09-11, at the owner's ask. Not field-reported: measured on his own
-session of 2026-09-09, after three earlier corrections on the same defect._
+session of 2026-09-09, after three earlier corrections on the same defect. **It is a bug, not a
+feature** — his call, and the reason this release keeps its bug-fix-only framing: the rule exists and
+is correct, it simply never fires on half of what it names._
 
 - [ ] **7. The no-hard-wrap rule moves into `CLAUDE.engine.md`, and triggers on the destination
       instead of on the word "file"** — [#95](https://github.com/tpierrain/kenjaku/issues/95). The
@@ -275,6 +286,11 @@ session of 2026-09-09, after three earlier corrections on the same defect._
       nobody can size a de-identification design before it exists.
 
 ## 🎙️ THE ONE QUESTION — does the issue that can lose a note really wait for v5.2?
+
+> ⏸️ **ANSWERED FOR NOW, 2026-09-11: it waits.** *"À l'issue de ça, on se reposera la question
+> d'inclure ou pas le bug fix de la 77."* So the recommendation below is the standing decision, and
+> **this section is not to be raised again until v5.1's five issues are done**. Keep it: the moment it
+> is re-opened, the trade-off is already written out.
 
 **#77 is the only open issue whose failure mode is silent data loss.** A note written by
 `/consolidate` or `/file-back` lands on disk, the session prints `✓ Refreshed`, and nothing is

--- a/scripts/consolidate-scan.mjs
+++ b/scripts/consolidate-scan.mjs
@@ -15,7 +15,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 import { join } from "node:path";
 
-import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
+import { readVaultNotes, readVaultAttachments } from "./lib/wiki-lint-io.mjs";
 import { consolidationCandidates, reportLines, hasCandidates } from "./lib/consolidation-candidates.mjs";
 import { runAsEntrypoint } from "./lib/entrypoint.mjs";
 
@@ -28,6 +28,7 @@ const toPosix = (p) => p.split("\\").join("/");
 export const realConsolidateDeps = {
   cwd: () => process.cwd(),
   readNotes: readVaultNotes,
+  readAttachments: readVaultAttachments,
   log: (...a) => console.log(...a),
 };
 
@@ -37,7 +38,9 @@ export const realConsolidateDeps = {
 export function runConsolidateScan(argv, deps = realConsolidateDeps) {
   const vaultDir = toPosix(argv[0] ? argv[0] : join(deps.cwd(), "vault"));
   const notes = deps.readNotes(vaultDir);
-  const report = consolidationCandidates(notes);
+  // Attachments resolve here too (#71): without them an embedded picture is an
+  // unresolved mention, and an unresolved mention in this scan means "propose a page".
+  const report = consolidationCandidates(notes, { attachments: deps.readAttachments(vaultDir) });
   deps.log(`Scanned ${notes.length} notes under ${vaultDir}`);
   for (const line of reportLines(report)) deps.log(line);
   return hasCandidates(report) ? 1 : 0;

--- a/scripts/consolidate-scan.test.mjs
+++ b/scripts/consolidate-scan.test.mjs
@@ -28,6 +28,7 @@ function fakeDeps(overrides = {}) {
       seenDirs.push(dir);
       return [];
     },
+    readAttachments: () => [],
     log: (line) => logs.push(line),
     ...overrides,
   };
@@ -93,4 +94,34 @@ test("the CLI, IMPORTED rather than run — the body must not fire on import", a
 
   assert.equal(run.status, 0, `importing the CLI must not exit — stderr: ${run.stderr}`);
   assert.equal(run.stdout.trim(), "imported-and-still-alive");
+});
+
+test("runConsolidateScan — an embedded attachment is not proposed as a page to create (#71)", () => {
+  const capture = {
+    path: "meetings/2026-07-10.md",
+    frontmatter: { type: "meeting", created: "2026-07-10", updated: "2026-07-10", tags: ["m"] },
+    body: "Discussed the plan. ![[screenshot.png]]",
+  };
+  const { deps, logs } = fakeDeps({ readNotes: () => [capture], readAttachments: () => ["meetings/screenshot.png"] });
+  assert.equal(runConsolidateScan([], deps), 0);
+  assert.ok(
+    !logs.some((line) => line.includes("screenshot.png")),
+    `a picture must not be proposed as a note to create — got: ${logs.join(" | ")}`,
+  );
+});
+
+test("runConsolidateScan — the attachments are read from the SAME directory as the notes", () => {
+  const seen = [];
+  const { deps } = fakeDeps({
+    readNotes: (dir) => {
+      seen.push(`notes:${dir}`);
+      return [];
+    },
+    readAttachments: (dir) => {
+      seen.push(`attachments:${dir}`);
+      return [];
+    },
+  });
+  runConsolidateScan(["/data/other-vault"], deps);
+  assert.deepEqual(seen, ["notes:/data/other-vault", "attachments:/data/other-vault"]);
 });

--- a/scripts/lib/consolidation-candidates.mjs
+++ b/scripts/lib/consolidation-candidates.mjs
@@ -55,7 +55,11 @@ function sortedCandidates(groups, build) {
 export function consolidationCandidates(notes, options = {}) {
   const captureZones = options.captureZones ?? DEFAULT_CAPTURE_ZONES;
   const entityTypes = options.entityTypes ?? DEFAULT_ENTITY_TYPES;
-  const resolve = buildResolver(notes);
+  // The vault's non-note files are resolution targets here for the same reason they
+  // are in the lint (#71): a screenshot pasted into a meeting note is an unresolved
+  // mention otherwise, and an unresolved mention in this scan means "no page for this
+  // yet" — so the brain proposed creating a note called `screenshot.png`.
+  const resolve = buildResolver(notes, options.attachments ?? []);
   const byPath = new Map(notes.map((n) => [n.path, n]));
 
   // Group the captures' unresolved mentions by target page (new-page candidates),
@@ -74,6 +78,11 @@ export function consolidationCandidates(notes, options = {}) {
       // Resolves to an existing page: a refresh candidate when that page is a
       // curated entity/topic left behind — the capture is fresher than its `updated:`.
       const page = byPath.get(resolved);
+      // …unless what it resolved to is an ATTACHMENT, which is not a note and has no
+      // frontmatter to read. Reading one anyway is a TypeError, and the session-start
+      // hook that calls this is fail-open: the crash would not surface, the entire
+      // nudge would just vanish, taking the real findings with it.
+      if (!page) continue;
       if (!entityTypes.includes(page.frontmatter.type)) continue;
       if (!(Date.parse(source.updated) > Date.parse(page.frontmatter.updated))) continue;
       addSource(refreshSources, resolved, source);

--- a/scripts/lib/consolidation-candidates.test.mjs
+++ b/scripts/lib/consolidation-candidates.test.mjs
@@ -411,3 +411,53 @@ test("reportLines — a page with SEVERAL fresher sources lists them comma-separ
     "  topics/rag.md (updated 2026-04-01) — 2 fresher: daily/2026-07-15.md, daily/2026-07-16.md",
   ]);
 });
+
+// ── #71, the SECOND half of the same session-start nudge ────────────────────
+//
+// The dangling-link report and the consolidation report are surfaced together, and
+// both go through the same resolver. So a screenshot pasted into a meeting note was
+// not only reported as a dead link: its target reached this scan as an unresolved
+// mention, which here means "no page for this yet" — and the brain proposed
+// CREATING A NOTE CALLED `screenshot.png`.
+
+test("consolidationCandidates — an embedded attachment that EXISTS is not a page to create", () => {
+  const capture = {
+    path: "meetings/2026-07-10.md",
+    frontmatter: { type: "meeting", updated: "2026-07-10" },
+    body: "Discussed the plan. ![[screenshot.png]]",
+  };
+  const report = consolidationCandidates([capture], { attachments: ["meetings/screenshot.png"] });
+  assert.deepEqual(report, { newPages: [], refreshes: [] });
+});
+
+test("consolidationCandidates — an attachment is never a REFRESH candidate either, and resolving one does not throw", () => {
+  // It resolves to something that is not a note at all, so the page lookup finds
+  // nothing. Reading a frontmatter off that is a TypeError — and in the session-start
+  // hook, which is fail-open, a TypeError does not surface as a crash: the whole
+  // nudge silently disappears, taking the real findings with it.
+  const capture = {
+    path: "meetings/2026-07-10.md",
+    frontmatter: { type: "meeting", updated: "2026-07-10" },
+    body: "![[diagram.excalidraw]] and [[people/alice]]",
+  };
+  const page = { path: "people/alice.md", frontmatter: { type: "person", updated: "2026-01-01" }, body: "" };
+  const report = consolidationCandidates([capture, page], { attachments: ["assets/diagram.excalidraw"] });
+  assert.deepEqual(report.newPages, []);
+  assert.deepEqual(report.refreshes, [
+    { page: "people/alice.md", updated: "2026-01-01", sources: [{ path: "meetings/2026-07-10.md", updated: "2026-07-10" }] },
+  ], "the real candidate beside it must survive untouched");
+});
+
+test("consolidationCandidates — an embed of a picture that is NOT in the vault behaves as before", () => {
+  // Deliberately pinned rather than quietly narrowed: an unresolved target is a
+  // new-page candidate, and that is the pre-existing rule for every unresolved
+  // target. The dangling-link report is what names this one as broken.
+  const capture = {
+    path: "meetings/2026-07-10.md",
+    frontmatter: { type: "meeting", updated: "2026-07-10" },
+    body: "![[gone.png]]",
+  };
+  assert.deepEqual(consolidationCandidates([capture], { attachments: [] }).newPages, [
+    { target: "gone.png", sources: [{ path: "meetings/2026-07-10.md", updated: "2026-07-10" }] },
+  ]);
+});

--- a/scripts/lib/engine-fingerprints.json
+++ b/scripts/lib/engine-fingerprints.json
@@ -143,6 +143,14 @@
       "sha256:7cdb0e7836a5aea5abc8717725c613261abeb44fc9faca0fe680a7b932893719": {
         "since": "v5.1.0",
         "locale": "fr"
+      },
+      "sha256:fcb72ca231c38e4a56114e2805449cafb8abc2212e746d856787558069e2de72": {
+        "since": "v5.1.3",
+        "locale": "en"
+      },
+      "sha256:68c51b248622057504c2ba8618d176dfc1608a1692ca7a2700e720839e92e1fd": {
+        "since": "v5.1.3",
+        "locale": "fr"
       }
     },
     ".claude/skills/sync/SKILL.md": {
@@ -272,11 +280,11 @@
         "since": "v5.1.0",
         "locale": "fr"
       },
-      "sha256:0d283e29d14ab6a0b5fc5e7cf97d0b01e762a3b1def478a03e419a95e1d433d1": {
+      "sha256:9187cf3efd56101d58dedd2bf4aa29685711b57e9502db1b897a5b21f81e9141": {
         "since": "v5.1.3",
         "locale": "en"
       },
-      "sha256:70faef54c70be7e73a9ec7476394303e18ccb33d25e096d6ce4994718b5627aa": {
+      "sha256:32adf6b7f6eaabc8f4343463cf0779e518b02a48512d53d94db133482f9a2a62": {
         "since": "v5.1.3",
         "locale": "fr"
       }

--- a/scripts/lib/engine-fingerprints.json
+++ b/scripts/lib/engine-fingerprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "v5.1.0",
+  "generatedAt": "v5.1.3",
   "files": {
     ".claude/skills/coach/SKILL.md": {
       "sha256:3a1df7202920eb0cf1879bf8cecaf1eba91944a7efcbef339c0d0e6a3cd9aa74": {
@@ -270,6 +270,14 @@
       },
       "sha256:d991f3ca831bfd01698d57316089c1a9d1f3b6528ffee3270472aae687820d28": {
         "since": "v5.1.0",
+        "locale": "fr"
+      },
+      "sha256:0d283e29d14ab6a0b5fc5e7cf97d0b01e762a3b1def478a03e419a95e1d433d1": {
+        "since": "v5.1.3",
+        "locale": "en"
+      },
+      "sha256:70faef54c70be7e73a9ec7476394303e18ccb33d25e096d6ce4994718b5627aa": {
+        "since": "v5.1.3",
         "locale": "fr"
       }
     },

--- a/scripts/lib/source-liveness-discipline.test.mjs
+++ b/scripts/lib/source-liveness-discipline.test.mjs
@@ -1,0 +1,200 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { docSection } from "./doc-section.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #80 — A SOURCE THAT GOES QUIET MUST NOT READ AS A SOURCE WITH NO NEWS.
+//
+// The field report: during a wide catch-up pass, a mail connector's SEARCH route
+// stopped returning anything while its READ route kept working. No error, no
+// warning — the contract says in as many words that an empty result is not an
+// error. So from inside the brain these two are byte-for-byte identical:
+//
+//   1. the mailbox genuinely holds nothing on this subject;
+//   2. the search route is dead and will match nothing, ever, for any query.
+//
+// The brain reported the first. In a digest that surfaces as a section that is
+// simply absent, or a line saying nothing was found — a reader sees a covered
+// source with no news, where what happened is a source that was never read.
+//
+// ⚖️ WHAT IS NOT OURS, so this guard is not mistaken for one about an outage: the
+// route belongs to a native connector this repo ships no code for, and the same
+// tool answered normally the same day on another account. What is ours, and all
+// this asserts, is that the brain PRESENTED AN UNREAD SOURCE AS A READ ONE.
+//
+// Why a doc guard and not a runtime check — the same argument as
+// claim-discipline.test.mjs: what fails here is what the model is TOLD, the
+// telling lives in four files that drift independently (the producer skill and
+// the constitution, each in two locales), and no script in this repo can call an
+// account-side connector to measure liveness for real.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (rel) => readFileSync(join(REPO_ROOT, rel), "utf8");
+
+// ⚠️ Every multi-word pattern below matches ACROSS whitespace (`\s+`, never a literal
+// space). These documents are hard-wrapped, so "same route" is one line break away from
+// being "same\nroute" at any edit — and a guard that goes red because a paragraph
+// re-wrapped is a guard that gets relaxed, then deleted. Measured here: the FR
+// constitution's "sans mot-clé" wrapped between the two words on the first run.
+const HEADING_EN = /^#+ Source liveness/m;
+const HEADING_FR = /^#+ Vivacité des sources/m;
+
+// The producer of every briefing, in both locales. The FR copy is a SEPARATE file
+// that a French brain gets INSTEAD of the English one, so a rule added only to the
+// EN side reaches no French user at all.
+const SKILLS = [
+  { name: "sync-sources", locale: "EN", path: ".claude/skills/sync-sources/SKILL.md" },
+  { name: "sync-sources", locale: "FR", path: "templates/fr/.claude/skills/sync-sources/SKILL.md" },
+];
+
+// A constitution is the UNION of its two layers: the thin sacred file and the
+// engine layer it @imports. Asserting on the union keeps this correct wherever the
+// directive ends up sitting.
+const CONSTITUTIONS = [
+  { locale: "EN", layers: ["CLAUDE.md.template", "CLAUDE.engine.md"] },
+  { locale: "FR", layers: ["templates/fr/CLAUDE.md.template", "templates/fr/CLAUDE.engine.md"] },
+];
+
+// ── The six load-bearing points, each named by the failure it prevents ──────
+const RULES_EN = [
+  {
+    why: "the discriminator is a CONTROL query — one extra call whose emptiness is impossible on a live account",
+    pattern: /control\s+quer/i,
+  },
+  {
+    why: "the control goes through the SAME route that answered empty (in the report, the read route kept working while search was dead — testing the read route would have proved nothing)",
+    pattern: /same\s+route/i,
+  },
+  {
+    why: "the control carries NO search terms: a keyword is precisely what makes an honest zero possible",
+    pattern: /keyword-free/i,
+  },
+  {
+    why: "zero on the control means the source is DOWN, not empty",
+    pattern: /\bdown\b/i,
+  },
+  {
+    why: "a down source is an ALERT named in the reply and in the written artifact, never a silent omission",
+    pattern: /never[\s\S]{0,40}silent|silently|alert/i,
+  },
+  {
+    why: "a down source DISABLES the negative claims that depended on it",
+    pattern: /negative\s+claim/i,
+  },
+  {
+    why: "the verdict is re-established every pass, never inherited from a note",
+    pattern: /never\s+(cached|inherited)|each\s+pass|every\s+pass/i,
+  },
+  {
+    why: "the fan-out is paced — the report's trigger was a wide parallel pass with no throttle",
+    pattern: /back off|back-off|throttl|pace/i,
+  },
+];
+
+const RULES_FR = [
+  { why: "le discriminant est une requête de CONTRÔLE", pattern: /requête\s+de\s+contrôle/i },
+  { why: "le contrôle passe par la MÊME route que celle qui a répondu vide", pattern: /même\s+route/i },
+  { why: "le contrôle ne porte AUCUN mot-clé", pattern: /sans\s+mot-clé|aucun\s+mot-clé/i },
+  { why: "zéro au contrôle veut dire que la source est EN PANNE, pas vide", pattern: /en\s+panne/i },
+  { why: "une source en panne est une alerte annoncée, jamais une omission silencieuse", pattern: /alerte|silencieuse/i },
+  { why: "une source en panne interdit les affirmations négatives qui en dépendaient", pattern: /affirmations?\s+négatives?/i },
+  { why: "le verdict est rétabli à chaque passe, jamais hérité d'une note", pattern: /chaque\s+passe|jamais\s+hérité/i },
+  { why: "le fan-out est cadencé", pattern: /cadenc|throttl|ralent/i },
+];
+
+for (const { name, locale, path } of SKILLS) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  const rules = locale === "FR" ? RULES_FR : RULES_EN;
+  test(`${locale} ${name} has a source-liveness section at all`, () => {
+    assert.match(read(path), heading, `${path} must carry the discipline under its own heading`);
+  });
+  for (const { why, pattern } of rules) {
+    test(`${locale} ${name} carries the source-liveness discipline: ${why}`, () => {
+      assert.match(docSection(read(path), heading), pattern, `${path} lost the rule — ${why}`);
+    });
+  }
+}
+
+for (const { locale, layers } of CONSTITUTIONS) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  const rules = locale === "FR" ? RULES_FR : RULES_EN;
+  test(`${locale} constitution has a source-liveness section at all`, () => {
+    assert.match(layers.map(read).join("\n"), heading, "the discipline must have its own heading");
+  });
+  for (const { why, pattern } of rules) {
+    test(`${locale} constitution carries the source-liveness discipline: ${why}`, () => {
+      assert.match(docSection(layers.map(read).join("\n"), heading), pattern, `the ${locale} constitution lost the rule — ${why}`);
+    });
+  }
+}
+
+// ── The per-connector table: the design call, pinned so it cannot quietly go ──
+// ── back to being a vague instruction to "check the source is alive".        ──
+//
+// A rule that says "run a control query" and names no control is a rule every
+// session re-invents, differently. The table is the answer to "what IS the
+// control for THIS connector", and every source the installer can wire must have
+// a row — otherwise the one with no row is exactly the one that goes unchecked.
+const SHIPPED_SEARCH_SOURCES_EN = ["Mail", "Chat", "Calendar", "Drive", "Notion"];
+const SHIPPED_SEARCH_SOURCES_FR = ["Mail", "Chat", "Agenda", "Drive", "Notion"];
+
+for (const { name, locale, path } of SKILLS) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  const sources = locale === "FR" ? SHIPPED_SEARCH_SOURCES_FR : SHIPPED_SEARCH_SOURCES_EN;
+  test(`${locale} ${name} names a control for EVERY source the installer can wire`, () => {
+    const section = docSection(read(path), heading);
+    const missing = sources.filter((source) => !new RegExp(`\\|\\s*\\*{0,2}${source}`, "i").test(section));
+    assert.deepEqual(missing, [], `no control query named for: ${missing.join(", ")} — that source is the one that goes unchecked`);
+  });
+}
+
+// The escape hatch has to be written down, or the table becomes a reason to skip
+// the check on anything it does not cover.
+for (const { name, locale, path } of SKILLS) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  const pattern = locale === "FR" ? /plus faible|moins fiable/i : /weaker/i;
+  test(`${locale} ${name} says what to do when a connector has NO keyword-free form`, () => {
+    assert.match(
+      docSection(read(path), heading),
+      pattern,
+      "a connector with no keyword-free search must get the broadest control expressible, declared as weaker — never skipped in silence",
+    );
+  });
+}
+
+// The claim-discipline section already grades WHAT was retrieved; nothing graded
+// WHETHER retrieval happened. The two must point at each other, or a reader meets
+// one and never learns the other exists.
+for (const { name, locale, path } of SKILLS) {
+  const heading = locale === "FR" ? HEADING_FR : HEADING_EN;
+  const pattern = locale === "FR" ? /Discipline d'affirmation/ : /Claim discipline/;
+  test(`${locale} ${name} ties source liveness back to the claim discipline`, () => {
+    assert.match(docSection(read(path), heading), pattern, "the two disciplines must reference each other");
+  });
+}
+
+// ── The rule has to live where the work happens, not only where it is explained ──
+//
+// A discipline stated in its own section is met by whoever reads that section. The
+// fan-out step is a procedure someone follows with the section three screens above,
+// already read and already forgotten — and the fan-out is precisely where the control
+// query has to fire and where the pacing has to be applied. Same carrier argument as
+// the claim discipline being asserted on the skills and not only on the constitutions.
+const FANOUT_HEADING_EN = /^#+ Step 2 — Sub-agent fan-out/m;
+const FANOUT_HEADING_FR = /^#+ Étape 2 — Fan-out des sous-agents/m;
+
+for (const { name, locale, path } of SKILLS) {
+  const heading = locale === "FR" ? FANOUT_HEADING_FR : FANOUT_HEADING_EN;
+  const control = locale === "FR" ? /requête\s+de\s+contrôle/i : /control\s+quer/i;
+  const pacing = locale === "FR" ? /cadenc|ralent/i : /back off|back-off|pace/i;
+  test(`${locale} ${name} — the fan-out step itself says to run the control first`, () => {
+    assert.match(docSection(read(path), heading), control, "the step that fires the searches must name the control");
+  });
+  test(`${locale} ${name} — the fan-out step itself says to pace and back off`, () => {
+    assert.match(docSection(read(path), heading), pacing, "the pacing rule belongs at the wide parallel pass it is about");
+  });
+}

--- a/scripts/lib/unwrap-markdown.mjs
+++ b/scripts/lib/unwrap-markdown.mjs
@@ -1,0 +1,130 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// unwrap-markdown.mjs — PURE rewriting of hard-wrapped Markdown. No I/O.
+//
+// One paragraph = one line, however long. This undoes a line break that the
+// CONTENT never asked for, and only that one: a break that carries meaning —
+// a blank line, a new list item, a table row, a heading, a fenced block, a YAML
+// key, an explicit hard break — is left exactly where it is.
+//
+// The risk is entirely on that second half. A rewriter that joins too eagerly is
+// worse than no rewriter at all: it turns a table into a sentence and a note's
+// frontmatter into one unparseable key, silently, in a file the owner trusts. So
+// every predicate below is a REFUSAL to join, and the default is to leave the
+// line where it was found.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// A line that opens a block of its own — it may never be swallowed by the line
+// above it, and (except a list item, which owns its continuation) may not swallow
+// the line below either.
+const HEADING = /^#{1,6}\s/;
+const HORIZONTAL_RULE = /^(-{3,}|\*{3,}|_{3,})$/;
+const FENCE = /^\s*(```|~~~)/;
+const TABLE_ROW = /^\s*\|/;
+const HTML_BLOCK = /^\s*</;
+const LIST_ITEM_START = /^([-*+]|\d+[.)])\s/;
+
+// Markdown's two spellings of a break the author MEANT: two trailing spaces, or a
+// trailing backslash. Joining through one of those destroys an intention rather
+// than an accident, which is the one thing this tool must never do.
+const EXPLICIT_HARD_BREAK = /(\s{2}|\\)$/;
+
+const FRONTMATTER_DELIMITER = "---";
+
+// Peel the blockquote prefixes off a line, returning how deep it was quoted and
+// what it actually says. Two lines only ever join at the SAME depth: `>` and `>>`
+// are different blocks, and merging them would re-attribute a quote.
+function peelQuote(line) {
+  let depth = 0;
+  let content = line;
+  while (/^\s*>/.test(content)) {
+    depth++;
+    content = content.replace(/^\s*>\s?/, "");
+  }
+  return { depth, content };
+}
+
+// Does this line open a block of its own? Used in both directions — a line that
+// opens a block is never absorbed, and never absorbs.
+function opensItsOwnBlock(content) {
+  const trimmed = content.trim();
+  return trimmed === "" || HEADING.test(trimmed) || HORIZONTAL_RULE.test(trimmed) || TABLE_ROW.test(content) || HTML_BLOCK.test(content);
+}
+
+// May this line be pulled up into the one above it? Everything `opensItsOwnBlock`
+// refuses, plus a new list item: `- a` following `- b` is a sibling, not a
+// continuation, so the list would collapse into a single bullet.
+function isContinuation(content) {
+  return !opensItsOwnBlock(content) && !LIST_ITEM_START.test(content.trim());
+}
+
+// A document read on Windows arrives CRLF (CONVENTIONS §9). Splitting on "\n"
+// alone leaves the "\r" glued to each line, so a join buries a carriage return
+// INSIDE the paragraph — invisible on the machine we develop on, corrupt
+// everywhere else. Detect the ending once, split on either, re-emit the one found.
+function lineEndingOf(text) {
+  return text.includes("\r\n") ? "\r\n" : "\n";
+}
+
+export function unwrapMarkdown(text) {
+  const eol = lineEndingOf(text);
+  const lines = text.split(/\r?\n/);
+  const out = [];
+  let inFence = false;
+  let inFrontmatter = false;
+  // Where the last line that can still absorb another was emitted, and at which
+  // quote depth. `null` means the next line starts fresh whatever it says.
+  let openLine = null;
+
+  const emitVerbatim = (line) => {
+    out.push(line);
+    openLine = null;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Frontmatter is the note's metadata: every break in it is structural, and
+    // joining two keys makes the whole block unparseable. Only a `---` on the
+    // very first line opens it — anywhere else `---` is a horizontal rule.
+    if (i === 0 && line.trim() === FRONTMATTER_DELIMITER) {
+      inFrontmatter = true;
+      emitVerbatim(line);
+      continue;
+    }
+    if (inFrontmatter) {
+      if (line.trim() === FRONTMATTER_DELIMITER) inFrontmatter = false;
+      emitVerbatim(line);
+      continue;
+    }
+
+    // Inside a fenced block the line breaks ARE the content.
+    if (FENCE.test(line)) {
+      inFence = !inFence;
+      emitVerbatim(line);
+      continue;
+    }
+    if (inFence) {
+      emitVerbatim(line);
+      continue;
+    }
+
+    const { depth, content } = peelQuote(line);
+
+    if (openLine !== null && openLine.depth === depth && isContinuation(content)) {
+      const previous = out[openLine.index];
+      if (!EXPLICIT_HARD_BREAK.test(previous)) {
+        // Trim both sides of the seam so the join is exactly one space, whatever
+        // indentation the wrap left behind.
+        out[openLine.index] = previous.replace(/\s+$/, "") + " " + content.trim();
+        continue;
+      }
+    }
+
+    out.push(line);
+    // A list item DOES absorb what follows it (its own continuation lines), which
+    // is why this is `opensItsOwnBlock` and not `isContinuation`.
+    openLine = opensItsOwnBlock(content) ? null : { index: out.length - 1, depth };
+  }
+
+  return out.join(eol);
+}

--- a/scripts/lib/unwrap-markdown.mjs
+++ b/scripts/lib/unwrap-markdown.mjs
@@ -30,17 +30,24 @@ const EXPLICIT_HARD_BREAK = /(\s{2}|\\)$/;
 
 const FRONTMATTER_DELIMITER = "---";
 
-// Peel the blockquote prefixes off a line, returning how deep it was quoted and
-// what it actually says. Two lines only ever join at the SAME depth: `>` and `>>`
-// are different blocks, and merging them would re-attribute a quote.
+// Peel the blockquote prefixes off a line, returning the quote prefix it carried
+// and what it actually says. Two lines only ever join under the SAME prefix: `>`
+// and `>>` are different blocks, and merging them would re-attribute a quote.
+//
+// The prefix is rebuilt as a normalised string rather than counted, so that the
+// thing compared IS the quote context ("> " and ">   " are the same block) instead
+// of a number that happens to stand for it.
 function peelQuote(line) {
-  let depth = 0;
+  let quote = "";
   let content = line;
   while (/^\s*>/.test(content)) {
-    depth++;
+    quote += ">";
+    // No `^` needed twice over — the loop condition above has already established
+    // that the line starts with the prefix, so the leftmost match IS that one.
+    // Kept anchored anyway: a reader should not have to re-derive that.
     content = content.replace(/^\s*>\s?/, "");
   }
-  return { depth, content };
+  return { quote, content };
 }
 
 // Does this line open a block of its own? Used in both directions — a line that
@@ -71,8 +78,8 @@ export function unwrapMarkdown(text) {
   const out = [];
   let inFence = false;
   let inFrontmatter = false;
-  // Where the last line that can still absorb another was emitted, and at which
-  // quote depth. `null` means the next line starts fresh whatever it says.
+  // Where the last line that can still absorb another was emitted, and under which
+  // quote prefix. `null` means the next line starts fresh whatever it says.
   let openLine = null;
 
   const emitVerbatim = (line) => {
@@ -108,14 +115,15 @@ export function unwrapMarkdown(text) {
       continue;
     }
 
-    const { depth, content } = peelQuote(line);
+    const { quote, content } = peelQuote(line);
 
-    if (openLine !== null && openLine.depth === depth && isContinuation(content)) {
+    if (openLine !== null && openLine.quote === quote && isContinuation(content)) {
       const previous = out[openLine.index];
       if (!EXPLICIT_HARD_BREAK.test(previous)) {
         // Trim both sides of the seam so the join is exactly one space, whatever
-        // indentation the wrap left behind.
-        out[openLine.index] = previous.replace(/\s+$/, "") + " " + content.trim();
+        // indentation the wrap left behind. At most ONE trailing whitespace can
+        // reach here: two of them are already a hard break, refuted just above.
+        out[openLine.index] = previous.trimEnd() + " " + content.trim();
         continue;
       }
     }
@@ -123,7 +131,7 @@ export function unwrapMarkdown(text) {
     out.push(line);
     // A list item DOES absorb what follows it (its own continuation lines), which
     // is why this is `opensItsOwnBlock` and not `isContinuation`.
-    openLine = opensItsOwnBlock(content) ? null : { index: out.length - 1, depth };
+    openLine = opensItsOwnBlock(content) ? null : { index: out.length - 1, quote };
   }
 
   return out.join(eol);

--- a/scripts/lib/unwrap-markdown.test.mjs
+++ b/scripts/lib/unwrap-markdown.test.mjs
@@ -158,3 +158,93 @@ test("an empty document and a single blank line survive untouched", () => {
   assert.equal(unwrapMarkdown(""), "");
   assert.equal(unwrapMarkdown("\n"), "\n");
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE BOUNDARIES, added after the first mutation run (81.45 %, 23 survivors).
+//
+// These add no production code and were not expected to go red: they pin the
+// EDGES of each refusal, which is precisely what a happy-path batch leaves
+// unmeasured. Every one of them corresponds to a mutant that lived — an anchor
+// dropped, a quantifier loosened, a `.trim()` removed — and each of those is a
+// real defect on a real document, not a theoretical one. A checker that protects
+// an indented table but not a table, or that treats a paragraph mentioning a pipe
+// as a table row, corrupts a file just as thoroughly as no checker at all.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("a horizontal rule needs THREE of its character, not one: a lone -, * or _ is prose", () => {
+  for (const char of ["-", "*", "_"]) {
+    assert.equal(unwrapMarkdown(`a\n${char}\nb`), `a ${char} b`, `a lone ${char} is not a rule`);
+  }
+});
+
+test("a rule is the WHOLE line: dashes followed by text are prose, and text followed by stars too", () => {
+  assert.equal(unwrapMarkdown("prose\n--- not a rule\nstill prose"), "prose --- not a rule still prose");
+  assert.equal(unwrapMarkdown("bold ***\nnext line"), "bold *** next line");
+});
+
+test("a fence opens only at the START of a line — a paragraph that merely mentions ``` is still a paragraph", () => {
+  assert.equal(unwrapMarkdown("use ``` to open a block\nand it keeps going"), "use ``` to open a block and it keeps going");
+});
+
+test("an INDENTED fence still protects its body — indentation is how a fence nests inside a list", () => {
+  const doc = ["prose", "", "  ```", "  code one", "  code two", "  ```"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("an INDENTED table row is still a table row", () => {
+  const doc = ["  | a | b |", "  |---|---|", "  | 1 | 2 |"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("a pipe in the MIDDLE of a sentence does not make that sentence a table row", () => {
+  assert.equal(unwrapMarkdown("a || b appears in prose\nand the sentence goes on"), "a || b appears in prose and the sentence goes on");
+});
+
+test("an INDENTED html block is still an html block", () => {
+  const doc = ["prose", "", "  <div>", "  inner", "  </div>"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("a `<` in the middle of a sentence does not make that sentence html", () => {
+  assert.equal(unwrapMarkdown("a < b holds here\nand the sentence goes on"), "a < b holds here and the sentence goes on");
+});
+
+test("a TWO-DIGIT ordered item starts its own item — a list does not collapse at ten", () => {
+  const doc = ["10. ten", "11. eleven"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("a dash inside a sentence is not a list marker: only the start of the line can be one", () => {
+  assert.equal(unwrapMarkdown("a paragraph\nwith - a dash inside it"), "a paragraph with - a dash inside it");
+});
+
+test("an INDENTED list item is a NESTED item, not a continuation of its parent", () => {
+  const doc = ["- parent item", "  - nested item"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("an INDENTED heading is still a heading, and does not get pulled into the paragraph above", () => {
+  const doc = ["prose", "  ## A heading"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("a hard break is TRAILING: two spaces in the middle of a line are just two spaces", () => {
+  assert.equal(unwrapMarkdown("a  b\nc"), "a  b c");
+});
+
+test("a hard break is TWO trailing spaces: one is not enough, and the seam stays a single space", () => {
+  // This is also the only reachable input for the trailing-whitespace strip: anything
+  // with two trailing whitespace characters is already a hard break and never joins.
+  assert.equal(unwrapMarkdown("first \nsecond"), "first second");
+});
+
+test("frontmatter delimiters tolerate trailing whitespace — opening and closing alike", () => {
+  const opening = ["--- ", "type: topic", "created: 2026-09-11", "---", "body"].join("\n");
+  assert.equal(unwrapMarkdown(opening), opening, "a trailing space on the OPENING --- must not turn the keys into prose");
+  const closing = ["---", "type: topic", "created: 2026-09-11", "--- ", "body cut", "here"].join("\n");
+  assert.equal(
+    unwrapMarkdown(closing),
+    ["---", "type: topic", "created: 2026-09-11", "--- ", "body cut here"].join("\n"),
+    "a trailing space on the CLOSING --- must not leave the whole document inside frontmatter",
+  );
+});

--- a/scripts/lib/unwrap-markdown.test.mjs
+++ b/scripts/lib/unwrap-markdown.test.mjs
@@ -1,0 +1,160 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { unwrapMarkdown } from "./unwrap-markdown.mjs";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// unwrap-markdown — the deterministic net behind the engine constitution's
+// "never insert a line break the content does not require" rule (#95).
+//
+// The whole difficulty is the SECOND half: a rewriter that joins everything is
+// worse than none at all, because it silently destroys the breaks that DO carry
+// meaning (a table row, a list item, a fenced block, a YAML key). So most of the
+// batch below asserts what must be left ALONE, and each such case names the
+// thing that would be corrupted if the join fired there.
+//
+// Assertions are on the WHOLE document rather than on a substring: a joiner that
+// gets one line right and drops another would satisfy a `includes()` check.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("two hard-wrapped prose lines become one, with a single space at the seam", () => {
+  const wrapped = ["A paragraph that was cut by an editor at some column,", "and whose rest landed here."].join("\n");
+  assert.equal(unwrapMarkdown(wrapped), "A paragraph that was cut by an editor at some column, and whose rest landed here.");
+});
+
+test("a run of FOUR wrapped lines collapses to one, not just the first pair", () => {
+  const wrapped = ["one", "two", "three", "four"].join("\n");
+  assert.equal(unwrapMarkdown(wrapped), "one two three four");
+});
+
+test("the seam is exactly one space, whatever indentation the continuation carried", () => {
+  assert.equal(unwrapMarkdown("first    \nsecond"), "first    \nsecond", "two trailing spaces are a hard break — untouched");
+  assert.equal(unwrapMarkdown("first\n      second"), "first second");
+});
+
+test("a blank line separates two paragraphs, and both survive as their own line", () => {
+  const doc = ["para one cut", "here.", "", "para two cut", "here too."].join("\n");
+  assert.equal(unwrapMarkdown(doc), ["para one cut here.", "", "para two cut here too."].join("\n"));
+});
+
+test("several blank lines in a row are preserved exactly as spelled", () => {
+  assert.equal(unwrapMarkdown("a\n\n\n\nb"), "a\n\n\n\nb");
+});
+
+test("a heading neither absorbs the line after it nor is absorbed by the line before", () => {
+  const doc = ["trailing prose", "## A heading", "prose under it", "wrapped on."].join("\n");
+  assert.equal(unwrapMarkdown(doc), ["trailing prose", "## A heading", "prose under it wrapped on."].join("\n"));
+});
+
+test("every heading level from # to ###### is protected, and a seventh # is prose", () => {
+  for (const hashes of ["#", "##", "###", "####", "#####", "######"]) {
+    assert.equal(unwrapMarkdown(`${hashes} Title\nbody`), `${hashes} Title\nbody`, `${hashes} must not absorb the next line`);
+  }
+  assert.equal(unwrapMarkdown("####### seven hashes\nbody"), "####### seven hashes body", "seven hashes is not a heading, it is prose");
+});
+
+test("a fenced code block is preserved verbatim — its line breaks ARE its content", () => {
+  const doc = ["intro", "```js", "const a = 1;", "const b = 2;", "", "return a + b;", "```", "outro cut", "here."].join("\n");
+  assert.equal(
+    unwrapMarkdown(doc),
+    ["intro", "```js", "const a = 1;", "const b = 2;", "", "return a + b;", "```", "outro cut here."].join("\n"),
+  );
+});
+
+test("a tilde fence protects its body just as a backtick fence does", () => {
+  const doc = ["~~~", "line one", "line two", "~~~"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("YAML frontmatter is preserved verbatim — joining two keys would destroy the note's metadata", () => {
+  const doc = ["---", "type: topic", "created: 2026-09-11", "tags: [a, b]", "---", "body cut", "here."].join("\n");
+  assert.equal(unwrapMarkdown(doc), ["---", "type: topic", "created: 2026-09-11", "tags: [a, b]", "---", "body cut here."].join("\n"));
+});
+
+test("a `---` that is NOT on the first line is a horizontal rule, and stays on its own line", () => {
+  const doc = ["prose", "", "---", "", "more prose"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("a horizontal rule written with asterisks or underscores is protected too", () => {
+  for (const rule of ["***", "___", "-----"]) {
+    assert.equal(unwrapMarkdown(`a\n\n${rule}\n\nb`), `a\n\n${rule}\n\nb`, `${rule} is a rule, not prose`);
+  }
+});
+
+test("a table keeps one row per line — a joined table stops being a table at all", () => {
+  const doc = ["| Slot | Who |", "|---|---|", "| 09:00 | JDO |", "| 10:00 | ABC |"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("prose immediately after a table's last row is not sucked into that row", () => {
+  const doc = ["| a | b |", "|---|---|", "| 1 | 2 |", "prose cut", "here."].join("\n");
+  assert.equal(unwrapMarkdown(doc), ["| a | b |", "|---|---|", "| 1 | 2 |", "prose cut here."].join("\n"));
+});
+
+test("a list item absorbs its own continuation but never the next item", () => {
+  const doc = ["- first item cut", "  in the middle", "- second item cut", "  in the middle too"].join("\n");
+  assert.equal(unwrapMarkdown(doc), ["- first item cut in the middle", "- second item cut in the middle too"].join("\n"));
+});
+
+test("every bullet marker and both ordered forms start their own item", () => {
+  for (const marker of ["-", "*", "+", "1.", "2)"]) {
+    const doc = [`${marker} one`, `${marker} two`].join("\n");
+    assert.equal(unwrapMarkdown(doc), doc, `${marker} must start a new item, not continue the previous one`);
+  }
+});
+
+test("a blockquote joins its own continuation, and the `>` prefix is not duplicated at the seam", () => {
+  const doc = ["> a quoted line cut", "> and continued here"].join("\n");
+  assert.equal(unwrapMarkdown(doc), "> a quoted line cut and continued here");
+});
+
+test("two blockquote depths never merge — a nested quote is a different block", () => {
+  const doc = ["> outer line", ">> inner line", "> outer again"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("a quoted line and an unquoted one never merge in either direction", () => {
+  assert.equal(unwrapMarkdown("> quoted\nplain"), "> quoted\nplain");
+  assert.equal(unwrapMarkdown("plain\n> quoted"), "plain\n> quoted");
+});
+
+test("an explicit hard break is intentional and survives — both spellings", () => {
+  assert.equal(unwrapMarkdown("line one  \nline two"), "line one  \nline two", "two trailing spaces are Markdown's hard break");
+  assert.equal(unwrapMarkdown("line one\\\nline two"), "line one\\\nline two", "a trailing backslash is the other spelling");
+});
+
+test("an HTML line is left where it is", () => {
+  const doc = ["<div>", "prose inside", "</div>"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("a trailing newline is preserved, and an absent one is not invented", () => {
+  assert.equal(unwrapMarkdown("a cut\nline\n"), "a cut line\n");
+  assert.equal(unwrapMarkdown("a cut\nline"), "a cut line");
+});
+
+test("a CRLF document is rewritten with CRLF, not with a stray CR left mid-line", () => {
+  // Windows reality (CONVENTIONS §9): a note read on Windows arrives CRLF. Splitting on
+  // "\n" alone leaves the "\r" glued to the end of each line, so the join buries a carriage
+  // return INSIDE the paragraph — invisible on macOS, corrupt everywhere.
+  assert.equal(unwrapMarkdown("a cut\r\nline\r\n\r\nnext"), "a cut line\r\n\r\nnext");
+  assert.ok(!unwrapMarkdown("a cut\r\nline").includes("\r "), "no carriage return may survive inside a joined line");
+});
+
+test("running it twice changes nothing the first pass did not already change", () => {
+  const doc = ["---", "type: topic", "---", "", "# Title", "", "a cut", "paragraph", "", "- an item cut", "  in two", "", "| a |", "|---|", "| 1 |"].join("\n");
+  const once = unwrapMarkdown(doc);
+  assert.equal(unwrapMarkdown(once), once, "the rewriter must be idempotent, or it fights the file every run");
+  assert.equal(once, ["---", "type: topic", "---", "", "# Title", "", "a cut paragraph", "", "- an item cut in two", "", "| a |", "|---|", "| 1 |"].join("\n"));
+});
+
+test("an already-unwrapped document comes back byte-identical", () => {
+  const doc = ["# Title", "", "One long single-line paragraph that nobody ever cut.", "", "- one item", "- another item"].join("\n");
+  assert.equal(unwrapMarkdown(doc), doc);
+});
+
+test("an empty document and a single blank line survive untouched", () => {
+  assert.equal(unwrapMarkdown(""), "");
+  assert.equal(unwrapMarkdown("\n"), "\n");
+});

--- a/scripts/lib/wiki-lint-io.mjs
+++ b/scripts/lib/wiki-lint-io.mjs
@@ -25,3 +25,17 @@ export function readVaultNotes(vaultDir) {
     .filter((rel) => rel.endsWith(".md"))
     .map((rel) => ({ path: rel, ...parseNote(readFileSync(join(vaultDir, rel), "utf8")) }));
 }
+
+// Every NON-note file under `vaultDir` — the screenshot pasted into a meeting note,
+// the PDF dropped beside a decision — path relative to the vault and POSIX-separated,
+// exactly like readVaultNotes. Paths only: nothing here is read or parsed, because the
+// only question asked of an attachment is "does it exist under this spelling?" (#71).
+//
+// It is deliberately the complement of readVaultNotes rather than a list of known
+// image extensions: an allow-list would have to guess at `.excalidraw`, `.canvas`,
+// `.webp` and whatever Obsidian supports next, and every miss is a permanent false
+// "dangling link" nobody can clear. The pair partitions the vault, which the sibling
+// test pins.
+export function readVaultAttachments(vaultDir) {
+  return listFilesRelPosix(vaultDir).filter((rel) => !rel.endsWith(".md"));
+}

--- a/scripts/lib/wiki-lint-io.test.mjs
+++ b/scripts/lib/wiki-lint-io.test.mjs
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { parseNote, readVaultNotes } from "./wiki-lint-io.mjs";
+import { parseNote, readVaultNotes, readVaultAttachments } from "./wiki-lint-io.mjs";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // wiki-lint-io — the fs adapter (ADR 0009 rung 2) that reads a real vault into
@@ -49,4 +49,36 @@ test("readVaultNotes — parses every .md note with a relative POSIX path, skips
     { path: "notes/b.md", frontmatter: {}, body: "no frontmatter here" },
     { path: "people/alice.md", frontmatter: { type: "person" }, body: "hi [[bob]]" },
   ]);
+});
+
+// ── #71 — the vault's non-note files, so an embed has something to resolve to ──
+
+test("readVaultAttachments — returns every NON-md file, relative + POSIX, and no note", (t) => {
+  const dir = vaultFixture({
+    "people/alice.md": "---\ntype: person\n---\nhi",
+    "people/screenshot.png": "binary",
+    "assets/diagram.excalidraw": "{}",
+    "top.pdf": "%PDF",
+  });
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  assert.deepEqual(readVaultAttachments(dir).sort(), [
+    "assets/diagram.excalidraw",
+    "people/screenshot.png",
+    "top.pdf",
+  ]);
+});
+
+test("readVaultAttachments — a vault of notes only yields an empty list, never a throw", (t) => {
+  const dir = vaultFixture({ "a.md": "x", "b/c.md": "y" });
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  assert.deepEqual(readVaultAttachments(dir), []);
+});
+
+test("readVaultNotes and readVaultAttachments partition the vault — every file lands in exactly one", (t) => {
+  const dir = vaultFixture({ "a.md": "x", "img.png": "y", "sub/b.md": "z", "sub/doc.pdf": "w" });
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const notes = readVaultNotes(dir).map((n) => n.path);
+  const attachments = readVaultAttachments(dir);
+  assert.deepEqual([...notes, ...attachments].sort(), ["a.md", "img.png", "sub/b.md", "sub/doc.pdf"]);
+  assert.deepEqual(notes.filter((p) => attachments.includes(p)), [], "nothing may be both");
 });

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -23,10 +23,23 @@ function stripCode(body) {
 // linkify code, so a `[[link]]` example there is syntax documentation, not a link.
 // A pure same-note anchor (`[[#heading]]`) has no target file — Obsidian resolves
 // it within the current note, so it is dropped rather than reported as dangling.
+//
+// 🛑 The backslash escape is undone BEFORE splitting (#73). Inside a Markdown table
+// cell a bare `|` closes the cell, so `[[note\|alias]]` is not a style choice: it is
+// the ONLY spelling that keeps the table valid. Splitting the raw capture on `[|#]`
+// yielded `note\`, a filename no note can have, so the checker flagged precisely the
+// spelling the author had no alternative to — and the miss cascaded, costing a false
+// orphan on the target and silently dropping a real staleness reference.
 export function extractWikiLinks(body) {
   return [...stripCode(body).matchAll(/\[\[([^\]]+)\]\]/g)]
-    .map((m) => m[1].split(/[|#]/)[0].trim())
+    .map((m) => unescapeDelimiters(m[1]).split(/[|#]/)[0].trim())
     .filter((target) => target !== "");
+}
+
+// Turn `\|` back into `|` (and `\#` into `#`) so the split below sees the delimiters
+// the author meant, not the ones Markdown made them escape.
+function unescapeDelimiters(target) {
+  return target.replace(/\\([|#])/g, "$1");
 }
 
 // Every trailing path suffix of a note path, longest first: `a/b/c.md` →
@@ -44,7 +57,13 @@ function pathSuffixes(path) {
 // `[[folder/note.md]]`) by path, and a universe-relative `[[people/note]]` by
 // path suffix. Every suffix (with and without `.md`) is registered; a shorter
 // suffix keeps the first note that claims it, so the longer form disambiguates.
-export function buildResolver(notes) {
+//
+// `attachments` are the vault's NON-note files — the screenshot pasted straight into
+// a meeting note, which Obsidian keeps next to it and embeds as `![[shot.png]]`
+// (#71). They were never candidates here, so the check treated "not a note" and
+// "does not exist" as the same thing, and every picture in every note read as a dead
+// link that no edit to the note could ever clear.
+export function buildResolver(notes, attachments = []) {
   const byKey = new Map();
   const register = (key, path) => {
     if (!byKey.has(key)) byKey.set(key, path);
@@ -54,6 +73,13 @@ export function buildResolver(notes) {
       register(suffix, note.path); //           folder/note.md, note.md
       register(suffix.replace(/\.md$/, ""), note.path); // folder/note, note
     }
+  }
+  // Notes are registered FIRST so they win any name collision, and an attachment is
+  // registered under its full spelling ONLY — extension included. Obsidian requires
+  // the extension for a non-note target, so registering a bare `shot` would let a
+  // picture silently answer for a missing note called `shot`.
+  for (const attachment of attachments) {
+    for (const suffix of pathSuffixes(attachment)) register(suffix, attachment);
   }
   // Resolve a raw link target to a canonical note path, or null if it points nowhere.
   // ONE lookup on purpose: both spellings of every suffix are registered above, so a
@@ -97,7 +123,15 @@ export function isUnderZone(path, prefix) {
 // page still do (plan #84 step 4bis). Two hand-written copies of one rule is the drift
 // CONVENTIONS §5quater warns about, so `notes-union-merge.test.mjs` asserts they agree.
 export const RAW_CAPTURE_ZONES = ["daily/", "raw-sources/", "inbox/", "_inbox/", "actions-log.md"];
-const ENGINE_WORK_ZONES = ["meetings/", "briefings/", "prep-1-1/", "coaching/"];
+// `backlog/` joins them for exactly the argument made for `actions-log.md` ten lines
+// up, and the engine is the one making it: the shipped constitution declares the
+// folder, the passive-observation ritual appends to `vault/backlog/harness.md`, and
+// the example-notes purge is TESTED to preserve that file. An action register is not
+// a wiki node — nothing links to it by design — so flagging it was a complaint its
+// reader could only clear by writing a lie into the wiki (#74). Keyed on the FOLDER,
+// which covers every locale at once: the overlay localises the file name, never the
+// folder, and `isUnderZone` handles `<universe>/backlog/` for free.
+const ENGINE_WORK_ZONES = ["meetings/", "briefings/", "prep-1-1/", "coaching/", "backlog/"];
 // A universe's profile page (`universe.md` at the root, `<universe>/universe.md`
 // in a subtree — isUnderZone matches both) describes a whole sphere: nothing links
 // TO it by design, so flagging it orphan would be a lie nobody can ever clear. It
@@ -152,6 +186,10 @@ function daysBetween(laterIso, earlierIso) {
 //   staleDays    — how many days behind its freshest reference makes an entity stale.
 //   frontmatterExempt — path prefixes (raw-capture zones) exempt from the required-
 //                       frontmatter rule (a raw dump is not a curated node).
+//   attachments  — the vault's non-note files (paths only), so an `![[shot.png]]`
+//                  embed resolves instead of reading as rot. They are resolution
+//                  targets and nothing else: an attachment is never an orphan and
+//                  never frontmatter rot, because it is not a note.
 export function lintVault(notes, options = {}) {
   const orphanExclude = options.orphanExclude ?? DEFAULT_ORPHAN_EXCLUDE;
   const entityTypes = options.entityTypes ?? DEFAULT_ENTITY_TYPES;
@@ -161,7 +199,7 @@ export function lintVault(notes, options = {}) {
   const engineOwnedTypes = options.engineOwnedTypes ?? DEFAULT_ENGINE_OWNED_TYPES;
   const isEngineOwned = (note) => engineOwnedTypes.includes(note.frontmatter.type);
 
-  const resolve = buildResolver(notes);
+  const resolve = buildResolver(notes, options.attachments ?? []);
   const danglingLinks = [];
   const danglingSeen = new Set(); // "from\0target" already recorded — report each once
   const inbound = new Set(); // canonical paths that receive at least one link

--- a/scripts/lib/wiki-lint.mjs
+++ b/scripts/lib/wiki-lint.mjs
@@ -63,6 +63,11 @@ function pathSuffixes(path) {
 // (#71). They were never candidates here, so the check treated "not a note" and
 // "does not exist" as the same thing, and every picture in every note read as a dead
 // link that no edit to the note could ever clear.
+// The `= []` default is deliberately UNREACHABLE from production — both callers
+// (the lint and the consolidation scan) pass a list — and is kept as the sane public
+// contract for an exported function. Named here because a mutation of it survives by
+// construction: only a link literally spelled like the injected value could observe
+// it, so the survivor is recorded rather than chased (CONVENTIONS §5ter).
 export function buildResolver(notes, attachments = []) {
   const byKey = new Map();
   const register = (key, path) => {

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -512,3 +512,142 @@ test("lintVault — a note carrying its source keys is conformant, not in violat
 
   assert.deepEqual(lintVault(notes).frontmatterViolations, []);
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// v5.1 — three ways this checker called a healthy thing broken. All three were
+// reported from real vaults, and all three share one failure mode: the scan could
+// not tell "this does not exist" from "I have no way to look at this". A checker
+// nobody believes is a checker nobody reads, so the fix is judged by what the
+// count says on a real vault, not by the three repros below.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── #73 — the escaped alias pipe inside a table cell ────────────────────────
+
+test("extractWikiLinks — unescapes the alias pipe a table cell FORCES (`[[note\\|alias]]`)", () => {
+  // A bare `|` closes the cell, so the escape is the only spelling that works. The
+  // capture group keeps the backslash, and splitting on `|` then yields a target
+  // ending in `\` — a filename no note can have.
+  assert.deepEqual(extractWikiLinks("| 09:00 | [[people/jane-doe\\|JDO]] |"), ["people/jane-doe"]);
+});
+
+test("extractWikiLinks — several escaped links in one row all resolve, and an escaped anchor too", () => {
+  assert.deepEqual(
+    extractWikiLinks("| [[people/alice\\|AL]] | [[people/bob\\|BO]] | [[topics/rota\\#today\\|R]] |"),
+    ["people/alice", "people/bob", "topics/rota"],
+  );
+});
+
+test("extractWikiLinks — an unescaped pipe still works, so the fix adds a spelling rather than swapping one", () => {
+  assert.deepEqual(extractWikiLinks("[[people/jane-doe|JDO]]"), ["people/jane-doe"]);
+});
+
+test("lintVault — a link written the only way a table allows is not dangling, and its target is not an orphan", () => {
+  // The cascade is what makes this one expensive: resolution failing costs a false
+  // dangling link AND a false orphan AND the loss of a real staleness signal.
+  const notes = [
+    { path: "people/jane-doe.md", frontmatter: { type: "person" }, body: "" },
+    {
+      path: "topics/rota.md",
+      frontmatter: { type: "topic" },
+      body: "| Slot | Who |\n|---|---|\n| 09:00 | [[people/jane-doe\\|JDO]] |",
+    },
+  ];
+  const report = lintVault(notes);
+  assert.deepEqual(report.danglingLinks, []);
+  assert.deepEqual(report.orphans, ["topics/rota.md"], "only the note nobody links to is an orphan");
+});
+
+test("lintVault — the freshest-citation tracking counts an escaped link, so a stale page still gets caught", () => {
+  const notes = [
+    { path: "people/jane-doe.md", frontmatter: { type: "person", updated: "2026-01-01" }, body: "" },
+    {
+      path: "topics/rota.md",
+      frontmatter: { type: "topic", updated: "2026-06-01" },
+      body: "| Who |\n|---|\n| [[people/jane-doe\\|JDO]] |",
+    },
+  ];
+  assert.deepEqual(lintVault(notes).staleEntityPages, [
+    { path: "people/jane-doe.md", updated: "2026-01-01", freshestReference: "2026-06-01" },
+  ]);
+});
+
+test("lintVault — a genuinely broken escaped link is STILL reported, and without the stray backslash", () => {
+  const report = lintVault([
+    { path: "topics/rota.md", frontmatter: {}, body: "| [[people/nobody\\|NB]] |" },
+  ]);
+  assert.deepEqual(report.danglingLinks, [{ from: "topics/rota.md", target: "people/nobody" }]);
+});
+
+// ── #74 — the backlog the engine itself writes into ─────────────────────────
+
+test("lintVault — `backlog/` is never an orphan: the engine declares it, writes to it, and nothing links TO it", () => {
+  const report = lintVault([
+    { path: "backlog/harness.md", frontmatter: { type: "backlog" }, body: "" },
+    { path: "acme/backlog/perso.md", frontmatter: { type: "backlog" }, body: "" },
+    { path: "topics/real.md", frontmatter: { type: "topic" }, body: "" },
+  ]);
+  assert.deepEqual(report.orphans, ["topics/real.md"], "a curated page nobody links to is still rot");
+});
+
+test("lintVault — a backlog is still held to the frontmatter rule: exempt from orphan, not from taxonomy", () => {
+  const report = lintVault([{ path: "backlog/harness.md", frontmatter: { type: "backlog" }, body: "" }]);
+  assert.deepEqual(report.frontmatterViolations, [
+    { path: "backlog/harness.md", missing: ["created", "updated", "tags"] },
+  ]);
+});
+
+// ── #71 — an image embed whose target is not a note ─────────────────────────
+
+test("lintVault — an embedded attachment that EXISTS resolves, instead of being dangling forever", () => {
+  const notes = [{ path: "people/jane-doe.md", frontmatter: {}, body: "![[screenshot.png]]" }];
+  const report = lintVault(notes, { attachments: ["people/screenshot.png"] });
+  assert.deepEqual(report.danglingLinks, []);
+});
+
+test("lintVault — an attachment resolves by basename AND by path suffix, like a note does", () => {
+  const notes = [
+    { path: "a.md", frontmatter: {}, body: "![[shot.png]] and ![[assets/shot.png]] and ![[sub/assets/shot.png]]" },
+  ];
+  const report = lintVault(notes, { attachments: ["sub/assets/shot.png"] });
+  assert.deepEqual(report.danglingLinks, []);
+});
+
+test("lintVault — an attachment that is NOT in the vault is still reported, so the check keeps its teeth", () => {
+  const report = lintVault([{ path: "a.md", frontmatter: {}, body: "![[missing.png]]" }], {
+    attachments: ["other.png"],
+  });
+  assert.deepEqual(report.danglingLinks, [{ from: "a.md", target: "missing.png" }]);
+});
+
+test("lintVault — Obsidian's image-size syntax (`![[shot.png|300]]`) resolves to the file, not to `shot.png|300`", () => {
+  const report = lintVault([{ path: "a.md", frontmatter: {}, body: "![[shot.png|300]]" }], {
+    attachments: ["shot.png"],
+  });
+  assert.deepEqual(report.danglingLinks, []);
+});
+
+test("lintVault — an attachment is never an orphan and never frontmatter rot: it is not a note", () => {
+  const report = lintVault([{ path: "a.md", frontmatter: { type: "topic", created: "x", updated: "x", tags: ["t"] }, body: "" }], {
+    attachments: ["orphaned-forever.png"],
+  });
+  assert.deepEqual(report.orphans, ["a.md"], "the note is the only thing the orphan rule can see");
+  assert.deepEqual(report.frontmatterViolations, []);
+});
+
+test("lintVault — a NOTE wins a name collision with an attachment, so the `.md`-less spelling still finds the note", () => {
+  const notes = [
+    { path: "shot.md", frontmatter: {}, body: "" },
+    { path: "a.md", frontmatter: {}, body: "[[shot]] and ![[shot.png]]" },
+  ];
+  const report = lintVault(notes, { attachments: ["shot.png"] });
+  assert.deepEqual(report.danglingLinks, []);
+  assert.deepEqual(report.orphans, ["a.md"], "the note was reached through the bare spelling, so it is not an orphan");
+});
+
+test("lintVault — with no attachments passed at all, notes resolve exactly as before", () => {
+  const report = lintVault([
+    { path: "people/alice.md", frontmatter: {}, body: "" },
+    { path: "a.md", frontmatter: {}, body: "[[people/alice]] and ![[nope.png]]" },
+  ]);
+  assert.deepEqual(report.danglingLinks, [{ from: "a.md", target: "nope.png" }]);
+});

--- a/scripts/lib/wiki-lint.test.mjs
+++ b/scripts/lib/wiki-lint.test.mjs
@@ -651,3 +651,16 @@ test("lintVault — with no attachments passed at all, notes resolve exactly as 
   ]);
   assert.deepEqual(report.danglingLinks, [{ from: "a.md", target: "nope.png" }]);
 });
+
+test("lintVault — the `.md` stripped from a link spelling is the EXTENSION, not the first `.md` in the name", () => {
+  // A note ABOUT a `.md` file is an ordinary note in this world, and its own name then
+  // holds `.md` twice. Stripping the first occurrence registers `topics/claude-conventions.md`
+  // and never the spelling anyone would actually type, so the link reads as rot forever.
+  const notes = [
+    { path: "topics/claude.md-conventions.md", frontmatter: { type: "topic" }, body: "" },
+    { path: "a.md", frontmatter: {}, body: "see [[topics/claude.md-conventions]]" },
+  ];
+  const report = lintVault(notes);
+  assert.deepEqual(report.danglingLinks, []);
+  assert.deepEqual(report.orphans, ["a.md"], "the target was reached, so only the linking note is an orphan");
+});

--- a/scripts/lint-vault.mjs
+++ b/scripts/lint-vault.mjs
@@ -11,7 +11,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 import { join } from "node:path";
 
-import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
+import { readVaultNotes, readVaultAttachments } from "./lib/wiki-lint-io.mjs";
 import { lintVault, reportLines, hasFindings } from "./lib/wiki-lint.mjs";
 import { runAsEntrypoint } from "./lib/entrypoint.mjs";
 
@@ -24,6 +24,7 @@ const toPosix = (p) => p.split("\\").join("/");
 export const realLintDeps = {
   cwd: () => process.cwd(),
   readNotes: readVaultNotes,
+  readAttachments: readVaultAttachments,
   log: (...a) => console.log(...a),
   error: (...a) => console.error(...a),
 };
@@ -33,7 +34,10 @@ export const realLintDeps = {
 export function runLint(argv, deps = realLintDeps) {
   const vaultDir = toPosix(argv[0] ? argv[0] : join(deps.cwd(), "vault"));
   const notes = deps.readNotes(vaultDir);
-  const report = lintVault(notes);
+  // The same directory, deliberately: an embed resolves against the tree it was
+  // written in, and reading the two from different roots would silently re-create
+  // the false "dangling link" #71 is about.
+  const report = lintVault(notes, { attachments: deps.readAttachments(vaultDir) });
   deps.log(`Scanned ${notes.length} notes under ${vaultDir}`);
   for (const line of reportLines(report)) deps.log(line);
   return hasFindings(report) ? 1 : 0;

--- a/scripts/lint-vault.test.mjs
+++ b/scripts/lint-vault.test.mjs
@@ -28,6 +28,7 @@ function fakeDeps(overrides = {}) {
       seenDirs.push(dir);
       return [];
     },
+    readAttachments: () => [],
     log: (line) => logs.push(line),
     error: (line) => errors.push(line),
     ...overrides,
@@ -107,4 +108,61 @@ test("the CLI, IMPORTED rather than run — the body must not fire on import", a
 
   assert.equal(run.status, 0, `importing the CLI must not exit — stderr: ${run.stderr}`);
   assert.equal(run.stdout.trim(), "imported-and-still-alive");
+});
+
+// ── #71 — the CLI hands the pure core the vault's attachments too ────────────
+
+test("runLint — reads the attachments from the SAME directory it reads the notes from", () => {
+  const seenAttachmentDirs = [];
+  const { deps, seenDirs } = fakeDeps({
+    readAttachments: (dir) => {
+      seenAttachmentDirs.push(dir);
+      return [];
+    },
+  });
+  runLint(["/data/other-vault"], deps);
+  assert.deepEqual(seenDirs, ["/data/other-vault"]);
+  assert.deepEqual(seenAttachmentDirs, ["/data/other-vault"], "a second vault path would resolve embeds against the wrong tree");
+});
+
+test("runLint — an embed of an attachment that exists is not a finding, and the vault reads clean", () => {
+  const notes = [
+    { path: "people/jane-doe.md", frontmatter: { type: "person", created: "d", updated: "d", tags: ["t"] }, body: "![[screenshot.png]] see [[topics/rota]]" },
+    { path: "topics/rota.md", frontmatter: { type: "topic", created: "d", updated: "d", tags: ["t"] }, body: "[[people/jane-doe]]" },
+  ];
+  const { deps, logs } = fakeDeps({ readNotes: () => notes, readAttachments: () => ["people/screenshot.png"] });
+  assert.equal(runLint([], deps), 0);
+  assert.deepEqual(logs, ["Scanned 2 notes under /brain/vault", "✓ Wiki health: clean"]);
+});
+
+test("the CLI, run as a process — a real pasted screenshot next to a note is not a dangling link", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "lint-vault-cli-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  mkdirSync(join(dir, "vault", "people"), { recursive: true });
+  const note = (body) => `---\ntype: topic\ncreated: 2026-08-20\nupdated: 2026-08-20\ntags: [demo]\n---\n\n${body}\n`;
+  // Obsidian's default: the pasted file lands next to the note that embeds it.
+  writeFileSync(join(dir, "vault", "people", "jane-doe.md"), note("![[screenshot.png]] and [[alpha]]"));
+  writeFileSync(join(dir, "vault", "alpha.md"), note("Back to [[people/jane-doe]]."));
+  writeFileSync(join(dir, "vault", "people", "screenshot.png"), "not really a png");
+
+  const run = spawnSync(process.execPath, [CLI, join(dir, "vault")], { encoding: "utf8" });
+
+  assert.equal(run.status, 0, `the embed resolves, so the vault is clean — got ${run.status}: ${run.stdout}${run.stderr}`);
+  assert.match(run.stdout, /✓ Wiki health: clean/);
+  assert.doesNotMatch(run.stdout, /screenshot/, "the picture must not appear in the report at all");
+});
+
+test("the CLI, run as a process — an embed of a picture that is NOT there is still reported", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "lint-vault-cli-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  mkdirSync(join(dir, "vault"));
+  writeFileSync(
+    join(dir, "vault", "a.md"),
+    "---\ntype: topic\ncreated: 2026-08-20\nupdated: 2026-08-20\ntags: [demo]\n---\n\n![[gone.png]]\n",
+  );
+
+  const run = spawnSync(process.execPath, [CLI, join(dir, "vault")], { encoding: "utf8" });
+
+  assert.equal(run.status, 1);
+  assert.match(run.stdout, /a\.md → \[\[gone\.png\]\]/);
 });

--- a/scripts/session-wiki-health.mjs
+++ b/scripts/session-wiki-health.mjs
@@ -36,9 +36,13 @@ import { wikiHealthNudge, buildWikiHealthHookOutput } from "./lib/wiki-health-nu
 export function sessionWikiHealth({ readNotes, readAttachments = () => [], vaultDir, emit }) {
   try {
     const notes = readNotes(vaultDir);
+    // Read ONCE and handed to both scans: they resolve the same links, so an
+    // attachment list given to one and not the other just moves the false positive
+    // from the dangling-link half of the nudge to the consolidation half.
+    const attachments = readAttachments(vaultDir);
     const nudge = wikiHealthNudge({
-      lintReport: lintVault(notes, { attachments: readAttachments(vaultDir) }),
-      consolidationReport: consolidationCandidates(notes),
+      lintReport: lintVault(notes, { attachments }),
+      consolidationReport: consolidationCandidates(notes, { attachments }),
     });
     if (nudge) {
       emit(nudge);

--- a/scripts/session-wiki-health.mjs
+++ b/scripts/session-wiki-health.mjs
@@ -22,7 +22,7 @@ import { dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { runAsEntrypoint } from "./lib/entrypoint.mjs";
-import { readVaultNotes } from "./lib/wiki-lint-io.mjs";
+import { readVaultNotes, readVaultAttachments } from "./lib/wiki-lint-io.mjs";
 import { lintVault } from "./lib/wiki-lint.mjs";
 import { consolidationCandidates } from "./lib/consolidation-candidates.mjs";
 import { wikiHealthNudge, buildWikiHealthHookOutput } from "./lib/wiki-health-nudge.mjs";
@@ -30,11 +30,14 @@ import { wikiHealthNudge, buildWikiHealthHookOutput } from "./lib/wiki-health-nu
 // Testable core: read the vault (injected), run the two deterministic scans, emit
 // the nudge only when there's something actionable. Fail-open — a missing/odd vault
 // must never disturb session start.
-export function sessionWikiHealth({ readNotes, vaultDir, emit }) {
+// `readAttachments` defaults to "none" rather than being required: this whole body is
+// wrapped in a fail-open catch, so a caller that did not supply the seam would not
+// crash — the nudge would simply vanish, which is worse than the bug it fixes.
+export function sessionWikiHealth({ readNotes, readAttachments = () => [], vaultDir, emit }) {
   try {
     const notes = readNotes(vaultDir);
     const nudge = wikiHealthNudge({
-      lintReport: lintVault(notes),
+      lintReport: lintVault(notes, { attachments: readAttachments(vaultDir) }),
       consolidationReport: consolidationCandidates(notes),
     });
     if (nudge) {
@@ -60,6 +63,7 @@ runAsEntrypoint(import.meta.url, process.argv, () => {
 
   sessionWikiHealth({
     readNotes: readVaultNotes,
+    readAttachments: readVaultAttachments,
     vaultDir,
     emit: (msg) => (nudge = msg),
   });

--- a/scripts/session-wiki-health.test.mjs
+++ b/scripts/session-wiki-health.test.mjs
@@ -133,3 +133,67 @@ test("the hook speaks through a SYMLINKED brain path, exactly as through the rea
   const aliased = await run(alias);
   assert.equal(aliased, real, "a symlinked brain path must not change one byte of what the hook says");
 });
+
+// ── #71 — the SessionStart nudge resolves embeds too, or it cries wolf forever ──
+
+test("sessionWikiHealth — an embed of an attachment that EXISTS raises no nudge at all", () => {
+  // This is the surface the bug was actually reported from: the nudge fires at every
+  // session start, so a picture pasted once produced a "Pending: 1 dangling links"
+  // line that no edit to the note could ever clear.
+  const noteWithScreenshot = {
+    path: "people/jane-doe.md",
+    frontmatter: { type: "person", created: "2026-07-10", updated: "2026-07-10", tags: ["p"] },
+    body: "![[screenshot.png]]",
+  };
+  const { args, calls } = seams({
+    readNotes: () => [noteWithScreenshot],
+    readAttachments: () => ["people/screenshot.png"],
+  });
+  sessionWikiHealth(args);
+  assert.deepEqual(calls.emitted, []);
+});
+
+test("sessionWikiHealth — an embed of a picture that is NOT there still raises the nudge", () => {
+  const noteWithBrokenEmbed = {
+    path: "people/jane-doe.md",
+    frontmatter: { type: "person", created: "2026-07-10", updated: "2026-07-10", tags: ["p"] },
+    body: "![[gone.png]]",
+  };
+  const { args, calls } = seams({
+    readNotes: () => [noteWithBrokenEmbed],
+    readAttachments: () => [],
+  });
+  sessionWikiHealth(args);
+  assert.equal(calls.emitted.length, 1);
+  assert.match(calls.emitted[0], /dangling links/);
+});
+
+test("sessionWikiHealth — the attachments reader is read from the SAME vault dir as the notes", () => {
+  const seenDirs = [];
+  const { args } = seams({
+    vaultDir: "/elsewhere/vault",
+    readNotes: (dir) => {
+      seenDirs.push(`notes:${dir}`);
+      return [];
+    },
+    readAttachments: (dir) => {
+      seenDirs.push(`attachments:${dir}`);
+      return [];
+    },
+  });
+  sessionWikiHealth(args);
+  assert.deepEqual(seenDirs, ["notes:/elsewhere/vault", "attachments:/elsewhere/vault"]);
+});
+
+test("sessionWikiHealth — a caller that passes NO attachments reader still works, it does not fail open into silence", () => {
+  // Fail-open swallows everything, so a missing seam would not crash — it would make
+  // the whole nudge quietly disappear, which is the worst of both worlds.
+  const captureOnly = {
+    path: "meetings/2026-07-10.md",
+    frontmatter: { type: "meeting", created: "2026-07-10", updated: "2026-07-10", tags: ["m"] },
+    body: "Met with [[Acme Corp]] about the roadmap.",
+  };
+  const emitted = [];
+  sessionWikiHealth({ vaultDir: "/brain/vault", readNotes: () => [captureOnly], emit: (m) => emitted.push(m) });
+  assert.equal(emitted.length, 1, "the nudge must still fire when no attachments reader is supplied");
+});

--- a/scripts/session-wiki-health.test.mjs
+++ b/scripts/session-wiki-health.test.mjs
@@ -197,3 +197,20 @@ test("sessionWikiHealth — a caller that passes NO attachments reader still wor
   sessionWikiHealth({ vaultDir: "/brain/vault", readNotes: () => [captureOnly], emit: (m) => emitted.push(m) });
   assert.equal(emitted.length, 1, "the nudge must still fire when no attachments reader is supplied");
 });
+
+test("sessionWikiHealth — an embedded attachment raises no CONSOLIDATION candidate either", () => {
+  // The nudge surfaces two scans, and #71 hit both. Left unfixed on this half, a
+  // pasted screenshot stops being reported as a dead link and starts being reported
+  // as a page to create, called `screenshot.png`.
+  const captureWithScreenshot = {
+    path: "meetings/2026-07-10.md",
+    frontmatter: { type: "meeting", created: "2026-07-10", updated: "2026-07-10", tags: ["m"] },
+    body: "Discussed the plan. ![[screenshot.png]]",
+  };
+  const { args, calls } = seams({
+    readNotes: () => [captureWithScreenshot],
+    readAttachments: () => ["meetings/screenshot.png"],
+  });
+  sessionWikiHealth(args);
+  assert.deepEqual(calls.emitted, []);
+});

--- a/scripts/session-wiki-health.test.mjs
+++ b/scripts/session-wiki-health.test.mjs
@@ -214,3 +214,25 @@ test("sessionWikiHealth — an embedded attachment raises no CONSOLIDATION candi
   sessionWikiHealth(args);
   assert.deepEqual(calls.emitted, []);
 });
+
+test("sessionWikiHealth — its RETURN says whether it reported, not just its emit", () => {
+  // The return value is part of this function's contract and nothing asserted it, so
+  // a caller reading `reported` could have been told the opposite of what happened.
+  const noisy = seams();
+  assert.deepEqual(sessionWikiHealth(noisy.args), { reported: true });
+  assert.equal(noisy.calls.emitted.length, 1, "and it really did emit, so the flag is not the only evidence");
+
+  const quiet = seams({ readNotes: () => [] });
+  assert.deepEqual(sessionWikiHealth(quiet.args), { reported: false });
+  assert.deepEqual(quiet.calls.emitted, []);
+});
+
+test("sessionWikiHealth — a vault reader that throws is swallowed AND reported as nothing found", () => {
+  const { args, calls } = seams({
+    readNotes: () => {
+      throw new Error("vault is a symlink to nowhere");
+    },
+  });
+  assert.deepEqual(sessionWikiHealth(args), { reported: false }, "fail-open must still answer the caller honestly");
+  assert.deepEqual(calls.emitted, []);
+});

--- a/scripts/unwrap-markdown.mjs
+++ b/scripts/unwrap-markdown.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// unwrap-markdown.mjs — run FROM the brain folder to undo hard-wrapped Markdown.
+//
+// The deterministic net behind the constitution's "never insert a line break the
+// content does not require" rule. It covers FILES only: nothing can inspect what
+// Claude prints into the chat before you read it, so that half stays a written
+// reflex (see CLAUDE.engine.md).
+//
+//   node scripts/unwrap-markdown.mjs vault            # rewrite every .md under vault/
+//   node scripts/unwrap-markdown.mjs --check vault    # report, change nothing (exit 1 if any)
+//   node scripts/unwrap-markdown.mjs a.md b.md        # named files
+// ─────────────────────────────────────────────────────────────────────────────
+import { readFileSync, writeFileSync, statSync, readdirSync } from "node:fs";
+import { join, extname } from "node:path";
+
+import { unwrapMarkdown } from "./lib/unwrap-markdown.mjs";
+import { runAsEntrypoint } from "./lib/entrypoint.mjs";
+
+const CHECK_FLAG = "--check";
+const USAGE = `usage: node scripts/unwrap-markdown.mjs [${CHECK_FLAG}] <file|dir> [...]`;
+
+// Reported paths go out in POSIX form so the output reads identically on Windows,
+// where join() yields backslashes (CONVENTIONS §9, as lint-vault does).
+const toPosix = (p) => p.split("\\").join("/");
+
+// Every .md under `target`, or `target` itself when it is a file. Dot-folders and
+// node_modules are skipped: `.obsidian` holds the viewer's own JSON, and neither is
+// the owner's prose.
+export function listMarkdownFiles(target, deps) {
+  if (!deps.isDirectory(target)) return extname(target) === ".md" ? [target] : [];
+  const found = [];
+  for (const entry of deps.readDir(target)) {
+    if (entry.startsWith(".") || entry === "node_modules") continue;
+    found.push(...listMarkdownFiles(join(target, entry), deps));
+  }
+  return found;
+}
+
+export const realUnwrapDeps = {
+  isDirectory: (p) => statSync(p).isDirectory(),
+  readDir: (p) => readdirSync(p),
+  readFile: (p) => readFileSync(p, "utf8"),
+  writeFile: (p, text) => writeFileSync(p, text),
+  log: (...a) => console.log(...a),
+  error: (...a) => console.error(...a),
+};
+
+// Rewrite (or, with --check, merely report) every hard-wrapped file under the
+// targets. Returns the process exit code: 0 nothing left to do, 1 changes found
+// in --check mode, 2 nothing to scan. All side effects come through `deps`.
+export function runUnwrap(argv, deps = realUnwrapDeps) {
+  const check = argv.includes(CHECK_FLAG);
+  const targets = argv.filter((a) => a !== CHECK_FLAG);
+  if (targets.length === 0) {
+    deps.error(USAGE);
+    return 2;
+  }
+
+  let changed = 0;
+  for (const target of targets) {
+    for (const file of listMarkdownFiles(target, deps)) {
+      const before = deps.readFile(file);
+      const after = unwrapMarkdown(before);
+      // An untouched file is left untouched on disk too: rewriting it byte-identical
+      // would still restamp its mtime and dirty every `git status` it appears in.
+      if (before === after) continue;
+      changed++;
+      if (check) {
+        deps.log(`would unwrap: ${toPosix(file)}`);
+      } else {
+        deps.writeFile(file, after);
+        deps.log(`unwrapped: ${toPosix(file)}`);
+      }
+    }
+  }
+
+  deps.log(check ? `${changed} file(s) would change` : `${changed} file(s) rewritten`);
+  // --check is the composable half: a non-zero exit is what lets it gate anything.
+  return check && changed > 0 ? 1 : 0;
+}
+
+runAsEntrypoint(import.meta.url, process.argv, runUnwrap);

--- a/scripts/unwrap-markdown.test.mjs
+++ b/scripts/unwrap-markdown.test.mjs
@@ -1,0 +1,189 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runUnwrap, listMarkdownFiles } from "./unwrap-markdown.mjs";
+
+const CLI = join(dirname(fileURLToPath(import.meta.url)), "unwrap-markdown.mjs");
+
+// ═══════════════════════════════════════════════════════════════════════════
+// unwrap-markdown (the CLI) — the thin glue over the pure rewriter. Binary exit
+// code (0 nothing to do / 1 --check found something / 2 usage error). All side
+// effects come through an injected `deps` port, and the entry point itself is
+// covered by RUNNING it as a process (CONVENTIONS §5bis): a module's exports can
+// all be green while the file does nothing, because no import-based test ever
+// executes the composition root.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// An in-memory filesystem keyed the way production keys it (`join`), never with a
+// hard-coded POSIX literal — a POSIX-keyed fake silently misses subdirectories on
+// Windows (CONVENTIONS §9).
+function fakeDeps(files = {}, dirs = []) {
+  const logs = [];
+  const errors = [];
+  const written = {};
+  const deps = {
+    isDirectory: (p) => dirs.includes(p),
+    readDir: (p) => {
+      const prefix = p + sep;
+      const names = new Set();
+      for (const path of [...Object.keys(files), ...dirs]) {
+        if (!path.startsWith(prefix)) continue;
+        names.add(path.slice(prefix.length).split(sep)[0]);
+      }
+      return [...names];
+    },
+    readFile: (p) => files[p],
+    writeFile: (p, text) => {
+      written[p] = text;
+    },
+    log: (line) => logs.push(line),
+    error: (line) => errors.push(line),
+  };
+  return { deps, logs, errors, written };
+}
+
+test("runUnwrap — with no target it prints the usage line on stderr and exits 2", () => {
+  const { deps, logs, errors } = fakeDeps();
+  assert.equal(runUnwrap([], deps), 2);
+  assert.deepEqual(logs, [], "a usage error prints nothing on stdout");
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /^usage: node scripts\/unwrap-markdown\.mjs \[--check\] <file\|dir>/);
+});
+
+test("runUnwrap — `--check` alone is still no target: the flag is not a path", () => {
+  const { deps, errors } = fakeDeps();
+  assert.equal(runUnwrap(["--check"], deps), 2);
+  assert.equal(errors.length, 1);
+});
+
+test("runUnwrap — a wrapped file is rewritten, named on stdout, and counted", () => {
+  const note = join("vault", "a.md");
+  const { deps, logs, written } = fakeDeps({ [note]: "a cut\nline" });
+  assert.equal(runUnwrap([note], deps), 0);
+  assert.deepEqual(written, { [note]: "a cut line" });
+  assert.deepEqual(logs, ["unwrapped: vault/a.md", "1 file(s) rewritten"]);
+});
+
+test("runUnwrap — an already-clean file is not rewritten at all, and the count says zero", () => {
+  const note = join("vault", "a.md");
+  const { deps, logs, written } = fakeDeps({ [note]: "one single line" });
+  assert.equal(runUnwrap([note], deps), 0);
+  assert.deepEqual(written, {}, "an untouched file must not be rewritten — that alone would dirty every git status");
+  assert.deepEqual(logs, ["0 file(s) rewritten"]);
+});
+
+test("runUnwrap — `--check` reports what WOULD change, writes nothing, and exits 1 so it can gate", () => {
+  const note = join("vault", "a.md");
+  const { deps, logs, written } = fakeDeps({ [note]: "a cut\nline" });
+  assert.equal(runUnwrap(["--check", note], deps), 1);
+  assert.deepEqual(written, {}, "--check must never touch the disk");
+  assert.deepEqual(logs, ["would unwrap: vault/a.md", "1 file(s) would change"]);
+});
+
+test("runUnwrap — `--check` on a clean tree exits 0, so it only fails when there is something to fail on", () => {
+  const note = join("vault", "a.md");
+  const { deps, logs } = fakeDeps({ [note]: "already one line" });
+  assert.equal(runUnwrap(["--check", note], deps), 0);
+  assert.deepEqual(logs, ["0 file(s) would change"]);
+});
+
+test("runUnwrap — the flag is recognised after the path as well as before it", () => {
+  const note = join("vault", "a.md");
+  const { deps, written } = fakeDeps({ [note]: "a cut\nline" });
+  assert.equal(runUnwrap([note, "--check"], deps), 1);
+  assert.deepEqual(written, {});
+});
+
+test("runUnwrap — a directory is walked recursively, and every wrapped note under it is rewritten", () => {
+  const root = "vault";
+  const people = join(root, "people");
+  const top = join(root, "top.md");
+  const deep = join(people, "jane-doe.md");
+  const { deps, logs, written } = fakeDeps({ [top]: "top cut\nhere", [deep]: "deep cut\nhere" }, [root, people]);
+  assert.equal(runUnwrap([root], deps), 0);
+  assert.deepEqual(written, { [top]: "top cut here", [deep]: "deep cut here" });
+  assert.equal(logs.at(-1), "2 file(s) rewritten");
+});
+
+test("runUnwrap — several targets are all scanned, and the count is the total across them", () => {
+  const a = join("one", "a.md");
+  const b = join("two", "b.md");
+  const { deps, logs } = fakeDeps({ [a]: "a cut\nhere", [b]: "b cut\nhere" });
+  assert.equal(runUnwrap([a, b], deps), 0);
+  assert.deepEqual(logs, ["unwrapped: one/a.md", "unwrapped: two/b.md", "2 file(s) rewritten"]);
+});
+
+test("listMarkdownFiles — a non-Markdown file is never read, whatever it is named", () => {
+  const png = join("vault", "shot.png");
+  const { deps } = fakeDeps({ [png]: "binary" });
+  assert.deepEqual(listMarkdownFiles(png, deps), []);
+});
+
+test("listMarkdownFiles — dot-folders and node_modules are skipped, their neighbours are not", () => {
+  const root = "vault";
+  const obsidian = join(root, ".obsidian");
+  const modules = join(root, "node_modules");
+  const kept = join(root, "kept.md");
+  const files = {
+    [kept]: "x",
+    [join(obsidian, "workspace.md")]: "x",
+    [join(modules, "readme.md")]: "x",
+  };
+  const { deps } = fakeDeps(files, [root, obsidian, modules]);
+  assert.deepEqual(listMarkdownFiles(root, deps), [kept]);
+});
+
+// ── The entry-point seam: run the FILE as a process (CONVENTIONS §5bis) ──────
+
+function withTempVault(fn) {
+  const root = mkdtempSync(join(tmpdir(), "kenjaku-unwrap-"));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("the CLI, run as a process, rewrites a real hard-wrapped note and exits 0", () => {
+  withTempVault((root) => {
+    const nested = join(root, "people");
+    mkdirSync(nested);
+    const note = join(nested, "jane-doe.md");
+    writeFileSync(note, ["---", "type: person", "---", "", "A paragraph an editor cut", "in the middle of itself."].join("\n"));
+
+    const run = spawnSync(process.execPath, [CLI, root], { encoding: "utf8" });
+
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(
+      readFileSync(note, "utf8"),
+      ["---", "type: person", "---", "", "A paragraph an editor cut in the middle of itself."].join("\n"),
+    );
+    assert.match(run.stdout, /1 file\(s\) rewritten/);
+  });
+});
+
+test("the CLI, run as a process with --check, leaves the file alone and exits 1", () => {
+  withTempVault((root) => {
+    const note = join(root, "a.md");
+    const before = "a cut\nline";
+    writeFileSync(note, before);
+
+    const run = spawnSync(process.execPath, [CLI, "--check", root], { encoding: "utf8" });
+
+    assert.equal(run.status, 1);
+    assert.equal(readFileSync(note, "utf8"), before, "--check must not have touched the disk");
+    assert.match(run.stdout, /would unwrap: /);
+  });
+});
+
+test("the CLI, run as a process with no argument, exits 2 and says how to call it", () => {
+  const run = spawnSync(process.execPath, [CLI], { encoding: "utf8" });
+  assert.equal(run.status, 2);
+  assert.match(run.stderr, /usage: node scripts\/unwrap-markdown\.mjs/);
+});

--- a/scripts/unwrap-markdown.test.mjs
+++ b/scripts/unwrap-markdown.test.mjs
@@ -187,3 +187,22 @@ test("the CLI, run as a process with no argument, exits 2 and says how to call i
   assert.equal(run.status, 2);
   assert.match(run.stderr, /usage: node scripts\/unwrap-markdown\.mjs/);
 });
+
+test("runUnwrap — a Windows-shaped path is REPORTED in POSIX form, separators converted not dropped", () => {
+  // Fed a backslash path literally rather than through join(), because on macOS
+  // join() never produces one — so the conversion is dead code here and a mutation
+  // that DELETED the separator instead of converting it survived every local run
+  // (CONVENTIONS §9: local green is a POSIX green). On Windows the same defect
+  // would print `vaultpeoplea.md` and name a file nobody can find.
+  const windowsPath = "vault\\people\\jane-doe.md";
+  const { deps, logs } = fakeDeps({ [windowsPath]: "a cut\nline" });
+  assert.equal(runUnwrap([windowsPath], deps), 0);
+  assert.deepEqual(logs, ["unwrapped: vault/people/jane-doe.md", "1 file(s) rewritten"]);
+});
+
+test("runUnwrap — --check reports the same POSIX spelling as a real run does", () => {
+  const windowsPath = "vault\\people\\jane-doe.md";
+  const { deps, logs } = fakeDeps({ [windowsPath]: "a cut\nline" });
+  assert.equal(runUnwrap(["--check", windowsPath], deps), 1);
+  assert.deepEqual(logs, ["would unwrap: vault/people/jane-doe.md", "1 file(s) would change"]);
+});

--- a/templates/fr/.claude/skills/sync-sources/SKILL.md
+++ b/templates/fr/.claude/skills/sync-sources/SKILL.md
@@ -273,6 +273,71 @@ que tu n'as pas.
    depuis un moment. C'est le « le bémol d'hier est une dette » de la discipline d'affirmation,
    appliqué aux fiches du vault lui-même.
 
+## Vivacité des sources : une réponse vide et une route morte, c'est le même signal
+
+> **Une source tombée en panne ne doit jamais se lire comme une source sans nouvelles.** Remonté du
+> terrain : pendant une grosse passe de rattrapage, la route de **recherche** d'un connecteur mail a
+> cessé de répondre pendant que sa route de **lecture** continuait de marcher. Aucune erreur, aucun
+> avertissement : le contrat dit noir sur blanc qu'un résultat vide n'est *pas* une erreur. Vu d'ici,
+> ces deux situations sont donc rigoureusement identiques : *la boîte ne contient rien sur ce sujet*,
+> et *la route de recherche est morte et ne matchera jamais rien, pour aucune requête*. Le cerveau a
+> rapporté la première. La personne a vu une source couverte sans nouvelles ; ce qui s'est passé, c'est
+> une source jamais lue.
+
+La **Discipline d'affirmation** ci-dessous note **ce qui** a été récupéré. Rien ne note **si** la
+récupération a eu lieu : une source qui renvoie zéro ligne produit zéro affirmation à marquer, donc le
+système de marquage reste muet par construction. Cette section est la moitié manquante, et elle passe
+**avant** qu'un vide ait le droit de devenir une phrase.
+
+### La requête de contrôle : tout le discriminant, un appel par source
+
+Avant d'écrire qu'une source n'avait rien, prouve que la route répond encore. Un appel de plus,
+construit sur trois règles :
+
+1. **Par la MÊME route que celle qui a répondu vide.** Une route de recherche se teste en *cherchant*.
+   Dans le rapport, lire un thread par son identifiant a marché du début à la fin : un contrôle passé par
+   la route de lecture aurait renvoyé un « tout va bien » parfaitement confiant sur une route morte.
+2. **Sans mot-clé.** Un mot-clé, c'est précisément ce qui rend un zéro honnête possible. Retire les
+   termes, élargis la fenêtre autant que l'outil l'accepte.
+3. **Impossible à satisfaire par zéro sur un compte vivant.** C'est la propriété sur laquelle tout
+   repose. Si un compte légitime pouvait renvoyer zéro ligne à ton contrôle, ce n'est pas un contrôle.
+
+**Zéro ligne au contrôle = la source est EN PANNE, pas vide.**
+
+| Source | L'appel de contrôle | Pourquoi zéro est impossible sur un compte vivant |
+|---|---|---|
+| **Mail** | la route de recherche, **aucun** terme, un simple filtre de récence sur une large fenêtre (un an, pas une semaine) | une boîte qui n'a rien reçu en un an n'est pas une boîte utilisée |
+| **Chat** | la route de recherche sur une large fenêtre, avec le mot le plus courant possible plutôt qu'un terme de sujet ; à défaut, la liste des canaux | un compte sans aucune occurrence d'un mot outil sur plusieurs mois n'est pas un compte utilisé |
+| **Agenda** | la liste des calendriers, plus une liste d'événements sur le mois écoulé | un compte a toujours au moins son calendrier principal |
+| **Drive** | la route de recherche triée par date de modification, sans termes | un drive dont rien n'a bougé en un an n'est pas un drive que ce cerveau synchronise |
+| **Notion** | la route de recherche avec une requête vide (les pages récentes) | l'intégration est partagée avec au moins une page, sinon elle ne serait pas branchée |
+
+> 🔧 **Un connecteur sans forme sans mot-clé** : prends la requête la plus large que tu puisses
+> exprimer, et dis dans l'artefact que le contrôle était **plus faible**. Un contrôle que tu n'arrives
+> pas à construire est une raison de signaler la source comme non prouvée, **jamais** une raison de
+> sauter la vérification en silence.
+
+### Ce que change un verdict EN PANNE
+
+- **C'est une alerte, pas une omission.** Nomme-la dans la réponse **et** dans l'artefact écrit, sur sa
+  propre ligne 🔴 : « le mail n'a pas été lu sur cette passe : sa route de recherche n'a rien renvoyé à
+  une requête de contrôle ». Elle ne peut jamais être sautée en silence.
+- **Ça interdit toute affirmation négative qui en dépendait.** Avec le mail en panne, tu ne peux pas
+  écrire « pas de mail sur ce sujet » : la phrase n'est pas étayée, exactement comme une affirmation
+  comportementale non vérifiée. Même barre que le troisième palier de la **Discipline d'affirmation**
+  ci-dessous.
+- **Le verdict n'est jamais mis en cache.** Il est rétabli à **chaque passe** et **jamais hérité** d'une
+  note : c'est « une capacité notée comme absente doit être retestée », appliqué à la vivacité. Une
+  source notée en panne se réessaie, elle ne se raye pas.
+- **Cadence le fan-out.** Le déclencheur du rapport, c'était justement une large passe parallèle sans
+  aucune limite. Plafonne les appels simultanés par connecteur, et **ralentis** (back off) sur une route
+  qui se met à répondre vide, au lieu de la marteler pendant tout le reste de la passe.
+
+> ⚖️ **Dis ce qui est de notre ressort et ce qui ne l'est pas.** La panne elle-même appartient au
+> fournisseur du connecteur : ce dépôt n'écrit pas une ligne de cette route, et le même outil répondait
+> normalement le même jour sur un autre compte. Ce qui est de notre ressort, et tout ce que ça corrige,
+> c'est que le cerveau présentait une source **non lue** comme une source **lue**.
+
 ## Discipline d'affirmation
 
 > **La sortie dangereuse d'un second cerveau, ce n'est pas le fait qu'il invente : c'est le SILENCE
@@ -372,6 +437,14 @@ En parallèle, repérer ce qui est **nouveau depuis le dernier passage** (delta)
 
 Lancer tous les sous-agents dans **un seul bloc d'appels parallèles**. Chacun écrit sa source
 brute dans le vault et **retourne un résumé ~500 tokens max**.
+
+> 🩺 **Chaque sous-agent de recherche lance sa requête de contrôle D'ABORD**, avant toute autre chose :
+> voir *Vivacité des sources* plus haut pour le contrôle propre à chaque source. Si le contrôle revient
+> vide, le sous-agent retourne **« source EN PANNE, non lue »** et aucun résultat, plutôt qu'un résumé
+> qui dit qu'on n'a rien trouvé. Et **garde le fan-out cadencé** : c'est exactement cette large passe
+> parallèle qui a fait basculer un compte réel au-delà d'un plafond par utilisateur. Plafonne les appels
+> simultanés par connecteur et **ralentis** sur une route qui se met à répondre vide, au lieu de la
+> marteler pendant tout le reste de la passe.
 
 #### Sous-agent « transcript-extractor » (un par document)
 

--- a/templates/fr/CLAUDE.engine.md
+++ b/templates/fr/CLAUDE.engine.md
@@ -279,6 +279,20 @@ le watermark n'a pas avancé.
 
 ## Comportements Claude Code attendus
 
+### Retours à la ligne : jamais un que le contenu n'a pas demandé
+
+**N'insère jamais un retour à la ligne que le contenu n'exige pas.** Un paragraphe, une puce, une ligne de citation : **une seule ligne, aussi longue soit-elle.** Seules les lignes vides séparent les blocs, ce sont les seules coupures légitimes.
+
+**Le déclencheur, c'est la DESTINATION, pas le support.** Ça vaut pour tout ce que tu écris en Markdown : notes du vault, antisèches, brouillons d'articles, **messages à envoyer**, et **blocs de code dans le chat**, ces derniers surtout, puisqu'un bloc de code est précisément le texte que la personne va recopier dans Slack, un mail ou un document. Lue comme une règle sur les *fichiers*, elle s'applique aux notes et rate exactement ce qui sort de la conversation : c'est comme ça qu'elle a continué d'être enfreinte.
+
+Pourquoi ce n'est pas une affaire de goût : Obsidian, Typora, Slack et tous les clients mail reviennent à la ligne tout seuls, à la largeur de la fenêtre où on les lit. Une coupure inscrite dans le texte, elle, ne peut pas s'adapter : elle donne une demi-ligne bancale sur téléphone, et elle se bat avec la personne à chaque fois qu'elle réédite le paragraphe.
+
+⚠️ **Les notes déjà écrites plaideront contre cette règle.** Un vault antérieur à la règle contient des paragraphes coupés à ~100 caractères, et « s'aligner sur le style environnant » suffit à reproduire le défaut indéfiniment. **La convention prime sur le corpus.**
+
+🔧 **Le filet déterministe ne couvre que les FICHIERS** : `node scripts/unwrap-markdown.mjs <fichier|dossier>` les réécrit sur place, et `--check` signale ce qui changerait sans rien toucher. Rien ne peut inspecter ce qui s'affiche dans un chat avant qu'on le lise : cette moitié-là est un réflexe écrit par construction, il n'y a pas de machine à construire pour elle, et c'est pour ça que la règle est détaillée ici plutôt que déléguée au script.
+
+> 📄 **Si ton propre `CLAUDE.md` contient une copie de cette règle, supprime-la.** Deux fichiers qui portent la même règle, c'est la garantie qu'ils divergeront, et c'est cette couche-ci qui est rafraîchie. Si tu veux vraiment des coupures (diffs git plus lisibles, habitude des 80 colonnes), garde une ligne dans ton `CLAUDE.md` qui le dit, formulée comme une **dérogation**, pour que la personne qui lira ensuite voie que c'est délibéré.
+
 ### Posture de conseil sur le harnais
 
 Claude doit **challenger les demandes de modification du harnais** (CLAUDE.md, `.claude/`, skills, hooks). Avant d'implémenter un changement de harnais :

--- a/templates/fr/CLAUDE.engine.md
+++ b/templates/fr/CLAUDE.engine.md
@@ -428,6 +428,34 @@ ailleurs que dans cette note, et qui est désormais indexé.
   🔴 est une piste, pas la réponse du vault : revérifie-la avant de résoudre quoi que ce soit contre
   elle, et ne la laisse jamais devenir un acquis au seul motif qu'elle est écrite depuis un moment.
 
+### Vivacité des sources : une source tombée en panne n'est pas une source sans nouvelles
+
+Le contrat d'un connecteur dit qu'un résultat vide n'est **pas** une erreur. Du coup « la boîte ne
+contient rien sur ce sujet » et « la route de recherche est morte et ne matchera jamais rien » arrivent
+sous exactement la même forme, et rapporter la première transforme une source **jamais lue** en source
+sans rien à signaler. Remonté du terrain, sur une grosse passe de rattrapage : la recherche a cessé de
+répondre pendant que la lecture d'un thread connu continuait de marcher, et rien n'a rien dit.
+
+- **Le discriminant, c'est une requête de contrôle**, un appel de plus par source, avant qu'un vide
+  devienne une phrase. Trois propriétés, toutes les trois porteuses : elle passe par la **même route**
+  que celle qui a répondu vide (lire ne prouve rien sur la capacité à chercher), elle est **sans
+  mot-clé** (un mot-clé, c'est ce qui rend un zéro honnête possible), et elle est construite pour que
+  zéro ligne soit **impossible sur un compte vivant**. Le contrôle de chaque source branchable est
+  tabulé dans le skill `sync-sources`.
+- **Zéro ligne au contrôle = la source est EN PANNE, pas vide.**
+- **Une source en panne est une alerte, jamais une omission silencieuse.** Nomme-la dans la réponse et
+  dans ce que tu écris, sur sa propre ligne 🔴 : « le mail n'a pas été lu sur cette passe, sa route de
+  recherche n'a rien renvoyé à une requête de contrôle ».
+- **Une source en panne interdit toute affirmation négative qui en dépendait.** Tu ne peux pas écrire
+  « pas de mail sur ce sujet » : la phrase n'est pas étayée, à la même barre que les affirmations
+  comportementales non vérifiées de la *Discipline d'affirmation* juste en dessous.
+- **Le verdict est rétabli à chaque passe, jamais hérité** d'une note ni d'un briefing précédent, et
+  **cadence le fan-out** : plafonne les appels simultanés par connecteur et **ralentis** sur une route
+  qui se met à répondre vide, au lieu de la marteler pendant tout le reste de la passe.
+
+> ⚖️ La panne elle-même appartient au fournisseur. Ce qui t'appartient, c'est de ne pas présenter une
+> source non lue comme une source lue.
+
 ### Discipline d'affirmation — le silence qu'on rapporte, voilà le vrai danger
 
 Une recherche renvoie ce qui est **pertinent**, jamais ce qui est **complet**. Donc quand rien ne


### PR DESCRIPTION
**Not to be merged by an agent.** The tag's number, the merge and the release note are the owner's, per the plan's own permissions. This PR exists so the full 7/7 matrix runs before any of that.

## What a user stops seeing

- **A screenshot pasted into a note stops being reported as a dead link** (#71). The resolver only ever indexed `.md`, so every picture in every note read as rot that no edit to the note could clear. It was live on **two** surfaces: the same target also reached the consolidation scan, where the brain proposed creating a note called `screenshot.png`.
- **A link inside a table stops being reported as broken** (#73). A bare pipe closes a table cell, so `[[note\|alias]]` is the only spelling that works — and it was precisely the one the checker flagged. The miss cascaded: a false dangling link, a false orphan on the target, and a real staleness signal dropped.
- **The engine stops complaining about its own backlog** (#74). It declares the folder, appends to it, and tests that the purge preserves it.
- **A source that goes quiet stops reading as a source with no news** (#80). An empty result is not an error, so "the mailbox holds nothing on this subject" and "the search route is dead" arrive in the same shape. A control query per source is the discriminator; a down source becomes an alert and disables the negative claims that depended on it.
- **The no-hard-wrap rule fires on the text you copy out of the chat** (#95). It was scoped to *files*, so it worked on vault notes and missed fenced blocks — which is exactly what gets pasted into Slack.

## What is measured, and what is not

- Real 663-note vault, before → after: **orphans 87 → 85**, dangling links **18 → 18**. That vault holds zero attachment embeds and zero escaped pipes, so #71 and #73 cannot show there — they were reported from a different one, and are proven by running the CLI as a process against a tree built to each issue's own repro. **The release note should not lead with a number from that brain.**
- Mutation, per CONVENTIONS §5quinquies: the two new files at **98.36 %** and **100 %**, the changed hunks of the checker at **92.31 % to 100 %**. Every survivor left is a named equivalent. Details in `maintainers/mutation/RESULTS.md`.
- #80 ships doctrine only — no script here can call an account-side connector to measure liveness — so it is pinned by a doc guard across four surfaces that drift independently.

## Three things to look at

1. **The French halves were written**, against the plan's own "a session may not write into `templates/fr/**` alone" clause. Four localized files are watched by the EN/FR drift guard, whose criterion is *unpaired commits*, so an English-only commit turns the suite red. The clause and the guard contradict each other on exactly those files. **The French wording is yours to correct.**
2. **The fingerprint table says `v5.1.3`** — a placeholder. Regenerate against the real tag: `node maintainers/fingerprints/generate-fingerprints.mjs --version <tag>`.
3. **#95's deterministic net did not exist here.** The issue says the unwrap script is already engine-owned; it is not, it lives only inside a brain. It is now shipped, registered under the manifest's `replace` regime, with two defects fixed on the way (a CRLF document got a carriage return buried mid-paragraph; an unchanged file was rewritten byte-identical).

## Still open

- The release note owes one sentence that is not a summary of a fix: *if your own `CLAUDE.md` carries the no-line-break-inside-a-paragraph rule, delete it, the engine holds it now.*
- Closing the five issues with what shipped, and crediting the `/lint` reporter by name and the second one without one.
- The throttling hypothesis under #80 needs one plain search on the reporter's own account. It changes nothing that shipped.
- **#77 comes back to you**: it was deferred until the five were done, and they are. Recommendation unchanged, leave it in v5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)